### PR TITLE
Support opening archives from streams

### DIFF
--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -89,12 +89,16 @@ class ArchiveReader(abc.ABC):
     format-specific functionality.
     """
 
-    def __init__(self, archive_path: str | bytes | os.PathLike, format: ArchiveFormat):
-        self.archive_path = (
-            archive_path.decode("utf-8")
-            if isinstance(archive_path, bytes)
-            else str(archive_path)
-        )
+    def __init__(
+        self, archive_path: BinaryIO | str | bytes | os.PathLike, format: ArchiveFormat
+    ):
+        self._input = archive_path
+        if isinstance(archive_path, (str, os.PathLike)):
+            self.archive_path = str(archive_path)
+        elif isinstance(archive_path, bytes):
+            self.archive_path = archive_path.decode("utf-8")
+        else:
+            self.archive_path = "<stream>"
         self.format = format
         self.config: ArchiveyConfig = get_default_config()
 
@@ -368,7 +372,7 @@ class BaseArchiveReader(ArchiveReader):
     def __init__(
         self,
         format: ArchiveFormat,
-        archive_path: str | bytes | os.PathLike,
+        archive_path: BinaryIO | str | bytes | os.PathLike,
         random_access_supported: bool,
         members_list_supported: bool,
         pwd: bytes | str | None = None,

--- a/src/archivey/compressed_streams.py
+++ b/src/archivey/compressed_streams.py
@@ -63,7 +63,7 @@ def _translate_gzip_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_gzip_stream(path: str) -> BinaryIO:
+def open_gzip_stream(path: str | BinaryIO) -> BinaryIO:
     return ExceptionTranslatingIO(gzip.open(path, mode="rb"), _translate_gzip_exception)
 
 
@@ -88,7 +88,7 @@ def _translate_rapidgzip_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_rapidgzip_stream(path: str) -> BinaryIO:
+def open_rapidgzip_stream(path: str | BinaryIO) -> BinaryIO:
     return ExceptionTranslatingIO(
         rapidgzip.open(path, parallelization=0), _translate_rapidgzip_exception
     )
@@ -105,7 +105,7 @@ def _translate_bz2_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_bzip2_stream(path: str) -> BinaryIO:
+def open_bzip2_stream(path: str | BinaryIO) -> BinaryIO:
     return ExceptionTranslatingIO(bz2.open(path), _translate_bz2_exception)
 
 
@@ -120,7 +120,7 @@ def _translate_indexed_bzip2_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_indexed_bzip2_stream(path: str) -> BinaryIO:
+def open_indexed_bzip2_stream(path: str | BinaryIO) -> BinaryIO:
     return ExceptionTranslatingIO(
         indexed_bzip2.open(path, parallelization=0), _translate_indexed_bzip2_exception
     )
@@ -134,7 +134,7 @@ def _translate_lzma_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_lzma_stream(path: str) -> BinaryIO:
+def open_lzma_stream(path: str | BinaryIO) -> BinaryIO:
     return ExceptionTranslatingIO(lzma.open(path), _translate_lzma_exception)
 
 
@@ -148,7 +148,7 @@ def _translate_python_xz_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_python_xz_stream(path: str) -> BinaryIO:
+def open_python_xz_stream(path: str | BinaryIO) -> BinaryIO:
     if xz is None:
         raise PackageNotInstalledError(
             "python-xz package is not installed, required for XZ archives"
@@ -163,7 +163,7 @@ def _translate_zstandard_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_zstandard_stream(path: str) -> BinaryIO:
+def open_zstandard_stream(path: str | BinaryIO) -> BinaryIO:
     if zstandard is None:
         raise PackageNotInstalledError(
             "zstandard package is not installed, required for Zstandard archives"
@@ -179,7 +179,7 @@ def _translate_pyzstd_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_pyzstd_stream(path: str) -> BinaryIO:
+def open_pyzstd_stream(path: str | BinaryIO) -> BinaryIO:
     if pyzstd is None:
         raise PackageNotInstalledError(
             "pyzstd package is not installed, required for Zstandard archives"
@@ -195,7 +195,7 @@ def _translate_lz4_exception(e: Exception) -> Optional[ArchiveError]:
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
-def open_lz4_stream(path: str) -> BinaryIO:
+def open_lz4_stream(path: str | BinaryIO) -> BinaryIO:
     if lz4 is None:
         raise PackageNotInstalledError(
             "lz4 package is not installed, required for LZ4 archives"
@@ -205,7 +205,7 @@ def open_lz4_stream(path: str) -> BinaryIO:
 
 
 def open_stream(
-    format: ArchiveFormat, path: str | PathLike, config: ArchiveyConfig
+    format: ArchiveFormat, path: str | PathLike | BinaryIO, config: ArchiveyConfig
 ) -> BinaryIO:
     path = str(path)
     if format == ArchiveFormat.GZIP:

--- a/src/archivey/compressed_streams.py
+++ b/src/archivey/compressed_streams.py
@@ -236,3 +236,62 @@ def open_stream(
             return open_pyzstd_stream(path)
 
     raise ValueError(f"Unsupported archive format: {format}")  # pragma: no cover
+
+
+def open_gzip_stream_fileobj(fileobj: BinaryIO) -> BinaryIO:
+    return ExceptionTranslatingIO(
+        gzip.GzipFile(fileobj=fileobj), _translate_gzip_exception
+    )
+
+
+def open_bzip2_stream_fileobj(fileobj: BinaryIO) -> BinaryIO:
+    return ExceptionTranslatingIO(bz2.BZ2File(fileobj), _translate_bz2_exception)
+
+
+def open_lzma_stream_fileobj(fileobj: BinaryIO) -> BinaryIO:
+    return ExceptionTranslatingIO(lzma.LZMAFile(fileobj), _translate_lzma_exception)
+
+
+def open_zstandard_stream_fileobj(fileobj: BinaryIO, use_zstandard: bool) -> BinaryIO:
+    if use_zstandard:
+        if zstandard is None:
+            raise PackageNotInstalledError(
+                "zstandard package is not installed, required for Zstandard archives"
+            ) from None
+        return ExceptionTranslatingIO(
+            zstandard.ZstdDecompressor().stream_reader(fileobj),
+            _translate_zstandard_exception,
+        )
+    else:
+        if pyzstd is None:
+            raise PackageNotInstalledError(
+                "pyzstd package is not installed, required for Zstandard archives"
+            ) from None
+        return ExceptionTranslatingIO(
+            pyzstd.ZstdFile(fileobj),
+            _translate_pyzstd_exception,
+        )
+
+
+def open_lz4_stream_fileobj(fileobj: BinaryIO) -> BinaryIO:
+    if lz4 is None:
+        raise PackageNotInstalledError(
+            "lz4 package is not installed, required for LZ4 archives"
+        ) from None
+    return ExceptionTranslatingIO(lz4.frame.open(fileobj), _translate_lz4_exception)
+
+
+def open_stream_fileobj(
+    format: ArchiveFormat, fileobj: BinaryIO, config: ArchiveyConfig
+) -> BinaryIO:
+    if format == ArchiveFormat.GZIP:
+        return open_gzip_stream_fileobj(fileobj)
+    elif format == ArchiveFormat.BZIP2:
+        return open_bzip2_stream_fileobj(fileobj)
+    elif format == ArchiveFormat.XZ:
+        return open_lzma_stream_fileobj(fileobj)
+    elif format == ArchiveFormat.LZ4:
+        return open_lz4_stream_fileobj(fileobj)
+    elif format == ArchiveFormat.ZSTD:
+        return open_zstandard_stream_fileobj(fileobj, config.use_zstandard)
+    raise ValueError(f"Unsupported archive format: {format}")

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, BinaryIO
 
 from archivey.base_reader import ArchiveReader, StreamingOnlyArchiveReaderWrapper
+from archivey.compressed_streams import open_stream_fileobj
 from archivey.config import ArchiveyConfig, default_config, get_default_config
 from archivey.exceptions import ArchiveNotSupportedError
 from archivey.folder_reader import FolderReader
@@ -11,11 +12,10 @@ from archivey.formats import (
     detect_archive_format,
     detect_archive_format_by_signature,
 )
-from archivey.compressed_streams import open_stream_fileobj
 from archivey.types import (
+    COMPRESSION_FORMAT_TO_TAR_FORMAT,
     SINGLE_FILE_COMPRESSED_FORMATS,
     TAR_COMPRESSED_FORMATS,
-    COMPRESSION_FORMAT_TO_TAR_FORMAT,
     ArchiveFormat,
 )
 
@@ -32,9 +32,7 @@ def _normalize_archive_path(
     elif isinstance(archive_path, str):
         return archive_path
 
-    raise TypeError(
-        f"Invalid archive path type: {type(archive_path)} {archive_path}"
-    )
+    raise TypeError(f"Invalid archive path type: {type(archive_path)} {archive_path}")
 
 
 def open_archive(
@@ -180,6 +178,9 @@ def open_archive(
             raise NotImplementedError("ISO reader is not yet implemented")
 
         elif format == ArchiveFormat.FOLDER:
+            assert isinstance(archive_path_normalized, str), (
+                "FolderReader only supports string paths"
+            )
             reader = FolderReader(archive_path_normalized)
 
         else:

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import io
 import logging
+import os
 import shutil
 import stat
 import struct
@@ -467,7 +468,7 @@ class RarReader(BaseArchiveReader):
 
     def __init__(
         self,
-        archive_path: str,
+        archive_path: str | BinaryIO | os.PathLike,
         *,
         pwd: bytes | str | None = None,
     ):

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -365,7 +365,7 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
 class RarStreamReader:
     def __init__(
         self,
-        archive_path: str,
+        archive_path: BinaryIO | str,
         members: list[ArchiveMember],
         *,
         pwd: bytes | str | None = None,

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -310,7 +310,7 @@ class SevenZipReader(BaseArchiveReader):
 
     def __init__(
         self,
-        archive_path: str,
+        archive_path: BinaryIO | str,
         *,
         pwd: bytes | str | None = None,
         streaming_only: bool = False,

--- a/src/archivey/single_file_reader.py
+++ b/src/archivey/single_file_reader.py
@@ -216,8 +216,12 @@ class SingleFileReader(BaseArchiveReader):
         self.archive_path = archive_path
         if isinstance(archive_path, str):
             self.ext = os.path.splitext(archive_path)[1].lower()
-            name_for_member = os.path.splitext(os.path.basename(archive_path))[0] or "unknown"
-            mtime = datetime.fromtimestamp(os.path.getmtime(archive_path), tz=timezone.utc)
+            name_for_member = (
+                os.path.splitext(os.path.basename(archive_path))[0] or "unknown"
+            )
+            mtime = datetime.fromtimestamp(
+                os.path.getmtime(archive_path), tz=timezone.utc
+            )
             compress_size = os.path.getsize(archive_path)
         else:
             self.ext = f".{format.value}"

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -67,7 +67,7 @@ class ZipReader(BaseArchiveReader):
 
     def __init__(
         self,
-        archive_path: str | bytes | os.PathLike,
+        archive_path: BinaryIO | str | bytes | os.PathLike,
         *,
         pwd: bytes | str | None = None,
     ):
@@ -80,7 +80,7 @@ class ZipReader(BaseArchiveReader):
         )
         self._format_info: ArchiveInfo | None = None
         try:
-            self._archive = zipfile.ZipFile(self.archive_path, "r")
+            self._archive = zipfile.ZipFile(archive_path, "r")
         except zipfile.BadZipFile as e:
             raise ArchiveCorruptedError(f"Invalid ZIP archive {archive_path}") from e
 

--- a/src/archivey/zip_reader.py
+++ b/src/archivey/zip_reader.py
@@ -80,7 +80,8 @@ class ZipReader(BaseArchiveReader):
         )
         self._format_info: ArchiveInfo | None = None
         try:
-            self._archive = zipfile.ZipFile(archive_path, "r")
+            # The typeshed definition of ZipFile is incorrect, it should allow byte streams.
+            self._archive = zipfile.ZipFile(archive_path, "r")  # type: ignore
         except zipfile.BadZipFile as e:
             raise ArchiveCorruptedError(f"Invalid ZIP archive {archive_path}") from e
 

--- a/tests/archivey/test_open_in_memory.py
+++ b/tests/archivey/test_open_in_memory.py
@@ -1,4 +1,5 @@
 import io
+
 import pytest
 
 from archivey.core import open_archive
@@ -14,7 +15,10 @@ for a in SAMPLE_ARCHIVES:
         continue
     archives_by_format.setdefault(fmt, a)
 
-@pytest.mark.parametrize("sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename)
+
+@pytest.mark.parametrize(
+    "sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename
+)
 def test_open_from_memory(sample_archive):
     skip_if_package_missing(sample_archive.creation_info.format, None)
     path = sample_archive.get_archive_path()

--- a/tests/archivey/test_open_in_memory.py
+++ b/tests/archivey/test_open_in_memory.py
@@ -1,0 +1,30 @@
+import io
+import pytest
+
+from archivey.core import open_archive
+from archivey.types import ArchiveFormat
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES
+from tests.archivey.testing_utils import skip_if_package_missing
+
+# Select one sample archive for each format (except FOLDER and ISO)
+archives_by_format = {}
+for a in SAMPLE_ARCHIVES:
+    fmt = a.creation_info.format
+    if fmt in (ArchiveFormat.FOLDER, ArchiveFormat.ISO):
+        continue
+    archives_by_format.setdefault(fmt, a)
+
+@pytest.mark.parametrize("sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename)
+def test_open_from_memory(sample_archive):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+    path = sample_archive.get_archive_path()
+    with open(path, "rb") as f:
+        data = f.read()
+
+    with open_archive(io.BytesIO(data)) as archive:
+        has_member = False
+        for member, stream in archive.iter_members_with_io():
+            has_member = True
+            if stream is not None:
+                stream.read()
+        assert has_member


### PR DESCRIPTION
## Summary
- allow `_normalize_archive_path` and `open_archive` to accept file objects
- detect archive format of streams using magic bytes and peek into tar contents
- update readers to accept file objects
- add helpers for opening compressed streams from file objects
- ensure tar and single-file readers handle streams correctly
- test opening archives from in-memory bytes

## Testing
- `uv run --extra optional pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685333d1ed28832dab8bc51ad67436f8