### PR TITLE
Add encrypted archive tests

### DIFF
--- a/tests/archivey/test_encrypted_archives.py
+++ b/tests/archivey/test_encrypted_archives.py
@@ -1,0 +1,183 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from archivey.core import open_archive
+from archivey.exceptions import ArchiveError, ArchiveEncryptedError
+from archivey.types import MemberType, ArchiveFormat
+from archivey.config import OverwriteMode
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES, SampleArchive, filter_archives
+from tests.archivey.testing_utils import skip_if_package_missing
+
+# Select encrypted sample archives that use a single password and no header password
+ENCRYPTED_ARCHIVES = filter_archives(
+    SAMPLE_ARCHIVES,
+    prefixes=["encryption", "encryption_with_plain", "encryption_solid"],
+    extensions=["zip", "rar", "7z"],
+    custom_filter=lambda a: not a.contents.has_multiple_passwords()
+    and a.contents.header_password is None,
+)
+
+
+def _archive_password(sample: SampleArchive) -> str:
+    for f in sample.contents.files:
+        if f.password is not None:
+            return f.password
+    raise ValueError("sample archive has no password")
+
+
+def _first_encrypted_file(sample: SampleArchive):
+    for f in sample.contents.files:
+        if f.password is not None and f.type == MemberType.FILE:
+            return f
+    raise ValueError("sample archive has no encrypted files")
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_password_in_open_archive(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    pwd = _archive_password(sample_archive)
+    with open_archive(sample_archive_path, pwd=pwd) as archive:
+        encrypted = _first_encrypted_file(sample_archive)
+        with archive.open(encrypted.name) as fh:
+            assert fh.read() == encrypted.contents
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_password_in_iter_members(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    pwd = _archive_password(sample_archive)
+    with open_archive(sample_archive_path) as archive:
+        if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+            pytest.skip("py7zr does not support password parameter for iter_members_with_io")
+        contents = {}
+        for m, stream in archive.iter_members_with_io(pwd=pwd):
+            if m.is_file:
+                contents[m.filename] = stream.read()
+        for f in sample_archive.contents.files:
+            if f.type == MemberType.FILE:
+                assert contents[f.name] == f.contents
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_password_in_open(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    pwd = _archive_password(sample_archive)
+    with open_archive(sample_archive_path) as archive:
+        for f in sample_archive.contents.files:
+            if f.type == MemberType.FILE:
+                with archive.open(f.name, pwd=pwd) as fh:
+                    assert fh.read() == f.contents
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_wrong_password_open(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    wrong = "wrong_password"
+    encrypted = _first_encrypted_file(sample_archive)
+    with open_archive(sample_archive_path) as archive:
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            with archive.open(encrypted.name, pwd=wrong):
+                pass
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_wrong_password_iter_members_read(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+        pytest.skip("py7zr does not support password parameter for iter_members_with_io")
+
+    wrong = "wrong_password"
+    with open_archive(sample_archive_path) as archive:
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            for m, stream in archive.iter_members_with_io(pwd=wrong):
+                if m.is_file:
+                    stream.read()
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_wrong_password_iter_members_no_read(sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    wrong = "wrong_password"
+    with open_archive(sample_archive_path) as archive:
+        if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+            pytest.skip("py7zr does not support password parameter for iter_members_with_io")
+        for _m, _stream in archive.iter_members_with_io(pwd=wrong):
+            pass
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_extract_with_password(tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    pwd = _archive_password(sample_archive)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    encrypted = _first_encrypted_file(sample_archive)
+    with open_archive(sample_archive_path) as archive:
+        if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+            pytest.skip("py7zr extract password support incomplete")
+        archive.config.overwrite_mode = OverwriteMode.OVERWRITE
+        path = archive.extract(encrypted.name, dest, pwd=pwd)
+    extracted_path = Path(path or dest / encrypted.name)
+    with open(extracted_path, "rb") as f:
+        assert f.read() == encrypted.contents
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_extractall_with_password(tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+        pytest.skip("py7zr extractall password support incomplete")
+
+    pwd = _archive_password(sample_archive)
+    dest = tmp_path / "all"
+    dest.mkdir()
+    with open_archive(sample_archive_path) as archive:
+        archive.extractall(dest, pwd=pwd)
+
+    for f in sample_archive.contents.files:
+        if f.type == MemberType.FILE:
+            path = dest / f.name
+            assert path.exists()
+            with open(path, "rb") as fh:
+                assert fh.read() == f.contents
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_extract_wrong_password(tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    wrong = "wrong_password"
+    dest = tmp_path / "out"
+    dest.mkdir()
+    encrypted = _first_encrypted_file(sample_archive)
+    with open_archive(sample_archive_path) as archive:
+        if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+            pytest.skip("py7zr extract password support incomplete")
+        archive.config.overwrite_mode = OverwriteMode.OVERWRITE
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            archive.extract(encrypted.name, dest, pwd=wrong)
+
+
+@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+def test_extractall_wrong_password(tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
+        pytest.skip("py7zr extractall password support incomplete")
+
+    wrong = "wrong_password"
+    dest = tmp_path / "all"
+    dest.mkdir()
+    with open_archive(sample_archive_path) as archive:
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            archive.extractall(dest, pwd=wrong)


### PR DESCRIPTION
## Summary
- add tests for handling encrypted archives

## Testing
- `uv run --extra optional pytest tests/archivey/test_encrypted_archives.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2cc7952c832d9712553dae70eca8