### PR TITLE
Add stream support to open_archive

### DIFF
--- a/src/archivey/compressed_streams.py
+++ b/src/archivey/compressed_streams.py
@@ -2,7 +2,6 @@ import bz2
 import gzip
 import lzma
 import os
-from os import PathLike
 from typing import TYPE_CHECKING, BinaryIO, Optional, cast
 
 from archivey.config import ArchiveyConfig
@@ -215,28 +214,38 @@ def open_stream(
                 gzip.GzipFile(fileobj=fileobj, mode="rb"), _translate_gzip_exception
             )
         elif format == ArchiveFormat.BZIP2:
-            return ExceptionTranslatingIO(bz2.BZ2File(fileobj), _translate_bz2_exception)
+            return ExceptionTranslatingIO(
+                bz2.BZ2File(fileobj), _translate_bz2_exception
+            )
         elif format == ArchiveFormat.XZ:
-            return ExceptionTranslatingIO(lzma.LZMAFile(fileobj), _translate_lzma_exception)
+            return ExceptionTranslatingIO(
+                lzma.LZMAFile(fileobj), _translate_lzma_exception
+            )
         elif format == ArchiveFormat.LZ4:
             if lz4 is None:
                 raise PackageNotInstalledError(
                     "lz4 package is not installed, required for LZ4 archives"
                 ) from None
-            return ExceptionTranslatingIO(lz4.frame.open(fileobj), _translate_lz4_exception)
+            return ExceptionTranslatingIO(
+                lz4.frame.open(fileobj), _translate_lz4_exception
+            )
         elif format == ArchiveFormat.ZSTD:
             if config.use_zstandard:
                 if zstandard is None:
                     raise PackageNotInstalledError(
                         "zstandard package is not installed, required for Zstandard archives"
                     ) from None
-                return ExceptionTranslatingIO(zstandard.open(fileobj), _translate_zstandard_exception)
+                return ExceptionTranslatingIO(
+                    zstandard.open(fileobj), _translate_zstandard_exception
+                )
             else:
                 if pyzstd is None:
                     raise PackageNotInstalledError(
                         "pyzstd package is not installed, required for Zstandard archives"
                     ) from None
-                return ExceptionTranslatingIO(pyzstd.open(fileobj), _translate_pyzstd_exception)
+                return ExceptionTranslatingIO(
+                    pyzstd.open(fileobj), _translate_pyzstd_exception
+                )
         else:
             raise ValueError(f"Unsupported archive format: {format}")
 

--- a/src/archivey/compressed_streams.py
+++ b/src/archivey/compressed_streams.py
@@ -1,8 +1,9 @@
 import bz2
 import gzip
 import lzma
+import os
 from os import PathLike
-from typing import TYPE_CHECKING, BinaryIO, Optional
+from typing import TYPE_CHECKING, BinaryIO, Optional, cast
 
 from archivey.config import ArchiveyConfig
 from archivey.types import ArchiveFormat
@@ -205,8 +206,40 @@ def open_lz4_stream(path: str) -> BinaryIO:
 
 
 def open_stream(
-    format: ArchiveFormat, path: str | PathLike, config: ArchiveyConfig
+    format: ArchiveFormat, path: str | os.PathLike | BinaryIO, config: ArchiveyConfig
 ) -> BinaryIO:
