### PR TITLE
Use ArchiveFormat enum for ArchiveInfo.format

### DIFF
--- a/src/archivey/folder_reader.py
+++ b/src/archivey/folder_reader.py
@@ -157,7 +157,7 @@ class FolderReader(BaseArchiveReader):
 
     def get_archive_info(self) -> ArchiveInfo:
         return ArchiveInfo(
-            format=self.format.value,
+            format=self.format,
             comment=str(self.archive_path),  # Use folder path as comment
             # is_solid, version, extra are not applicable for folders
         )

--- a/src/archivey/single_file_reader.py
+++ b/src/archivey/single_file_reader.py
@@ -282,7 +282,7 @@ class SingleFileReader(BaseArchiveReader):
     def get_archive_info(self) -> ArchiveInfo:
         """Get detailed information about the archive's format."""
         return ArchiveInfo(
-            format=self.format.value,
+            format=self.format,
             is_solid=False,
             extra=None,
         )

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -100,7 +100,7 @@ class CreateSystem(IntEnum):
 class ArchiveInfo:
     """Detailed information about an archive's format."""
 
-    format: str  # Will be ArchiveFormat from formats.py
+    format: ArchiveFormat
     version: Optional[str] = None  # e.g. "4" for RAR4, "5" for RAR5
     is_solid: bool = False
     extra: Optional[dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- change `ArchiveInfo.format` to use the `ArchiveFormat` enum
- update readers to pass enum value directly

## Testing
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e0d9df90832d949b4e78ae2612d1