### PR TITLE
Improve extractall metadata checks

### DIFF
--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -22,6 +22,15 @@ def _set_member_metadata(member: ArchiveMember, target_path: str) -> None:
         os.chmod(target_path, member.mode)
 
 
+def apply_members_metadata(members: Iterable[ArchiveMember], root_path: str) -> None:
+    """Apply stored metadata for a list of members extracted to ``root_path``."""
+
+    for member in members:
+        target_path = os.path.join(root_path, member.filename)
+        if os.path.exists(target_path):
+            _set_member_metadata(member, target_path)
+
+
 def _write_member(
     root_path: str,
     member: ArchiveMember,

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import datetime, timezone
 from typing import IO, List, Optional, cast
 
-from archivey.base_reader import BaseArchiveReaderRandomAccess, _set_member_metadata
+from archivey.base_reader import BaseArchiveReaderRandomAccess, apply_members_metadata
 from archivey.exceptions import (
     ArchiveCorruptedError,
     ArchiveEncryptedError,
@@ -275,7 +275,4 @@ class ZipReader(BaseArchiveReaderRandomAccess):
         except zipfile.BadZipFile as e:
             raise ArchiveCorruptedError(f"Error extracting archive: {e}") from e
 
-        for member in self.get_members():
-            target_path = os.path.join(target, member.filename)
-            if os.path.exists(target_path):
-                _set_member_metadata(member, target_path)
+        apply_members_metadata(self.get_members(), target)

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -4,7 +4,7 @@ import stat
 import struct
 import zipfile
 from datetime import datetime, timezone
-from typing import IO, List, Optional, cast
+from typing import IO, List, Optional, Callable, cast
 
 from archivey.base_reader import BaseArchiveReaderRandomAccess, apply_members_metadata
 from archivey.exceptions import (
@@ -258,11 +258,18 @@ class ZipReader(BaseArchiveReaderRandomAccess):
     def extractall(
         self,
         path: str | None = None,
+        members: list[ArchiveMember | str] | None = None,
         *,
         pwd: bytes | str | None = None,
+        filter: Callable[[ArchiveMember], bool] | None = None,
+        preserve_links: bool = True,
     ) -> None:
         if self._archive is None:
             raise ValueError("Archive is closed")
+
+        if members is not None or filter is not None or not preserve_links:
+            super().extractall(path, members, pwd, filter, preserve_links)
+            return
 
         target = path or os.getcwd()
 

--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from archivey.core import open_archive
+from datetime import datetime
 from archivey.types import ArchiveFormat, MemberType
 from tests.archivey.sample_archives import SAMPLE_ARCHIVES
 
@@ -13,6 +14,23 @@ def _get_sample(name: str):
         if a.filename == name:
             return a
     raise ValueError(name)
+
+
+def _check_file_metadata(path: Path, info, sample):
+    stat = path.lstat() if info.type == MemberType.LINK else path.stat()
+    features = sample.creation_info.features
+
+    if info.permissions is not None:
+        assert (stat.st_mode & 0o777) == info.permissions
+
+    if not features.mtime:
+        return
+
+    actual = datetime.fromtimestamp(stat.st_mtime)
+    if features.rounded_mtime:
+        assert abs(actual.timestamp() - info.mtime.timestamp()) <= 1
+    else:
+        assert actual == info.mtime
 
 
 @pytest.mark.parametrize(
@@ -42,6 +60,8 @@ def test_extractall(tmp_path: Path, filename: str):
             assert path.is_file()
             with open(path, "rb") as f:
                 assert f.read() == (info.contents or b"")
+
+        _check_file_metadata(path, info, sample)
 
     extracted = {str(p.relative_to(dest)).replace(os.sep, "/") for p in dest.rglob("*")}
     expected = {f.name.rstrip("/") for f in sample.contents.files}


### PR DESCRIPTION
## Summary
- verify extracted file permissions and timestamps
- preserve metadata when using ZipReader.extractall

## Testing
- `uv run --extra optional pytest tests/archivey/test_extractall.py -vv`
- `uv run --extra optional pytest -k test_extractall -vv`

------
https://chatgpt.com/codex/tasks/task_e_684358edd3dc832dbb726c5f7a1b5028