### PR TITLE
Add extraction modes and version flag to CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
-archivey = "archivey:main"
+archivey = "archivey.cli:main"
 
 [project.optional-dependencies]
 optional = [

--- a/src/archivey/__main__.py
+++ b/src/archivey/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/archivey/cli.py
+++ b/src/archivey/cli.py
@@ -1,24 +1,24 @@
-# A zipfile-like interface for reading all the files in an archive.
-
 import argparse
 import builtins
+import fnmatch
 import hashlib
 import logging
 import os
+import sys
 import zlib
 from datetime import datetime
-from typing import IO, Tuple
+from importlib.metadata import version as package_version
+from typing import IO, Callable, Tuple
 
 from tqdm import tqdm
 
-from archivey.base_reader import ArchiveReader
-from archivey.config import ArchiveyConfig
-from archivey.core import open_archive
-from archivey.exceptions import (
-    ArchiveError,
-)
-from archivey.io_helpers import IOStats, StatsIO
-from archivey.types import ArchiveMember, MemberType
+from .base_reader import ArchiveReader
+from .config import ArchiveyConfig
+from .core import open_archive
+from .dependency_checker import format_dependency_versions, get_dependency_versions
+from .exceptions import ArchiveError
+from .io_helpers import IOStats, StatsIO
+from .types import ArchiveMember, MemberType
 
 logging.basicConfig(level=logging.INFO)
 
@@ -32,103 +32,41 @@ def format_mode(member_type: MemberType, mode: int) -> str:
         if member_type == MemberType.LINK
         else "-"
     )
-    # Convert permissions to rwxrwxrwx format
     permissions_str = type_char
     letters = "xwr" * 3
     for bit in range(8, -1, -1):
-        if permissions & (1 << bit):
-            permissions_str += letters[bit]
-        else:
-            permissions_str += "-"
+        permissions_str += letters[bit] if permissions & (1 << bit) else "-"
     return permissions_str
 
 
 def get_member_checksums(member_file: IO[bytes]) -> Tuple[int, str]:
-    """
-    Compute both CRC32 and SHA256 checksums for a file within an archive.
-    Returns a tuple of (crc32, sha256) as hex strings.
-    """
     crc32_value: int = 0
     sha256 = hashlib.sha256()
-
-    # Read the file in chunks
     for block in iter(lambda: member_file.read(65536), b""):
         crc32_value = zlib.crc32(block, crc32_value)
         sha256.update(block)
     return crc32_value & 0xFFFFFFFF, sha256.hexdigest()
 
 
-parser = argparse.ArgumentParser(
-    description="List contents of archive files with checksums."
-)
-parser.add_argument("files", nargs="+", help="Archive files to process")
-parser.add_argument(
-    "--use-libarchive",
-    action="store_true",
-    help="Use libarchive for processing archives",
-)
-parser.add_argument(
-    "--use-rar-stream",
-    action="store_true",
-    help="Use the RAR stream reader for RAR files",
-)
-parser.add_argument(
-    "--use-rapidgzip",
-    action="store_true",
-    help="Use rapidgzip for reading gzip-compressed files",
-)
-parser.add_argument(
-    "--use-indexed-bzip2",
-    action="store_true",
-    help="Use indexed_bzip2 for reading bzip2-compressed files",
-)
-parser.add_argument(
-    "--use-python-xz",
-    action="store_true",
-    help="Use python-xz for reading xz-compressed files",
-)
-parser.add_argument("--stream", action="store_true", help="Stream the archive")
-parser.add_argument("--info", action="store_true", help="Print info about the archive")
-parser.add_argument("--password", help="Password for encrypted archives")
-parser.add_argument("--hide-progress", action="store_true", help="Hide progress bar")
-parser.add_argument(
-    "--use-stored-metadata",
-    action="store_true",
-    help="Use stored metadata for single file archives",
-)
-parser.add_argument(
-    "--track-io",
-    action="store_true",
-    help="Track IO statistics for archive file access",
-)
+def build_pattern_filter(patterns: list[str]) -> Callable[[ArchiveMember], bool] | None:
+    """Create a filter function for member names based on shell-style patterns."""
+    if not patterns:
+        return None
 
