### PR TITLE
Fix(tox): Configure cryptography and missing dependency tests

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -7,13 +7,13 @@ on:
     branches: [ main, master ] # Adjust if your main branch has a different name
 
 jobs:
-  test:
-    name: Tox tests - Python ${{ matrix.python-version }}
+  general-tests:
+    name: Tox - py${{ matrix.python-version }}-latest-deps
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # Add "3.13" and "3.14-beta" if available and stable with setup-python
+        python-version: ["3.10", "3.11", "3.12", "3.13"] # Add "3.14-beta" if available and stable with setup-python
 
     steps:
       - name: Check out code
@@ -33,5 +33,37 @@ jobs:
       - name: Run tox environment
         # We select a representative tox environment that uses the current Python version
         # and latest versions of rarfile and py7zr.
-        # You might want to run all environments or a different subset.
+        # For py310, py310-rarfilelatest-py7zrlatest is run. Other versions will use their respective latest.
         run: tox -e py${{ matrix.python-version }}-rarfilelatest-py7zrlatest
+
+  specific-py310-tests:
+    name: Tox - ${{ matrix.tox_env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tox_env:
+          - py310-missing-crypto
+          - py310-rarfilenotinstalled-py7zrnotinstalled
+          - py310-rarfile40-py7zr0220
+          - py310-rarfile42-py7zr100rc3
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Install unrar (for rarfile tests)
+        # unrar is needed for py310-rarfile40-py7zr0220 and py310-rarfile42-py7zr100rc3
+        # It's not strictly needed for missing-crypto (mocks) or notinstalled (mocks)
+        # but including it for consistency in this job group is simpler.
+        run: sudo apt-get update && sudo apt-get install -y unrar
+
+      - name: Run tox environment
+        run: tox -e ${{ matrix.tox_env }}

--- a/tests/archivey/test_read_archives.py
+++ b/tests/archivey/test_read_archives.py
@@ -372,6 +372,7 @@ BASIC_7Z_ARCHIVE = filter_archives(
 
 
 @patch("archivey.rar_reader.rarfile", None)
+@pytest.mark.missing_rarfile
 def test_rarfile_not_installed_raises_exception():
     """Test that LibraryNotInstalledError is raised for .rar when rarfile is not installed."""
     with pytest.raises(PackageNotInstalledError) as excinfo:
@@ -380,6 +381,7 @@ def test_rarfile_not_installed_raises_exception():
 
 
 @patch("archivey.sevenzip_reader.py7zr", None)
+@pytest.mark.missing_py7zr
 def test_py7zr_not_installed_raises_exception():
     """Test that LibraryNotInstalledError is raised for .7z when py7zr is not installed."""
     with pytest.raises(PackageNotInstalledError) as excinfo:
@@ -388,6 +390,7 @@ def test_py7zr_not_installed_raises_exception():
 
 
 @patch("archivey.rar_reader.rarfile._have_crypto", 0)
+@pytest.mark.missing_crypto
 def test_rarfile_missing_cryptography_raises_exception():
     """Test that LibraryNotInstalledError is raised for .rar when rarfile is not installed."""
     with pytest.raises(PackageNotInstalledError) as excinfo:
@@ -401,6 +404,7 @@ def test_rarfile_missing_cryptography_raises_exception():
 
 
 @patch("archivey.rar_reader.rarfile._have_crypto", 0)
+@pytest.mark.missing_crypto
 def test_rarfile_missing_cryptography_does_not_raise_exception_for_other_files():
     """Test that LibraryNotInstalledError is raised for .rar when rarfile is not installed."""
     with ArchiveStream(

--- a/tox.ini
+++ b/tox.ini
@@ -45,67 +45,58 @@ allowlist_externals =
 deps =
     .
     pytest
-    lz4>=4.4.4
-    zstandard>=0.23.0
-    rarfile40  # Factor for rarfile==4.0
-    py7zr0220  # Factor for py7zr==0.22.0
+    lz4>=4.4.4       # For test collection/sample_archives.py if not covered by .
+    zstandard>=0.23.0  # For test collection/sample_archives.py if not covered by .
+    # Factors rarfile40 and py7zr0220 from [testenv] apply automatically
 
 [testenv:py310-rarfile42-py7zr100rc3]
 deps =
     .[optional]
     pytest
-    rarfile42      # Factor for rarfile==4.2
-    py7zr100rc3    # Factor for py7zr==1.0.0rc3
+    # Factors rarfile42 and py7zr100rc3 from [testenv] apply automatically
 
 [testenv:py310-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest  # Factor for latest rarfile
-    py7zrlatest    # Factor for latest py7zr
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:py311-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest
-    py7zrlatest
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:py312-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest
-    py7zrlatest
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:py313-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest
-    py7zrlatest
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:py314beta-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest
-    py7zrlatest
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:latest-rarfilelatest-py7zrlatest]
 deps =
     .[optional]
     pytest
-    rarfilelatest
-    py7zrlatest
+    # Factors rarfilelatest and py7zrlatest from [testenv] apply automatically
 
 [testenv:py310-rarfilenotinstalled-py7zrnotinstalled]
 deps =
     pytest
     lz4>=4.4.4       # For test collection/sample_archives.py
     zstandard>=0.23.0  # For test collection/sample_archives.py
-    rarfilenotinstalled # Factor to ensure no rarfile installed by deps
-    py7zrnotinstalled   # Factor to ensure no py7zr installed by deps
+    # Factors rarfilenotinstalled and py7zrnotinstalled from [testenv] apply automatically
 commands =
     pytest -m "missing_rarfile or missing_py7zr" tests/archivey/test_read_archives.py
 
@@ -116,6 +107,6 @@ deps =
     rarfile            # rarfile is needed for the crypto tests (it's mocked as missing crypto features)
     lz4>=4.4.4       # For test collection/sample_archives.py
     zstandard>=0.23.0  # For test collection/sample_archives.py
-    missing-crypto     # Factor for this environment
+    # Factor missing-crypto from [testenv] applies automatically
 commands =
     pytest -m missing_crypto tests/archivey/test_read_archives.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,43 +3,32 @@ envlist =
     py310-rarfile40-py7zr0220,
     py310-rarfile42-py7zr100rc3,
     py310-rarfilelatest-py7zrlatest,
-    py310-rarfilenotinstalled-py7zrnotinstalled,
-    py310-missing-crypto,
+    py311-rarfilelatest-py7zrlatest,
+    py312-rarfilelatest-py7zrlatest,
     py313-rarfilelatest-py7zrlatest,
     py314beta-rarfilelatest-py7zrlatest,
-    latest-rarfilelatest-py7zrlatest
+    latest-rarfilelatest-py7zrlatest,
+    py310-rarfilenotinstalled-py7zrnotinstalled,
+    py310-missing-crypto
 skip_missing_interpreters = True
 
 [testenv]
 deps =
-    # For most environments, install with optional dependencies
-    py310-rarfile42-py7zr100rc3: .[optional]
-    py310-rarfilelatest-py7zrlatest: .[optional]
-    py313-rarfilelatest-py7zrlatest: .[optional]
-    py314beta-rarfilelatest-py7zrlatest: .[optional]
-    latest-rarfilelatest-py7zrlatest: .[optional]
-    # For specific older versions or no-install cases, install base package only or not at all
-    py310-rarfile40-py7zr0220: . # Install base package
-    # For notinstalled cases, .[optional] would pull them in, so just install pytest
-    py310-rarfilenotinstalled-py7zrnotinstalled: # No package
-    # py310-missing-crypto defines its deps in its own section
-
-    pytest
-    lz4>=4.4.4 # Needed by sample_archives.py for test collection
-    zstandard>=0.23.0 # Needed by sample_archives.py for test collection
-    # rarfile versions
+    # Factor definitions for rarfile versions
     rarfile40: rarfile==4.0
     rarfile42: rarfile==4.2
     rarfilelatest: rarfile
-    # py7zr versions
+    # Factor definitions for py7zr versions
     py7zr0220: py7zr==0.22.0
     py7zr100rc3: py7zr==1.0.0rc3
     py7zrlatest: py7zr
-    # No rarfile/py7zr for the 'notinstalled' cases / missing-crypto
-    rarfilenotinstalled:
-    py7zrnotinstalled:
-    missing-crypto: # py310-missing-crypto installs rarfile above
+    # Factors for special cases
+    rarfilenotinstalled: # Used by py310-rarfilenotinstalled-py7zrnotinstalled
+    py7zrnotinstalled:   # Used by py310-rarfilenotinstalled-py7zrnotinstalled
+    missing-crypto:      # Used by py310-missing-crypto
 commands =
+    # Note: sudo apt-get update is run once per job in GHA now,
+    # but keeping it here for local tox runs if needed.
     sudo apt-get update
     sudo apt-get install -y unrar
     pytest -m "not missing_crypto and not missing_rarfile and not missing_py7zr" tests/archivey/test_read_archives.py
@@ -50,20 +39,83 @@ allowlist_externals =
     sudo
     apt-get
 
-[testenv:py310-rarfilenotinstalled-py7zrnotinstalled]
+# Specific environment configurations
+
+[testenv:py310-rarfile40-py7zr0220]
 deps =
+    .
     pytest
     lz4>=4.4.4
     zstandard>=0.23.0
+    rarfile40  # Factor for rarfile==4.0
+    py7zr0220  # Factor for py7zr==0.22.0
+
+[testenv:py310-rarfile42-py7zr100rc3]
+deps =
+    .[optional]
+    pytest
+    rarfile42      # Factor for rarfile==4.2
+    py7zr100rc3    # Factor for py7zr==1.0.0rc3
+
+[testenv:py310-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest  # Factor for latest rarfile
+    py7zrlatest    # Factor for latest py7zr
+
+[testenv:py311-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest
+    py7zrlatest
+
+[testenv:py312-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest
+    py7zrlatest
+
+[testenv:py313-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest
+    py7zrlatest
+
+[testenv:py314beta-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest
+    py7zrlatest
+
+[testenv:latest-rarfilelatest-py7zrlatest]
+deps =
+    .[optional]
+    pytest
+    rarfilelatest
+    py7zrlatest
+
+[testenv:py310-rarfilenotinstalled-py7zrnotinstalled]
+deps =
+    pytest
+    lz4>=4.4.4       # For test collection/sample_archives.py
+    zstandard>=0.23.0  # For test collection/sample_archives.py
+    rarfilenotinstalled # Factor to ensure no rarfile installed by deps
+    py7zrnotinstalled   # Factor to ensure no py7zr installed by deps
 commands =
     pytest -m "missing_rarfile or missing_py7zr" tests/archivey/test_read_archives.py
 
 [testenv:py310-missing-crypto]
 deps =
-    .
+    .                  # Install the package itself
     pytest
-    rarfile # rarfile is needed for the crypto tests (it's mocked as missing crypto features)
-    lz4>=4.4.4
-    zstandard>=0.23.0
+    rarfile            # rarfile is needed for the crypto tests (it's mocked as missing crypto features)
+    lz4>=4.4.4       # For test collection/sample_archives.py
+    zstandard>=0.23.0  # For test collection/sample_archives.py
+    missing-crypto     # Factor for this environment
 commands =
     pytest -m missing_crypto tests/archivey/test_read_archives.py

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py310-rarfile42-py7zr100rc3,
     py310-rarfilelatest-py7zrlatest,
     py310-rarfilenotinstalled-py7zrnotinstalled,
+    py310-missing-crypto,
     py313-rarfilelatest-py7zrlatest,
     py314beta-rarfilelatest-py7zrlatest,
     latest-rarfilelatest-py7zrlatest
@@ -20,7 +21,8 @@ deps =
     # For specific older versions or no-install cases, install base package only or not at all
     py310-rarfile40-py7zr0220: . # Install base package
     # For notinstalled cases, .[optional] would pull them in, so just install pytest
-    py310-rarfilenotinstalled-py7zrnotinstalled: # No package, just pytest
+    py310-rarfilenotinstalled-py7zrnotinstalled: # No package
+    # py310-missing-crypto defines its deps in its own section
 
     pytest
     lz4>=4.4.4 # Needed by sample_archives.py for test collection
@@ -33,16 +35,35 @@ deps =
     py7zr0220: py7zr==0.22.0
     py7zr100rc3: py7zr==1.0.0rc3
     py7zrlatest: py7zr
-    # No rarfile/py7zr for the 'notinstalled' cases
+    # No rarfile/py7zr for the 'notinstalled' cases / missing-crypto
     rarfilenotinstalled:
     py7zrnotinstalled:
+    missing-crypto: # py310-missing-crypto installs rarfile above
 commands =
     sudo apt-get update
     sudo apt-get install -y unrar
-    pytest tests/archivey/test_read_archives.py
+    pytest -m "not missing_crypto and not missing_rarfile and not missing_py7zr" tests/archivey/test_read_archives.py
 setenv =
     PYTHONPATH = {toxinidir}/src
 passenv = *
 allowlist_externals =
     sudo
     apt-get
+
+[testenv:py310-rarfilenotinstalled-py7zrnotinstalled]
+deps =
+    pytest
+    lz4>=4.4.4
+    zstandard>=0.23.0
+commands =
+    pytest -m "missing_rarfile or missing_py7zr" tests/archivey/test_read_archives.py
+
+[testenv:py310-missing-crypto]
+deps =
+    .
+    pytest
+    rarfile # rarfile is needed for the crypto tests (it's mocked as missing crypto features)
+    lz4>=4.4.4
+    zstandard>=0.23.0
+commands =
+    pytest -m missing_crypto tests/archivey/test_read_archives.py


### PR DESCRIPTION
Addresses issues with tox tests failing due to missing cryptography.

Modifications:
- Added pytest markers (`missing_crypto`, `missing_rarfile`, `missing_py7zr`) to specific tests in `tests/archivey/test_read_archives.py` that check behavior when these optional dependencies are absent.
- Updated `tox.ini`:
    - Created a new environment `py310-missing-crypto` that installs `rarfile` but not its cryptography-related dependencies. This environment runs only tests marked with `missing_crypto`.
    - Modified the `py310-rarfilenotinstalled-py7zrnotinstalled` environment to only run tests marked `missing_rarfile` or `missing_py7zr`. It does not install the archivey package itself, nor rarfile/py7zr.
    - Updated all other test environments (which install `.[optional]`) to run tests *not* marked with `missing_crypto`, `missing_rarfile`, or `missing_py7zr`. This ensures they test the full functionality when all optional dependencies are present.
- Verified that `cryptography` and `pycryptodomex` are included in `[project.optional-dependencies]` in `pyproject.toml`, ensuring they are installed in environments that specify `.[optional]`.

This new configuration allows for targeted testing of scenarios where optional dependencies are missing, while ensuring that the main test suite runs with all features enabled.