### PR TITLE
Add folder reader tests

### DIFF
--- a/tests/archivey/test_folder_reader.py
+++ b/tests/archivey/test_folder_reader.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+import pathlib
+import pytest
+
+if not hasattr(pathlib.Path, "walk"):
+    def _walk(self, top_down=True, on_error=None, follow_symlinks=False):
+        for root, dirs, files in os.walk(
+            self, topdown=top_down, onerror=on_error, followlinks=follow_symlinks
+        ):
+            yield pathlib.Path(root), dirs, files
+
+    pathlib.Path.walk = _walk
+
+from archivey.core import open_archive
+from archivey.types import ArchiveFormat, MemberType
+from sample_archives import BASIC_FILES, SYMLINK_FILES, ENCODING_FILES
+from utils import write_files_to_dir
+
+
+FILES_SETS = [BASIC_FILES, SYMLINK_FILES, ENCODING_FILES]
+
+
+def check_folder(dir_path: str, files):
+    with open_archive(dir_path) as archive:
+        assert archive.format == ArchiveFormat.FOLDER
+        members = {m.filename: m for m in archive.get_members()}
+        file_map = {f.name.rstrip('/'): f for f in files}
+
+        for name, member in members.items():
+            info = file_map.get(name)
+            if info is None:
+                if member.type == MemberType.DIR:
+                    continue
+                else:
+                    assert False, f"Unexpected file {name}"
+
+            assert member.type == info.type
+            if info.type == MemberType.LINK:
+                assert member.link_target == info.link_target
+            if info.type == MemberType.FILE:
+                with archive.open(member) as stream:
+                    assert stream.read() == (info.contents or b"")
+
+        assert set(file_map) <= set(members)
+
+
+@pytest.mark.parametrize("files", FILES_SETS)
+def test_folder_reader(files):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        write_files_to_dir(tmpdir, files)
+        check_folder(tmpdir, files)

--- a/tests/archivey/utils.py
+++ b/tests/archivey/utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import os
+from archivey.types import MemberType
+from sample_archives import FileInfo
+
+
+def write_files_to_dir(dir: str, files: list[FileInfo]) -> None:
+    """Write the given list of FileInfo objects to a directory."""
+    # Leave directories for last so their timestamps aren't affected by file creation
+    for file in sorted(
+        files,
+        key=lambda x: [MemberType.FILE, MemberType.LINK, MemberType.DIR].index(x.type),
+    ):
+        full_path = os.path.join(dir, file.name)
+        if file.type == MemberType.DIR:
+            os.makedirs(full_path, exist_ok=True)
+        elif file.type == MemberType.LINK:
+            assert file.link_target is not None, "Link target is required"
+            dir_path = os.path.dirname(full_path)
+            os.makedirs(dir_path, exist_ok=True)
+            os.symlink(
+                file.link_target,
+                full_path,
+                target_is_directory=file.link_target_type == MemberType.DIR,
+            )
+        else:
+            assert file.contents is not None, "File contents are required"
+            dir_path = os.path.dirname(full_path)
+            os.makedirs(dir_path, exist_ok=True)
+            with open(full_path, "wb") as f:
+                f.write(file.contents)
+
+        os.utime(
+            full_path,
+            (file.mtime.timestamp(), file.mtime.timestamp()),
+            follow_symlinks=False,
+        )
+
+        default_permissions_by_type = {
+            MemberType.DIR: 0o755,
+            MemberType.LINK: 0o777,
+            MemberType.FILE: 0o644,
+        }
+        os.chmod(full_path, file.permissions or default_permissions_by_type[file.type])
+


### PR DESCRIPTION
## Summary
- factor out file writing helper to `tests.archivey.utils`
- use that helper in `create_archives.py`
- test `FolderReader` with basic, symlink and encoding file sets

## Testing
- `uv run --extra optional pytest tests/archivey/test_folder_reader.py -q`
- `uv run --extra optional pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'unrar')*

------
https://chatgpt.com/codex/tasks/task_e_684055f43fa4832dad08d98ea0a54db1