-args = parser.parse_args()
+    def _match(member: ArchiveMember) -> bool:
+        return any(fnmatch.fnmatch(member.filename, pat) for pat in patterns)
 
-stats_per_file: dict[str, IOStats] = {}
-if args.track_io:
-    original_open = builtins.open
-    target_paths = {os.path.abspath(p) for p in args.files}
-
-    def patched_open(file, mode="r", *oargs, **okwargs):
-        path = None
-        if isinstance(file, (str, bytes, os.PathLike)):
-            path = os.path.abspath(file)
-        if (
-            path in target_paths
-            and "r" in mode
-            and not any(m in mode for m in ["w", "a", "+"])
-        ):
-            f = original_open(file, mode, *oargs, **okwargs)
-            stats = stats_per_file.setdefault(path, IOStats())
-            return StatsIO(f, stats)
-        return original_open(file, mode, *oargs, **okwargs)
-
-    builtins.open = patched_open
+    return _match
 
 
 def process_member(
-    member: ArchiveMember, archive: ArchiveReader, stream: IO[bytes] | None = None
-):
+    member: ArchiveMember,
+    archive: ArchiveReader,
+    stream: IO[bytes] | None = None,
+    *,
+    verify: bool,
+    pwd: str | None = None,
+) -> None:
     stream_to_close: IO[bytes] | None = None
 
     encrypted_str = "E" if member.encrypted else " "
