### PR TITLE
Fix tests after refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ testpaths = ["tests"]
 addopts = "--log-level=DEBUG --cov=archivey --cov-report=term-missing"
 timeout = 5
 timeout_method = "thread"
+log_format = "%(asctime)s %(levelname)s %(threadName)s %(name)s:%(filename)s:%(lineno)d %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.hatch.envs.default]
 python = "3.13"

--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -401,11 +401,14 @@ class StreamingOnlyArchiveReaderWrapper(ArchiveReader):
 
     def iter_members_with_io(
         self,
-        filter: Callable[[ArchiveMember], bool] | None = None,
+        members: Union[
+            Collection[Union[ArchiveMember, str]], Callable[[ArchiveMember], bool], None
+        ] = None,
         *,
         pwd: bytes | str | None = None,
+        filter: Callable[[ArchiveMember], Union[ArchiveMember, None]] | None = None,
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
-        return self.reader.iter_members_with_io(filter=filter, pwd=pwd)
+        return self.reader.iter_members_with_io(members=members, filter=filter, pwd=pwd)
 
     def get_archive_info(self) -> ArchiveInfo:
         return self.reader.get_archive_info()

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -12,7 +12,6 @@ class OverwriteMode(Enum):
     ERROR = 3
 
 
-
 @dataclass
 class ArchiveyConfig:
     """Configuration for :func:`archivey.open_archive`."""
@@ -25,9 +24,11 @@ class ArchiveyConfig:
     use_python_xz: bool = False
     use_zstandard: bool = False
 
-    check_tar_integrity: bool = True
-    overwrite_mode: OverwriteMode = OverwriteMode.ERROR
+    tar_check_integrity: bool = True
 
+    sevenzip_read_link_targets_eagerly: bool = False
+
+    overwrite_mode: OverwriteMode = OverwriteMode.ERROR
 
 
 _default_config_var: contextvars.ContextVar[ArchiveyConfig] = contextvars.ContextVar(

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -74,7 +74,9 @@ def open_archive(
         elif format == ArchiveFormat.SEVENZIP:
             from archivey.sevenzip_reader import SevenZipReader
 
-            reader = SevenZipReader(archive_path, pwd=pwd)
+            reader = SevenZipReader(
+                archive_path, pwd=pwd, streaming_only=streaming_only
+            )
 
         elif format == ArchiveFormat.TAR or format in TAR_COMPRESSED_FORMATS:
             from archivey.tar_reader import TarReader

--- a/src/archivey/exceptions.py
+++ b/src/archivey/exceptions.py
@@ -61,9 +61,11 @@ class ArchiveIOError(ArchiveError):
 
 class ArchiveFileExistsError(ArchiveError):
     """Raised when a file already exists while extracting."""
+
     pass
 
 
 class ArchiveLinkTargetNotFoundError(ArchiveError):
     """Raised when a link target is not found in the archive."""
+
     pass

--- a/src/archivey/extraction_helper.py
+++ b/src/archivey/extraction_helper.py
@@ -20,8 +20,13 @@ def apply_member_metadata(member: ArchiveMember, target_path: str) -> None:
 
 
 class ExtractionHelper:
-    def __init__(self, archive_name: str, root_path: str, overwrite_mode: OverwriteMode,
-                 can_process_pending_extractions: bool = True):
+    def __init__(
+        self,
+        archive_name: str,
+        root_path: str,
+        overwrite_mode: OverwriteMode,
+        can_process_pending_extractions: bool = True,
+    ):
         self.archive_name = archive_name
         self.root_path = root_path
         self.overwrite_mode = overwrite_mode
@@ -38,9 +43,10 @@ class ExtractionHelper:
 
         self.failed_extractions: list[ArchiveMember] = []
 
-        self.pending_regular_files_to_extract_by_id: dict[int, ArchiveMember] = {}
-        self.pending_target_members_by_source_id: dict[int, list[ArchiveMember]] = collections.defaultdict(list)
-
+        self.pending_files_to_extract_by_id: dict[int, ArchiveMember] = {}
+        self.pending_target_members_by_source_id: dict[int, list[ArchiveMember]] = (
+            collections.defaultdict(list)
+        )
 
     def get_output_path(self, member: ArchiveMember) -> str:
         return os.path.normpath(os.path.join(self.root_path, member.filename))
@@ -49,11 +55,11 @@ class ExtractionHelper:
         # TODO: should we handle the case where some entry in the path to the file
         # is actually a symlink pointing outside the root path? Is that a possible
         # security issue?
-    
+
         if not os.path.lexists(path):
             # File doesn't exist, nothing to do
             return True
-    
+
         existing_file_is_dir = os.path.isdir(path)
         if member.type == MemberType.DIR and existing_file_is_dir:
             # No problem, we're overwriting a directory with a directory
@@ -62,7 +68,9 @@ class ExtractionHelper:
         if path in self.extracted_members_by_path:
             # The file was created during this extraction, so we can overwrite it regardless
             # of the overwrite mode.
-            logger.info(f"Overwriting existing {member.type.value} {path} as it was created during this extraction")
+            logger.info(
+                f"Overwriting existing {member.type.value} {path} as it was created during this extraction"
+            )
 
         elif self.overwrite_mode == OverwriteMode.SKIP:
             logger.info(f"Skipping existing {member.type.value} {path}")
@@ -76,36 +84,44 @@ class ExtractionHelper:
         if member.type == MemberType.DIR:
             # This is only reached if the member is a directory and the existing file is not
             self.failed_extractions.append(member)
-            raise ArchiveFileExistsError(f"Cannot create dir {path} as it already exists as a file")
+            raise ArchiveFileExistsError(
+                f"Cannot create dir {path} as it already exists as a file"
+            )
 
         if existing_file_is_dir:
             self.failed_extractions.append(member)
-            raise ArchiveFileExistsError(f"Cannot create {member.type.value} {path} as it already exists as a dir")
+            raise ArchiveFileExistsError(
+                f"Cannot create {member.type.value} {path} as it already exists as a dir"
+            )
 
         os.remove(path)
 
         return True
 
-
     def create_directory(self, member: ArchiveMember, path: str) -> bool:
         if not self.check_overwrites(member, path):
             return False
-        
+
         os.makedirs(path, exist_ok=True)
         self.extracted_members_by_path[path] = member
         return True
 
     def process_file_extracted(self, member: ArchiveMember, normpath: str) -> None:
         """Called for files that had a delayed extraction."""
-        assert member.type == MemberType.FILE
+        if member.is_link:
+            return self.process_link_extracted(member, normpath)
+
+        assert member.is_file
 
         targets = self.pending_target_members_by_source_id.get(member.internal_id)
         if not targets:
             # We were not expecting this file to be extracted. TODO: should we delete it?
-            logger.error(f"Unexpected file {member.filename} was extracted by an external library")
+            logger.error(
+                f"Unexpected file {member.filename} was extracted by an external library"
+            )
             return
 
-        self.pending_regular_files_to_extract_by_id.pop(member.internal_id, None)
+        self.pending_files_to_extract_by_id.pop(member.internal_id, None)
 
         for i, target in enumerate(targets):
             # TODO: handle exceptions
@@ -133,7 +149,9 @@ class ExtractionHelper:
                 except (AttributeError, NotImplementedError, OSError):
                     # os.link failed, so we need to create a copy as a regular file.
                     # The list of exceptions was taken from tarfile.py.
-                    logger.info(f"Creating hardlink for {target.filename} failed, copying the file instead")
+                    logger.info(
+                        f"Creating hardlink for {target.filename} failed, copying the file instead"
+                    )
                     shutil.copyfile(normpath, target_path)
 
             # Remove the file from the pending list.
@@ -141,15 +159,16 @@ class ExtractionHelper:
             self.extracted_path_by_source_id[target.internal_id] = target_path
             self.extracted_members_by_path[target_path] = target
 
-
-    def create_regular_file(self, member: ArchiveMember, stream: BinaryIO | None, path: str) -> bool:
+    def create_regular_file(
+        self, member: ArchiveMember, stream: BinaryIO | None, path: str
+    ) -> bool:
         if not self.check_overwrites(member, path):
             return False
 
         if stream is None:
             # This is a delayed extraction, so we need to store the member and the path
             # for later.
-            self.pending_regular_files_to_extract_by_id[member.internal_id] = member
+            self.pending_files_to_extract_by_id[member.internal_id] = member
             self.pending_target_members_by_source_id[member.internal_id].append(member)
             return True
 
@@ -164,11 +183,23 @@ class ExtractionHelper:
 
         return True
 
-    def create_link(self, member: ArchiveMember, path: str) -> bool:
+    def create_link(self, member: ArchiveMember, member_path: str) -> bool:
+        logger.error(
+            f"Creating link {member.filename} to {member.link_target} , path={member_path}"
+        )
         if member.link_target is None:
-            self.failed_extractions.append(member)
-            logger.error(f"Link target not set for {member.filename}")
-            return False
+            # The link target may not have been read yet (possible for 7z archives)
+            if self.can_process_pending_extractions:
+                logger.info(
+                    f"Link target not set for {member.filename}, storing for later extraction"
+                )
+                self.pending_files_to_extract_by_id[member.internal_id] = member
+
+                return True
+            else:
+                logger.error(f"Link target not set for {member.filename}")
+                self.failed_extractions.append(member)
+                return False
 
         if member.type == MemberType.HARDLINK:
             # Hard links can only point to files in the same archive.
@@ -176,58 +207,85 @@ class ExtractionHelper:
             target_member = member.link_target_member
             if target_member is None:
                 self.failed_extractions.append(member)
-                raise ArchiveLinkTargetNotFoundError(f"Hardlink target {member.link_target} not found for {member.filename}")
+                raise ArchiveLinkTargetNotFoundError(
+                    f"Hardlink target {member.link_target} not found for {member.filename}"
+                )
 
-            target_path = self.extracted_path_by_source_id.get(target_member.internal_id)
+            target_path = self.extracted_path_by_source_id.get(
+                target_member.internal_id
+            )
             if target_path is None:
                 # The target file was not extracted, so we need to store it for later
                 # extraction if possible.
                 if self.can_process_pending_extractions:
-                    logger.info(f"Storing hardlink {member.filename} for later extraction as its target {target_member.filename} was not extracted")
-                    self.pending_regular_files_to_extract_by_id[target_member.internal_id] = target_member
-                    self.pending_target_members_by_source_id[target_member.internal_id].append(member)
+                    logger.info(
+                        f"Storing hardlink {member.filename} for later extraction as its target {target_member.filename} was not extracted"
+                    )
+                    self.pending_files_to_extract_by_id[target_member.internal_id] = (
+                        target_member
+                    )
+                    self.pending_target_members_by_source_id[
+                        target_member.internal_id
+                    ].append(member)
                     return True
                 else:
-                    logger.error(f"Hardlink target {member.link_target} was not extracted for {member.filename}")
+                    logger.error(
+                        f"Hardlink target {member.link_target} was not extracted for {member.filename}"
+                    )
                     self.failed_extractions.append(member)
                     return False
 
         elif member.type == MemberType.SYMLINK:
             symlink_dir = os.path.dirname(os.path.join(self.root_path, member.filename))
-            target_path = os.path.normpath(os.path.join(symlink_dir, member.link_target))
+            target_path = os.path.normpath(
+                os.path.join(symlink_dir, member.link_target)
+            )
 
         else:
             raise ValueError(f"Unexpected member type: {member.type}")
 
-        if os.path.realpath(path) == os.path.realpath(target_path):
+        if os.path.realpath(member_path) == os.path.realpath(target_path):
             # .tar files can contain links to themselves, which is not a problem,
             # but we can't remove the previous file in this case as there would be
             # nowhere to point to.
             logger.info(f"Skipping {member.type.value} to self: {member.filename}")
             return True
 
-        if not self.check_overwrites(member, path):
+        if not self.check_overwrites(member, member_path):
             return False
 
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        os.makedirs(os.path.dirname(member_path), exist_ok=True)
         if member.type == MemberType.HARDLINK:
-            os.link(target_path, path)
+            os.link(target_path, member_path)
         else:
-            os.symlink(target_path, path, target_is_directory=member.link_target_type == MemberType.DIR)
-        self.extracted_members_by_path[path] = member
+            os.symlink(
+                member.link_target,
+                member_path,
+                target_is_directory=member.link_target_type == MemberType.DIR,
+            )
+        self.extracted_members_by_path[member_path] = member
         return True
 
-    
+    def process_link_extracted(self, member: ArchiveMember) -> None:
+        if member.link_target is None:
+            raise ValueError(
+                f"Link target not set for {member.filename} after external extraction"
+            )
+
+        self.create_link(member, self.get_output_path(member))
+
     def extract_member(self, member: ArchiveMember, stream: BinaryIO | None) -> bool:
         path = self.get_output_path(member)
-        logger.info(f"Extracting {member.filename} to {path}, stream: {stream is not None}")
+        logger.info(
+            f"Extracting {member.filename} to {path}, stream: {stream is not None}"
+        )
 
         if member.is_dir:
             return self.create_directory(member, path)
 
         elif member.is_file:
             return self.create_regular_file(member, stream, path)
-        
+
         elif member.is_link:
             return self.create_link(member, path)
 
@@ -236,21 +294,20 @@ class ExtractionHelper:
             logger.error(f"Unexpected member type: {member.type}")
             return False
 
-
     def process_external_extraction(self, member: ArchiveMember, rel_path: str) -> None:
         """Called for files that were extracted by an external library."""
         full_path = os.path.realpath(os.path.join(self.root_path, rel_path))
         self.process_file_extracted(member, full_path)
 
-
     def get_pending_extractions(self) -> list[ArchiveMember]:
-        logger.info(f"Getting pending extractions: {', '.join(f'{k}: {v.filename} ({v.type.value})' for k, v in self.pending_regular_files_to_extract_by_id.items())}")
-        return list(self.pending_regular_files_to_extract_by_id.values())
-    
+        logger.info(
+            f"Getting pending extractions: {', '.join(f'{k}: {v.filename} ({v.type.value})' for k, v in self.pending_files_to_extract_by_id.items())}"
+        )
+        return list(self.pending_files_to_extract_by_id.values())
+
     def get_failed_extractions(self) -> list[ArchiveMember]:
         return self.failed_extractions
-    
+
     def apply_metadata(self) -> None:
         for path, member in self.extracted_members_by_path.items():
             apply_member_metadata(member, path)
-

--- a/src/archivey/tar_reader.py
+++ b/src/archivey/tar_reader.py
@@ -197,7 +197,7 @@ class TarReader(BaseArchiveReaderRandomAccess):
 
             self.set_all_members_retrieved()
 
-            if self.config.check_tar_integrity and tarinfo is not None:
+            if self.config.tar_check_integrity and tarinfo is not None:
                 self._check_tar_integrity(tarinfo)
 
         return self._members
@@ -270,7 +270,9 @@ class TarReader(BaseArchiveReaderRandomAccess):
 
     def iter_members_with_io(
         self,
-        members: Union[List[ArchiveMember | str], Callable[[ArchiveMember], bool], None] = None,
+        members: Union[
+            List[ArchiveMember | str], Callable[[ArchiveMember], bool], None
+        ] = None,
         *,
         pwd: bytes | str | None = None,
         filter: Callable[[ArchiveMember], ArchiveMember | None] | None = None,
@@ -329,7 +331,7 @@ class TarReader(BaseArchiveReaderRandomAccess):
                 self._members = members
                 self.set_all_members_retrieved()
 
-            if self.config.check_tar_integrity and tarinfo is not None:
+            if self.config.tar_check_integrity and tarinfo is not None:
                 self._check_tar_integrity(tarinfo)
 
         except tarfile.ReadError as e:

--- a/src/archivey/unique_ids.py
+++ b/src/archivey/unique_ids.py
@@ -1,4 +1,3 @@
-
 import multiprocessing
 import threading
 
@@ -6,7 +5,7 @@ import threading
 class GlobalUniqueIdGenerator:
     def __init__(self, batch_size=1000):
         self._batch_size = batch_size
-        self._global_counter = multiprocessing.Value('i', 1)
+        self._global_counter = multiprocessing.Value("i", 1)
         self._lock = threading.Lock()
 
     def next_id(self):
@@ -15,8 +14,10 @@ class GlobalUniqueIdGenerator:
             self._global_counter.value += 1
             return value
 
+
 _global_generator = GlobalUniqueIdGenerator()
 _BATCH_SIZE = 1000
+
 
 class UniqueIdGenerator:
     def __init__(self):
@@ -37,4 +38,3 @@ class UniqueIdGenerator:
 
 
 UNIQUE_ID_GENERATOR = UniqueIdGenerator()
-

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -183,7 +183,7 @@ class ZipReader(BaseArchiveReaderRandomAccess):
                 },
                 raw_info=info,
                 link_target=self._get_link_target(info),
-            )   
+            )
             self._members.append(member)
             self.register_member(member)
 

--- a/tests/archivey/test_streaming_modes.py
+++ b/tests/archivey/test_streaming_modes.py
@@ -148,7 +148,7 @@ def test_iter_members_filter(
     with open_archive(sample_archive_path, streaming_only=streaming_only) as archive:
         seen = []
         for member, stream in archive.iter_members_with_io(
-            filter=lambda m: m.filename == target.name
+            members=lambda m: m.filename == target.name
         ):
             seen.append(member.filename)
             if member.type == MemberType.FILE:
@@ -178,7 +178,7 @@ def test_iter_members_partial_reads(
 
     with open_archive(sample_archive_path, streaming_only=streaming_only) as archive:
         for i, (member, stream) in enumerate(
-            archive.iter_members_with_io(filter=lambda m: m.type == MemberType.FILE)
+            archive.iter_members_with_io(members=lambda m: m.type == MemberType.FILE)
         ):
             if member.filename not in {f.name for f in files}:
                 continue


### PR DESCRIPTION
## Summary
- align tests with new `members` param for `iter_members_with_io`
- update sevenzip reader to register members, mark retrieval complete and implement `_extract_regular_files`
- adjust tar reader and streaming wrapper to support the `members` argument

## Testing
- `uv run --extra optional pytest -k 'not 7zcmd and not py7zr' -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c6885ff4832d83bcd9a4d1720ae4