### PR TITLE
Add sample archive fixture

### DIFF
--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -63,7 +63,10 @@ COMPRESSION_FORMAT_TO_TAR_FORMAT = {
     ArchiveFormat.LZ4: ArchiveFormat.TAR_LZ4,
 }
 
-TAR_FORMAT_TO_COMPRESSION_FORMAT = {v: k for k, v in COMPRESSION_FORMAT_TO_TAR_FORMAT.items()}
+TAR_FORMAT_TO_COMPRESSION_FORMAT = {
+    v: k for k, v in COMPRESSION_FORMAT_TO_TAR_FORMAT.items()
+}
+
 
 class MemberType(StrEnum):
     FILE = "file"

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -63,6 +63,7 @@ COMPRESSION_FORMAT_TO_TAR_FORMAT = {
     ArchiveFormat.LZ4: ArchiveFormat.TAR_LZ4,
 }
 
+TAR_FORMAT_TO_COMPRESSION_FORMAT = {v: k for k, v in COMPRESSION_FORMAT_TO_TAR_FORMAT.items()}
 
 class MemberType(StrEnum):
     FILE = "file"

--- a/tests/archivey/sample_archives.py
+++ b/tests/archivey/sample_archives.py
@@ -837,6 +837,33 @@ ARCHIVE_DEFINITIONS: list[tuple[ArchiveContents, list[ArchiveCreationInfo]]] = [
         ),
         BASIC_TAR_FORMATS,
     ),
+    (
+        ArchiveContents(
+            file_basename="fixture_zip",
+            files=[
+                FileInfo(
+                    name="fixture.txt",
+                    mtime=_fake_mtime(1),
+                    contents=b"fixture zip",
+                )
+            ],
+        ),
+        [ZIP_ZIPFILE],
+    ),
+    (
+        ArchiveContents(
+            file_basename="fixture_tar",
+            files=[
+                FileInfo(
+                    name="fixture.txt",
+                    mtime=_fake_mtime(1),
+                    contents=b"fixture tar",
+                )
+            ],
+            solid=True,
+        ),
+        [TAR_PLAIN_TARFILE],
+    ),
     # (
     #     ArchiveContents(
     #         file_basename="basic_iso",

--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -2,10 +2,10 @@ import os
 from pathlib import Path
 
 import pytest
-from tests.archivey.sample_archives import SAMPLE_ARCHIVES
 
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat, MemberType
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES
 
 
 def _get_sample(name: str):

--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
-from sample_archives import SAMPLE_ARCHIVES
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES
 
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat, MemberType

--- a/tests/archivey/test_fixture_integration.py
+++ b/tests/archivey/test_fixture_integration.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES, ArchiveInfo, filter_archives
+from tests.archivey.test_read_archives import check_iter_members
+
+
+@pytest.mark.parametrize(
+    "sample_archive",
+    filter_archives(SAMPLE_ARCHIVES, prefixes=["fixture_zip", "fixture_tar"]),
+    ids=lambda a: a.filename,
+)
+def test_fixture_generates_archives(sample_archive: ArchiveInfo, sample_archive_path: str):
+    assert os.path.exists(sample_archive_path)
+    check_iter_members(sample_archive, archive_path=sample_archive_path)

--- a/tests/archivey/test_fixture_integration.py
+++ b/tests/archivey/test_fixture_integration.py
@@ -11,6 +11,8 @@ from tests.archivey.test_read_archives import check_iter_members
     filter_archives(SAMPLE_ARCHIVES, prefixes=["fixture_zip", "fixture_tar"]),
     ids=lambda a: a.filename,
 )
-def test_fixture_generates_archives(sample_archive: ArchiveInfo, sample_archive_path: str):
+def test_fixture_generates_archives(
+    sample_archive: ArchiveInfo, sample_archive_path: str
+):
     assert os.path.exists(sample_archive_path)
     check_iter_members(sample_archive, archive_path=sample_archive_path)

--- a/tests/archivey/test_folder_reader.py
+++ b/tests/archivey/test_folder_reader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from sample_archives import BASIC_FILES, ENCODING_FILES, SYMLINK_FILES
+from tests.archivey.sample_archives import BASIC_FILES, ENCODING_FILES, SYMLINK_FILES
 
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat, MemberType

--- a/tests/archivey/test_folder_reader.py
+++ b/tests/archivey/test_folder_reader.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from tests.archivey.sample_archives import BASIC_FILES, ENCODING_FILES, SYMLINK_FILES
 
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat, MemberType
+from tests.archivey.sample_archives import BASIC_FILES, ENCODING_FILES, SYMLINK_FILES
 from tests.archivey.testing_utils import write_files_to_dir
 
 

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import patch
 
 import pytest
