### PR TITLE
Fix incorrect wrong-password streaming test

### DIFF
--- a/tests/archivey/test_encrypted_archives.py
+++ b/tests/archivey/test_encrypted_archives.py
@@ -112,7 +112,10 @@ def test_wrong_password_iter_members_read(
         for m, stream in archive.iter_members_with_io(pwd=wrong):
             assert stream is not None
             if m.is_file:
-                with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+                if m.encrypted:
+                    with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+                        stream.read()
+                else:
                     stream.read()
 
 


### PR DESCRIPTION
## Summary
- adjust `test_wrong_password_iter_members_read` so only encrypted
  members are expected to raise when read with an invalid password

## Testing
- `uv run --extra optional pytest tests/archivey/test_encrypted_archives.py::test_wrong_password_iter_members_read -vv`

------
https://chatgpt.com/codex/tasks/task_e_684ef9940078832d824d489e256003d7