+    if hasattr(path, "read"):
+        fileobj = cast(BinaryIO, path)
+        if format == ArchiveFormat.GZIP:
+            return ExceptionTranslatingIO(
+                gzip.GzipFile(fileobj=fileobj, mode="rb"), _translate_gzip_exception
+            )
+        elif format == ArchiveFormat.BZIP2:
+            return ExceptionTranslatingIO(bz2.BZ2File(fileobj), _translate_bz2_exception)
+        elif format == ArchiveFormat.XZ:
+            return ExceptionTranslatingIO(lzma.LZMAFile(fileobj), _translate_lzma_exception)
+        elif format == ArchiveFormat.LZ4:
+            if lz4 is None:
+                raise PackageNotInstalledError(
+                    "lz4 package is not installed, required for LZ4 archives"
+                ) from None
+            return ExceptionTranslatingIO(lz4.frame.open(fileobj), _translate_lz4_exception)
+        elif format == ArchiveFormat.ZSTD:
+            if config.use_zstandard:
+                if zstandard is None:
+                    raise PackageNotInstalledError(
+                        "zstandard package is not installed, required for Zstandard archives"
+                    ) from None
+                return ExceptionTranslatingIO(zstandard.open(fileobj), _translate_zstandard_exception)
+            else:
+                if pyzstd is None:
+                    raise PackageNotInstalledError(
+                        "pyzstd package is not installed, required for Zstandard archives"
+                    ) from None
+                return ExceptionTranslatingIO(pyzstd.open(fileobj), _translate_pyzstd_exception)
+        else:
+            raise ValueError(f"Unsupported archive format: {format}")
+
     path = str(path)
     if format == ArchiveFormat.GZIP:
         if config.use_rapidgzip:

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -18,7 +18,6 @@ from archivey.types import (
 # from archivey.iso_reader import IsoReader
 
 
-
 def _normalize_archive_path(
     archive_path: str | bytes | os.PathLike | BinaryIO,
 ) -> str | BinaryIO:

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import io
 import logging
+import os
 import shutil
 import stat
 import struct

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -243,9 +243,7 @@ class BaseRarReader(BaseArchiveReaderRandomAccess):
                     magic = f.read(8)
                 self._archive = rarfile.RarFile(archive_path, "r")
             self._version = (
-                "5"
-                if magic.startswith(b"\x52\x61\x72\x21\x1a\x07\x01\x00")
-                else "4"
+                "5" if magic.startswith(b"\x52\x61\x72\x21\x1a\x07\x01\x00") else "4"
             )
             if pwd:
                 self._archive.setpassword(pwd)

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -267,7 +267,7 @@ class SevenZipReader(BaseArchiveReaderRandomAccess):
 
     def __init__(
         self,
-        archive_path: str,
+        archive_path: str | os.PathLike | BinaryIO,
         *,
         pwd: bytes | str | None = None,
         streaming_only: bool = False,
@@ -284,7 +284,7 @@ class SevenZipReader(BaseArchiveReaderRandomAccess):
 
         try:
             self._archive = py7zr.SevenZipFile(
-                archive_path, "r", password=bytes_to_str(pwd)
+                self.archive_file or archive_path, "r", password=bytes_to_str(pwd)
             )
 
         except py7zr.Bad7zFile as e:

--- a/src/archivey/single_file_reader.py
+++ b/src/archivey/single_file_reader.py
@@ -207,7 +207,11 @@ class SingleFileReader(BaseArchiveReaderRandomAccess):
             raise ValueError(f"Unsupported archive format: {format}")
 
         self.archive_path = self.archive_path  # ensure str path if available
-        self.ext = os.path.splitext(self.archive_path)[1].lower() if isinstance(self.archive_path, str) else ""
+        self.ext = (
+            os.path.splitext(self.archive_path)[1].lower()
+            if isinstance(self.archive_path, str)
+            else ""
+        )
         self.use_stored_metadata = self.config.use_single_file_stored_metadata
 
         # Get the base name without compression extension
@@ -215,7 +219,9 @@ class SingleFileReader(BaseArchiveReaderRandomAccess):
         # maybe we should remove only extensions from known formats, and add an extra
         # extension if it doesn't have one?
         self.member_name = (
-            os.path.splitext(os.path.basename(self.archive_path))[0] if isinstance(self.archive_path, str) else "unknown"
+            os.path.splitext(os.path.basename(self.archive_path))[0]
+            if isinstance(self.archive_path, str)
+            else "unknown"
         )
 
         # Get file metadata
@@ -285,7 +291,9 @@ class SingleFileReader(BaseArchiveReaderRandomAccess):
         member, filename = self._resolve_member_to_open(member_or_filename)
 
         if self.fileobj is None:
-            return open_stream(self.format, self.archive_file or self.archive_path, self.config)
+            return open_stream(
+                self.format, self.archive_file or self.archive_path, self.config
+            )
 
         else:
             # If there's an open file already, return it, but set the class field

--- a/src/archivey/tar_reader.py
+++ b/src/archivey/tar_reader.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import stat
 import tarfile
 from datetime import datetime, timezone

--- a/src/archivey/tar_reader.py
+++ b/src/archivey/tar_reader.py
@@ -71,8 +71,8 @@ class TarReader(ArchiveReader):
 
         if hasattr(archive_path, "read"):
             self._fileobj = cast(BinaryIO, archive_path)
-            self.compression_method = (
-                TAR_FORMAT_TO_COMPRESSION_FORMAT.get(format, "store")
+            self.compression_method = TAR_FORMAT_TO_COMPRESSION_FORMAT.get(
+                format, "store"
             )
             if not streaming_only and not self._fileobj.seekable():
                 raise ArchiveError(

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -69,7 +69,7 @@ class ZipReader(BaseArchiveReaderRandomAccess):
 
     def __init__(
         self,
-        archive_path: str | bytes | os.PathLike,
+        archive_path: str | bytes | os.PathLike | BinaryIO,
         *,
         pwd: bytes | str | None = None,
     ):
@@ -78,7 +78,7 @@ class ZipReader(BaseArchiveReaderRandomAccess):
         self._format_info: ArchiveInfo | None = None
         self._pwd = pwd
         try:
-            self._archive = zipfile.ZipFile(self.archive_path, "r")
+            self._archive = zipfile.ZipFile(self.archive_file or self.archive_path, "r")
         except zipfile.BadZipFile as e:
             raise ArchiveCorruptedError(f"Invalid ZIP archive {archive_path}") from e
 

--- a/tests/archivey/test_stream_input.py
+++ b/tests/archivey/test_stream_input.py
@@ -1,0 +1,17 @@
+import io
+from archivey.core import open_archive
+from archivey.types import ArchiveFormat
+
+
+def test_open_zip_from_stream():
+    path = "tests/test_archives/basic_nonsolid__zipfile_deflate.zip"
+    with open(path, "rb") as f:
+        data = f.read()
+    stream = io.BytesIO(data)
+    with open_archive(stream) as archive:
+        assert archive.format == ArchiveFormat.ZIP
+        members = archive.get_members()
+        assert members[0].filename == "file1.txt"
+        with archive.open(members[0]) as mf:
+            assert mf.read().startswith(b"Hello")
+

--- a/tests/archivey/test_stream_input.py
+++ b/tests/archivey/test_stream_input.py
@@ -1,4 +1,5 @@
 import io
+
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat
 
@@ -14,4 +15,3 @@ def test_open_zip_from_stream():
         assert members[0].filename == "file1.txt"
         with archive.open(members[0]) as mf:
             assert mf.read().startswith(b"Hello")
-


### PR DESCRIPTION
## Summary
- allow opening archives from BinaryIO objects
- detect format by signature when passing a stream
- update archive readers to accept file objects
- add a regression test opening a zip archive from memory

## Testing
- `uv run --extra optional pytest tests/archivey/test_stream_input.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee27de030832dbdbceff7f0cb096f