### PR TITLE
Add folder reader unit test

### DIFF
--- a/src/archivey/folder_reader.py
+++ b/src/archivey/folder_reader.py
@@ -83,9 +83,17 @@ class FolderReader(BaseArchiveReaderRandomAccess):
         )
 
     def _iter_member_infos(self) -> Iterator[ArchiveMember]:
-        for dirpath, dirnames, filenames in self.path.walk(
-            top_down=True, follow_symlinks=False
-        ):
+        if hasattr(self.path, "walk"):
+            walker = self.path.walk(top_down=True, follow_symlinks=False)
+        else:  # Python < 3.12 fallback
+            walker = (
+                (Path(dp), dn, fn)
+                for dp, dn, fn in os.walk(
+                    self.path, topdown=True, followlinks=False
+                )
+            )
+
+        for dirpath, dirnames, filenames in walker:
             for dirname in dirnames:
                 yield self._convert_entry_to_member(dirpath / dirname)
             for filename in filenames:

--- a/tests/archivey/test_folder_reader.py
+++ b/tests/archivey/test_folder_reader.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from pathlib import Path
+
+import pytest
+
+from archivey.core import open_archive
+from archivey.types import ArchiveFormat, MemberType
+from sample_archives import BASIC_FILES, SYMLINK_FILES, ENCODING_FILES
+from utils import write_files_to_dir
+
+
+@pytest.mark.parametrize(
+    "files",
+    [BASIC_FILES, SYMLINK_FILES, ENCODING_FILES],
+    ids=["basic", "symlinks", "encodings"],
+)
+def test_folder_reader(tmp_path: Path, files: list):
+    folder = tmp_path / "folder"
+    write_files_to_dir(folder, files)
+
+    with open_archive(folder) as archive:
+        assert archive.format == ArchiveFormat.FOLDER
+        members = {m.filename: m for m in archive.get_members()}
+
+        expected_names = {f.name.rstrip("/") for f in files}
+        assert expected_names.issubset(set(members))
+
+        for file in files:
+            member = members[file.name.rstrip("/")]
+            assert member.type == file.type
+            assert member.mtime.replace(tzinfo=None) == file.mtime
+
+            if file.type == MemberType.LINK:
+                assert member.link_target == file.link_target
+            elif file.type == MemberType.FILE:
+                with archive.open(member) as fh:
+                    assert fh.read() == file.contents

--- a/tests/archivey/utils.py
+++ b/tests/archivey/utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import os
+from archivey.types import MemberType
+from sample_archives import FileInfo
+
+
+def write_files_to_dir(dir: str | os.PathLike, files: list[FileInfo]):
+    """Write the provided FileInfo objects to ``dir``."""
+    for file in sorted(
+        files,
+        key=lambda x: [MemberType.FILE, MemberType.LINK, MemberType.DIR].index(x.type),
+    ):
+        full_path = os.path.join(dir, file.name)
+        if file.type == MemberType.DIR:
+            os.makedirs(full_path, exist_ok=True)
+        elif file.type == MemberType.LINK:
+            assert file.link_target is not None, "Link target is required"
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            os.symlink(
+                file.link_target,
+                full_path,
+                target_is_directory=file.link_target_type == MemberType.DIR,
+            )
+        else:
+            assert file.contents is not None, "File contents are required"
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            with open(full_path, "wb") as f:
+                f.write(file.contents)
+
+        os.utime(
+            full_path,
+            (file.mtime.timestamp(), file.mtime.timestamp()),
+            follow_symlinks=False,
+        )
+
+        default_permissions_by_type = {
+            MemberType.DIR: 0o755,
+            MemberType.LINK: 0o777,
+            MemberType.FILE: 0o644,
+        }
+        os.chmod(full_path, file.permissions or default_permissions_by_type[file.type])


### PR DESCRIPTION
## Summary
- move `write_files_to_dir` helper into test utilities
- fallback to `os.walk` in `FolderReader` for Python < 3.12
- add tests for reading folders using existing file sets

## Testing
- `hatch run pytest tests/archivey/test_folder_reader.py -q`
- `hatch run pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'unrar')*

------
https://chatgpt.com/codex/tasks/task_e_68404a0646bc832d931abd1858f4ded9