-from sample_archives import (
+from tests.archivey.sample_archives import (
     SAMPLE_ARCHIVES,
     filter_archives,
 )

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -2,15 +2,15 @@ import os
 from unittest.mock import patch
 
 import pytest
-from tests.archivey.sample_archives import (
-    SAMPLE_ARCHIVES,
-    filter_archives,
-)
 
 from archivey.core import open_archive
 from archivey.dependency_checker import get_dependency_versions
 from archivey.exceptions import (
     PackageNotInstalledError,
+)
+from tests.archivey.sample_archives import (
+    SAMPLE_ARCHIVES,
+    filter_archives,
 )
 
 # Tests for LibraryNotInstalledError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
+import os
 import pathlib
+
 import pytest
 
-import os
-
+from archivey.exceptions import PackageNotInstalledError
+from tests.archivey.sample_archives import ArchiveInfo
 from tests.create_archives import create_archive
 from tests.create_corrupted_archives import corrupt_archive, truncate_archive
-from tests.archivey.sample_archives import ArchiveInfo
 
 
 @pytest.fixture
@@ -16,7 +17,13 @@ def sample_archive_path(sample_archive: ArchiveInfo, tmp_path_factory) -> str:
         return str(path)
 
     base_dir = tmp_path_factory.mktemp("generated_archives")
-    create_archive(sample_archive, str(base_dir))
+    try:
+        create_archive(sample_archive, str(base_dir))
+    except PackageNotInstalledError as e:
+        pytest.skip(
+            f"Required library for {sample_archive.filename} is not installed: {e}"
+        )
+        raise
     return sample_archive.get_archive_path(str(base_dir))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+import pathlib
+import pytest
+
+import os
+
+from tests.create_archives import create_archive
+from tests.create_corrupted_archives import corrupt_archive, truncate_archive
+from tests.archivey.sample_archives import ArchiveInfo
+
+
+@pytest.fixture
+def sample_archive_path(sample_archive: ArchiveInfo, tmp_path_factory) -> str:
+    """Return path to the sample archive, creating it if needed."""
+    path = pathlib.Path(sample_archive.get_archive_path())
+    if path.exists():
+        return str(path)
+
+    base_dir = tmp_path_factory.mktemp("generated_archives")
+    create_archive(sample_archive, str(base_dir))
+    return sample_archive.get_archive_path(str(base_dir))
+
+
+@pytest.fixture
+def truncated_archive_path(
+    sample_archive: ArchiveInfo, sample_archive_path: str, tmp_path_factory
+) -> str:
+    """Return path to a truncated variant of the sample archive."""
+    if not sample_archive.generate_corrupted_variants:
+        pytest.skip("No truncated variant defined for this archive")
+    base_dir = tmp_path_factory.mktemp("corrupted_archives")
+    name, ext = os.path.splitext(sample_archive.filename)
+    path = pathlib.Path(base_dir) / f"{name}.truncated{ext}"
+    if not path.exists():
+        truncate_archive(pathlib.Path(sample_archive_path), path)
+    return str(path)
+
+
+@pytest.fixture
+def corrupted_archive_path(
+    sample_archive: ArchiveInfo, sample_archive_path: str, tmp_path_factory
+) -> str:
+    """Return path to a corrupted variant of the sample archive."""
+    if not sample_archive.generate_corrupted_variants:
+        pytest.skip("No corrupted variant defined for this archive")
+    base_dir = tmp_path_factory.mktemp("corrupted_archives")
+    name, ext = os.path.splitext(sample_archive.filename)
+    path = pathlib.Path(base_dir) / f"{name}.corrupted{ext}"
+    if not path.exists():
+        corrupt_archive(pathlib.Path(sample_archive_path), path)
+    return str(path)

--- a/tests/create_archives.py
+++ b/tests/create_archives.py
@@ -315,7 +315,9 @@ def create_tar_archive_with_tarfile(
         output_stream = io.BytesIO()
         open_args = {"fileobj": output_stream}
             if zstandard is None:
-                raise ModuleNotFoundError("zstandard is required to create TAR_ZSTD archives")
+                raise ModuleNotFoundError(
+                    "zstandard is required to create TAR_ZSTD archives"
+                )
             if lz4_frame is None:
                 raise ModuleNotFoundError("lz4 is required to create TAR_LZ4 archives")
             compressed = lz4_frame.compress(tar_data)

--- a/tests/create_archives.py
+++ b/tests/create_archives.py
@@ -1,5 +1,6 @@
 import argparse
 import bz2
+from datetime import timezone
 import fnmatch
 import gzip
 import io
@@ -331,7 +332,7 @@ def create_tar_archive_with_tarfile(
     with tarfile.open(name=abs_archive_path, mode=tar_mode, fileobj=output_stream) as tf:  # type: ignore[reportArgumentType]
         for sample_file in contents.files:
             tarinfo = tarfile.TarInfo(name=sample_file.name)
-            tarinfo.mtime = int(sample_file.mtime.timestamp())
+            tarinfo.mtime = int(sample_file.mtime.replace(tzinfo=timezone.utc).timestamp())
 
             if sample_file.permissions is not None:
                 tarinfo.mode = sample_file.permissions


### PR DESCRIPTION
## Summary
- add fixture to generate missing sample archives on the fly
- create new sample archives and integration test for fixture
- use fixture in archive reading tests
- update imports to consistently reference the sample archives module
- generate corrupted/truncated archives on demand via fixture
- update tests to handle corrupted and truncated archives

## Testing
- `uv run --extra optional pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68419f8055f8832d99cb03e424ac1859