### PR TITLE
Resolve pyright typing warnings

### DIFF
--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -294,7 +294,6 @@ class ArchiveReader(abc.ABC):
             path=path,
             members=[member_or_filename],
             pwd=pwd,
-            preserve_links=preserve_links,
         )
         return list(d.values())[0] if len(d) else None
 

--- a/src/archivey/io_helpers.py
+++ b/src/archivey/io_helpers.py
@@ -260,7 +260,7 @@ class StatsIO(io.RawIOBase, BinaryIO):
         return data
 
     def readinto(self, b: bytearray | memoryview) -> int:  # type: ignore[override]
-        n = self._inner.readinto(b)
+        n = cast(io.BufferedIOBase, self._inner).readinto(b)
         self.stats.bytes_read += n
         return n
 

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -572,7 +572,7 @@ class RarStreamReader(BaseRarReader):
 
     def _open_unrar_stream(
         self, pwd: bytes | str | None = None
-    ) -> tuple[subprocess.Popen, BinaryIO]:
+    ) -> tuple[subprocess.Popen[bytes], BinaryIO]:
         if pwd is None:
             pwd = self._pwd
 
@@ -596,7 +596,7 @@ class RarStreamReader(BaseRarReader):
             )
             if proc.stdout is None:
                 raise RuntimeError("Could not open unrar output stream")
-            stream = proc.stdout  # type: ignore
+            stream = cast(BinaryIO, proc.stdout)
             return proc, stream
 
         except (OSError, subprocess.SubprocessError) as e:

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -217,7 +217,7 @@ class ZipReader(BaseArchiveReaderRandomAccess):
             )
 
             return ExceptionTranslatingIO(
-                stream,
+                cast(BinaryIO, stream),
                 lambda e: ArchiveCorruptedError(f"Error reading member {filename}: {e}")
                 if isinstance(e, zipfile.BadZipFile)
                 else None,


### PR DESCRIPTION
## Summary
- fix `extract()` call to not pass nonexistent arg
- adjust CLI IO tracking wrapper typing
- cast in `StatsIO.readinto`
- return BinaryIO from rar reader
- make tar reader stream handling type-safe
- cast zip reader stream for typing

## Testing
- `ruff check --fix src/archivey/base_reader.py src/archivey/cli.py src/archivey/io_helpers.py src/archivey/rar_reader.py src/archivey/tar_reader.py src/archivey/zip_reader.py`
- `ruff format src/archivey/base_reader.py src/archivey/cli.py src/archivey/io_helpers.py src/archivey/rar_reader.py src/archivey/tar_reader.py src/archivey/zip_reader.py`
- `npx pyright src/archivey`

------
https://chatgpt.com/codex/tasks/task_e_684a2e9330e8832dae4e65fa1e66a9eb