### PR TITLE
Implement lazy-open wrapper for archive streams

### DIFF
--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -6,7 +6,7 @@ import shutil
 from typing import IO, Callable, Iterator, List
 
 from archivey.exceptions import ArchiveError, ArchiveMemberNotFoundError
-from archivey.io_helpers import ErrorIOStream
+from archivey.io_helpers import ErrorIOStream, LazyOpenIO
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember
 
 logger = logging.getLogger(__name__)
@@ -120,7 +120,7 @@ class BaseArchiveReaderRandomAccess(ArchiveReader):
         for member in self.get_members():
             if filter is None or filter(member):
                 try:
-                    stream = self.open(member)
+                    stream = LazyOpenIO(self.open, member)
                     yield member, stream
                     stream.close()
                 except (ArchiveError, OSError) as e:

--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -120,7 +120,7 @@ class BaseArchiveReaderRandomAccess(ArchiveReader):
         for member in self.get_members():
             if filter is None or filter(member):
                 try:
-                    stream = LazyOpenIO(self.open, member)
+                    stream = LazyOpenIO(self.open, member, seekable=True)
                     yield member, stream
                     stream.close()
                 except (ArchiveError, OSError) as e:

--- a/src/archivey/folder_reader.py
+++ b/src/archivey/folder_reader.py
@@ -7,7 +7,7 @@ from typing import IO, Iterator, List, Optional
 
 from archivey.base_reader import BaseArchiveReaderRandomAccess
 from archivey.exceptions import ArchiveError, ArchiveIOError, ArchiveMemberNotFoundError
-from archivey.io_helpers import ErrorIOStream
+from archivey.io_helpers import ErrorIOStream, LazyOpenIO
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember, MemberType
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ class FolderReader(BaseArchiveReaderRandomAccess):
         for member in self._iter_member_infos():
             if member.is_file:
                 try:
-                    stream = self.open(member)
+                    stream = LazyOpenIO(self.open, member)
                 except (IOError, OSError) as e:
                     logger.info(f"Error opening member {member.filename}: {e}")
                     archive_error = ArchiveIOError(

--- a/src/archivey/folder_reader.py
+++ b/src/archivey/folder_reader.py
@@ -98,7 +98,7 @@ class FolderReader(BaseArchiveReaderRandomAccess):
         for member in self._iter_member_infos():
             if member.is_file:
                 try:
-                    stream = LazyOpenIO(self.open, member)
+                    stream = LazyOpenIO(self.open, member, seekable=True)
                 except (IOError, OSError) as e:
                     logger.info(f"Error opening member {member.filename}: {e}")
                     archive_error = ArchiveIOError(

--- a/src/archivey/tar_reader.py
+++ b/src/archivey/tar_reader.py
@@ -225,7 +225,7 @@ class TarReader(BaseArchiveReaderRandomAccess):
             member = self._tarinfo_to_archive_member(tarinfo)
             if filter is None or filter(member):
                 try:
-                    stream = LazyOpenIO(self.open, member)
+                    stream = LazyOpenIO(self.open, member, seekable=True)
                     yield member, stream
                     stream.close()
                 except (ArchiveError, OSError) as e:

--- a/src/archivey/tar_reader.py
+++ b/src/archivey/tar_reader.py
@@ -16,7 +16,7 @@ from archivey.exceptions import (
     ArchiveError,
     ArchiveMemberCannotBeOpenedError,
 )
-from archivey.io_helpers import ErrorIOStream
+from archivey.io_helpers import ErrorIOStream, LazyOpenIO
 from archivey.types import ArchiveFormat, MemberType
 
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ class TarReader(BaseArchiveReaderRandomAccess):
             member = self._tarinfo_to_archive_member(tarinfo)
             if filter is None or filter(member):
                 try:
-                    stream = self.open(member)
+                    stream = LazyOpenIO(self.open, member)
                     yield member, stream
                     stream.close()
                 except (ArchiveError, OSError) as e:

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -1,0 +1,33 @@
+import io
+from unittest.mock import Mock
+
+import pytest
+
+from archivey.io_helpers import LazyOpenIO
+
+
+def test_lazy_open_only_on_read():
+    open_fn = Mock(return_value=io.BytesIO(b"hello"))
+    wrapper = LazyOpenIO(open_fn)
+    assert open_fn.call_count == 0
+    assert wrapper.read() == b"hello"
+    assert open_fn.call_count == 1
+    wrapper.close()
+
+
+def test_lazy_open_not_called_when_unused():
+    open_fn = Mock(return_value=io.BytesIO(b"unused"))
+    wrapper = LazyOpenIO(open_fn)
+    wrapper.close()
+    assert open_fn.call_count == 0
+
+
+def test_lazy_open_closes_inner_stream():
+    inner = io.BytesIO(b"data")
+    open_fn = Mock(return_value=inner)
+    wrapper = LazyOpenIO(open_fn)
+    wrapper.read(1)
+    wrapper.close()
+    assert inner.closed
+    with pytest.raises(ValueError):
+        wrapper.read()

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -15,6 +15,13 @@ def test_lazy_open_only_on_read():
     wrapper.close()
 
 
+def test_lazy_open_seekable_does_not_open():
+    open_fn = Mock(return_value=io.BytesIO())
+    wrapper = LazyOpenIO(open_fn, seekable=True)
+    assert wrapper.seekable() is True
+    assert open_fn.call_count == 0
+
+
 def test_lazy_open_not_called_when_unused():
     open_fn = Mock(return_value=io.BytesIO(b"unused"))
     wrapper = LazyOpenIO(open_fn)


### PR DESCRIPTION
## Summary
- add `LazyOpenIO` helper to defer opening a stream until first read
- use lazy stream wrapper in default random-access iteration
- update folder and tar readers to yield lazy streams
- test the new wrapper

## Testing
- `uv run --extra optional pytest -q` *(fails: ArchiveError: Error opening RAR archive ...)*

------
https://chatgpt.com/codex/tasks/task_e_6840abed0ce4832d9c3cd45d6b0d1c9b