@@ -143,30 +81,34 @@ def process_member(
             if member.extra:
                 print(f"{member.filename} {member.extra}")
 
-            if stream is None:
-                stream = stream_to_close = archive.open(member, pwd=args.password)
-
-            crc32, sha256 = get_member_checksums(stream)
-            if member.crc32 is not None and member.crc32 != crc32:
-                crc_error = f" != {member.crc32:08x}"
+            if verify:
+                if stream is None:
+                    stream = stream_to_close = archive.open(member, pwd=pwd)
+                crc32, sha256 = get_member_checksums(stream)
+                if member.crc32 is not None and member.crc32 != crc32:
+                    crc_error = f" != {member.crc32:08x}"
+                else:
+                    crc_error = ""
+                sha = sha256[:16]
+                crc_display = f"{crc32:08x}{crc_error}"
             else:
-                crc_error = ""
-
+                crc_display = (
+                    f"{member.crc32:08x}" if member.crc32 is not None else "?" * 8
+                )
+                sha = " " * 16
             print(
-                f"{encrypted_str}  {size_str}  {format_str}  {crc32:08x}{crc_error}  {sha256[:16]}  {member.mtime}  {member.filename}"
+                f"{encrypted_str}  {size_str}  {format_str}  {crc_display}  {sha}  {member.mtime}  {member.filename}"
             )
-
         except ArchiveError as e:
-            formated_crc = (
+            formatted_crc = (
                 f"{member.crc32:08x}" if member.crc32 is not None else "?" * 8
             )
             print(
-                f"{encrypted_str}  {size_str}  {format_str}  {formated_crc}  {' ' * 16}  {member.mtime}  {member.filename} -- ERROR: {repr(e)}"
+                f"{encrypted_str}  {size_str}  {format_str}  {formatted_crc}  {' ' * 16}  {member.mtime}  {member.filename} -- ERROR: {repr(e)}"
             )
         finally:
             if stream_to_close is not None:
                 stream_to_close.close()
-
     elif member.is_link:
         assert isinstance(member.link_target, str) or member.link_target is None
         print(
@@ -180,60 +122,201 @@ def process_member(
         print(f"    Comment: {member.comment}")
 
 
-for archive_path in args.files:
-    try:
-        print(f"\nProcessing {archive_path}:")
-        config = ArchiveyConfig(
-            use_libarchive=args.use_libarchive,
-            use_rar_stream=args.use_rar_stream,
-            use_single_file_stored_metadata=args.use_stored_metadata,
-            use_rapidgzip=args.use_rapidgzip,
-            use_indexed_bzip2=args.use_indexed_bzip2,
-            use_python_xz=args.use_python_xz,
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Archivey command line interface."
+            " Use '--' followed by patterns to filter archive members."
         )
-        with open_archive(
-            archive_path,
-            pwd=args.password,
-            config=config,
-        ) as archive:
-            print(f"Archive format: {archive.format} {archive.get_archive_info()}")
-            if args.info:
-                continue
+    )
+    parser.add_argument("files", nargs="+", help="Archive files to process")
 
-            if args.stream:
-                members_if_available = archive.get_members_if_available()
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "-t",
+        "--test",
+        action="store_const",
+        const="test",
+        dest="mode",
+        help="List contents and verify checksums (default)",
+    )
+    mode.add_argument(
+        "-l",
+        "--list",
+        action="store_const",
+        const="list",
+        dest="mode",
+        help="List contents without verifying",
+    )
+    mode.add_argument(
+        "-x",
+        "--extract",
+        action="store_const",
+        const="extract",
+        dest="mode",
+        help="Extract files",
+    )
+    parser.set_defaults(mode="test")
 
-                for member, stream in tqdm(
-                    archive.iter_members_with_io(),
-                    desc="Computing checksums",
-                    disable=args.hide_progress,
-                    total=len(members_if_available)
-                    if members_if_available is not None
-                    else None,
-                ):
-                    process_member(member, archive, stream)
+    parser.add_argument(
+        "--use-libarchive",
+        action="store_true",
+        help="Use libarchive for processing archives",
+    )
+    parser.add_argument(
+        "--use-rar-stream",
+        action="store_true",
+        help="Use the RAR stream reader for RAR files",
+    )
+    parser.add_argument(
+        "--use-rapidgzip",
+        action="store_true",
+        help="Use rapidgzip for reading gzip-compressed files",
+    )
+    parser.add_argument(
+        "--use-indexed-bzip2",
+        action="store_true",
+        help="Use indexed_bzip2 for reading bzip2-compressed files",
+    )
+    parser.add_argument(
+        "--use-python-xz",
+        action="store_true",
+        help="Use python-xz for reading xz-compressed files",
+    )
+    parser.add_argument("--stream", action="store_true", help="Stream the archive")
+    parser.add_argument("--info", action="store_true", help="Print info about the archive")
+    parser.add_argument("--password", help="Password for encrypted archives")
+    parser.add_argument("--hide-progress", action="store_true", help="Hide progress bar")
+    parser.add_argument(
+        "--use-stored-metadata",
+        action="store_true",
+        help="Use stored metadata for single file archives",
+    )
+    parser.add_argument(
+        "--track-io",
+        action="store_true",
+        help="Track IO statistics for archive file access",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Show version and dependency information",
+    )
+    parser.add_argument(
+        "--dest",
+        default=".",
+        help="Destination directory for extraction (default: current directory)",
+    )
+    return parser
 
-            else:
-                members = archive.get_members()
 
-                for member in tqdm(
-                    members,
-                    desc="Computing checksums",
-                    disable=args.hide_progress,
-                    total=len(members) if members is not None else None,
-                ):
-                    process_member(member, archive)
+def main(argv: list[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
 
-    except ArchiveError as e:
-        print(f"Error processing {archive_path}: {e}")
+    pattern_args: list[str] = []
+    if "--" in argv:
+        idx = argv.index("--")
+        pattern_args = argv[idx + 1 :]
+        argv = argv[:idx]
+
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        print(f"archivey {package_version('archivey')}")
+        versions = get_dependency_versions()
+        print(format_dependency_versions(versions))
+        return
+
+    member_filter = build_pattern_filter(pattern_args)
+
+    stats_per_file: dict[str, IOStats] = {}
     if args.track_io:
-        abs_path = os.path.abspath(archive_path)
-        stats = stats_per_file.get(abs_path)
-        if stats is not None:
-            print(
-                f"IO stats for {archive_path}: {stats.bytes_read} bytes read, {stats.seek_calls} seeks"
-            )
-    print()
+        original_open = builtins.open
+        target_paths = {os.path.abspath(p) for p in args.files}
 
-if args.track_io:
-    builtins.open = original_open
+        def patched_open(file, mode="r", *oargs, **okwargs):
+            path = None
+            if isinstance(file, (str, bytes, os.PathLike)):
+                path = os.path.abspath(file)
+            if path in target_paths and "r" in mode and not any(m in mode for m in ["w", "a", "+"]):
+                f = original_open(file, mode, *oargs, **okwargs)
+                stats = stats_per_file.setdefault(path, IOStats())
+                return StatsIO(f, stats)
+            return original_open(file, mode, *oargs, **okwargs)
+
+        builtins.open = patched_open
+
+    for archive_path in args.files:
+        try:
+            print(f"\nProcessing {archive_path}:")
+            config = ArchiveyConfig(
+                use_libarchive=args.use_libarchive,
+                use_rar_stream=args.use_rar_stream,
+                use_single_file_stored_metadata=args.use_stored_metadata,
+                use_rapidgzip=args.use_rapidgzip,
+                use_indexed_bzip2=args.use_indexed_bzip2,
+                use_python_xz=args.use_python_xz,
+            )
+            with open_archive(archive_path, pwd=args.password, config=config) as archive:
+                print(f"Archive format: {archive.format} {archive.get_archive_info()}")
+                if args.info:
+                    continue
+
+                if args.mode == "extract":
+                    if member_filter is None:
+                        archive.extractall(args.dest)
+                    else:
+                        members = archive.get_members()
+                        if members is not None:
+                            members = [m for m in members if member_filter(m)]
+                        for member in tqdm(
+                            members,
+                            desc="Extracting",
+                            disable=args.hide_progress,
+                            total=len(members) if members is not None else None,
+                        ):
+                            archive.extract(member, root_path=args.dest)
+                    continue
+
+                verify = args.mode == "test"
+                if args.stream:
+                    members_if_available = archive.get_members_if_available()
+                    if members_if_available is not None and member_filter is not None:
+                        members_if_available = [m for m in members_if_available if member_filter(m)]
+                    for member, stream in tqdm(
+                        archive.iter_members_with_io(filter=member_filter),
+                        desc="Computing checksums" if verify else "Listing members",
+                        disable=args.hide_progress,
+                        total=len(members_if_available) if members_if_available is not None else None,
+                    ):
+                        process_member(member, archive, stream, verify=verify, pwd=args.password)
+                else:
+                    members = archive.get_members()
+                    if members is not None and member_filter is not None:
+                        members = [m for m in members if member_filter(m)]
+                    for member in tqdm(
+                        members,
+                        desc="Computing checksums" if verify else "Listing members",
+                        disable=args.hide_progress,
+                        total=len(members) if members is not None else None,
+                    ):
+                        process_member(member, archive, verify=verify, pwd=args.password)
+        except ArchiveError as e:
+            print(f"Error processing {archive_path}: {e}")
+        if args.track_io:
+            abs_path = os.path.abspath(archive_path)
+            stats = stats_per_file.get(abs_path)
+            if stats is not None:
+                print(
+                    f"IO stats for {archive_path}: {stats.bytes_read} bytes read, {stats.seek_calls} seeks"
+                )
+        print()
+
+    if args.track_io:
+        builtins.open = original_open  # type: ignore[has-type]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- extend `archivey.cli` to support `--list`, `--extract`, and default `--test` modes
- implement `--version` option showing package and dependency versions
- expose CLI via `archivey/__main__.py` so `python -m archivey` works
- fix script entrypoint in `pyproject.toml`
- add support for file pattern filtering using `--`

## Testing
- `uv run --extra optional pytest`


------
https://chatgpt.com/codex/tasks/task_e_68415d1c3288832da94ba1ac309af34c