### PR TITLE
Improve docs and CLI, update config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,20 @@ with open_archive("example.zip") as archive:
 
 ## Command line usage
 
-Archivey also provides a simple CLI for quick inspection or extraction of
-archives.
+Archivey installs a small command line tool simply called `archivey`.
+You can also invoke it via `python -m archivey`.
+The CLI is primarily meant for testing or exploring the library rather than
+being a full-fledged archive management utility.
 
 ```bash
-python -m archivey.cli my_archive.zip
-python -m archivey.cli --extract --dest out_dir my_archive.zip
+archivey my_archive.zip
+archivey --extract --dest out_dir my_archive.zip
 ```
 
 You can filter member names using shell patterns placed after `--`:
 
 ```bash
-python -m archivey.cli --list my_archive.zip -- "*.txt"
+archivey --list my_archive.zip -- "*.txt"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Or, if you don't want to add all dependencies to your project, add only the ones
 
 RAR support relies on the `unrar` tool, which you'll need to install separately.
 
+| Feature/Format | Python package | System requirement |
+| --- | --- | --- |
+| RAR archives | `rarfile` | `unrar` binary |
+| 7z archives | `py7zr` | |
+| ISO images | `pycdlib` | |
+| Gzip (fast) | `rapidgzip` | |
+| Bzip2 (indexed) | `indexed_bzip2` | |
+| XZ (pure Python) | `python-xz` | |
+| Zstandard | `zstandard` or `pyzstd` | |
+| LZ4 | `lz4` | |
+
 ## Usage
 
 ### Streaming access
@@ -45,6 +56,22 @@ with open_archive("example.zip") as archive:
     if member_to_read.is_file:
         stream = archive.open(member_to_read)
         data = stream.read()
+```
+
+## Command line usage
+
+Archivey also provides a simple CLI for quick inspection or extraction of
+archives.
+
+```bash
+python -m archivey.cli my_archive.zip
+python -m archivey.cli --extract --dest out_dir my_archive.zip
+```
+
+You can filter member names using shell patterns placed after `--`:
+
+```bash
+python -m archivey.cli --list my_archive.zip -- "*.txt"
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 Archivey offers a unified way to read and extract common archive formats such as ZIP, TAR, RAR, 7z and ISO. It works in streaming or random access mode and provides a small command line interface.
 
 See the [README](../README.md) for installation instructions and quick examples.
+The README also describes the [command line interface](../README.md#command-line-usage).
 
 - [User Guide](user_guide.md)
 - [Developer Guide](developer_guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,8 @@
 Archivey offers a unified way to read and extract common archive formats such as ZIP, TAR, RAR, 7z and ISO. It works in streaming or random access mode and provides a small command line interface.
 
 See the [README](../README.md) for installation instructions and quick examples.
-The README also describes the [command line interface](../README.md#command-line-usage).
+The README also describes the [command line interface](../README.md#command-line-usage),
+which is mainly intended for testing the library.
 
 - [User Guide](user_guide.md)
 - [Developer Guide](developer_guide.md)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -78,6 +78,31 @@ except ArchiveError as e:
     print(f"Error: {e}")
 ```
 
+## Configuration options
+
+`open_archive` accepts an `ArchiveyConfig` object to enable optional features.
+You can pass it directly or set it as the default using
+`archivey.config.default_config()`.
+
+```python
+from archivey import open_archive, ArchiveyConfig
+
+config = ArchiveyConfig(
+    use_rar_stream=True,
+    use_rapidgzip=True,
+    use_indexed_bzip2=True,
+    overwrite_mode=OverwriteMode.OVERWRITE,
+)
+
+with open_archive("file.rar", config=config) as archive:
+    ...
+```
+
+Fields on `ArchiveyConfig` enable support for optional dependencies such as
+`rapidgzip`, `indexed_bzip2`, `python-xz` and `zstandard`. Each flag requires the
+corresponding package to be installed. `overwrite_mode` controls how extraction
+handles existing files and may be `overwrite`, `skip` or `error`.
+
 ### Example: Reading a File from an Archive
 
 ```python

--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -684,11 +684,14 @@ class BaseArchiveReader(ArchiveReader):
                 continue
 
             try:
-                # TODO: some libraries support fast seeking for files (either all,
-                # or only non-compressed ones), so we should set seekable=True
-                # if possible.
+                # Some backends provide seekable streams for regular files.
                 stream = (
-                    LazyOpenIO(self.open_for_iteration, member, pwd=pwd, seekable=False)
+                    LazyOpenIO(
+                        self.open_for_iteration,
+                        member,
+                        pwd=pwd,
+                        seekable=self._random_access_supported,
+                    )
                     if member.is_file
                     else None
                 )

--- a/src/archivey/cli.py
+++ b/src/archivey/cli.py
@@ -164,11 +164,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.set_defaults(mode="test")
 
     parser.add_argument(
-        "--use-libarchive",
-        action="store_true",
-        help="Use libarchive for processing archives",
-    )
-    parser.add_argument(
         "--use-rar-stream",
         action="store_true",
         help="Use the RAR stream reader for RAR files",
@@ -272,7 +267,6 @@ def main(argv: list[str] | None = None) -> None:
         try:
             print(f"\nProcessing {archive_path}:")
             config = ArchiveyConfig(
-                use_libarchive=args.use_libarchive,
                 use_rar_stream=args.use_rar_stream,
                 use_single_file_stored_metadata=args.use_stored_metadata,
                 use_rapidgzip=args.use_rapidgzip,

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -16,7 +16,6 @@ class OverwriteMode(Enum):
 class ArchiveyConfig:
     """Configuration for :func:`archivey.open_archive`."""
 
-    use_libarchive: bool = False
     use_rar_stream: bool = False
     use_single_file_stored_metadata: bool = False
     use_rapidgzip: bool = False

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -137,9 +137,9 @@ def open_archive(
 
     with default_config(config):
         if format == ArchiveFormat.FOLDER:
-            assert isinstance(
-                archive_path_normalized, str
-            ), "FolderReader only supports string paths"
+            assert isinstance(archive_path_normalized, str), (
+                "FolderReader only supports string paths"
+            )
             reader = FolderReader(archive_path_normalized)
         else:
             assert reader_class is not None

--- a/src/archivey/dependency_checker.py
+++ b/src/archivey/dependency_checker.py
@@ -71,7 +71,7 @@ def get_dependency_versions() -> DependencyVersions:
                     if "unrar" in line.lower()
                 ]
                 versions.unrar_version = lines[0].split("   ")[0] if lines else None
-        except Exception:
+        except (subprocess.SubprocessError, OSError):
             versions.unrar_version = "available"
     else:
         versions.unrar_version = None

--- a/src/archivey/folder_reader.py
+++ b/src/archivey/folder_reader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import BinaryIO, Iterator, Optional
 
 from archivey.base_reader import BaseArchiveReader
-from archivey.exceptions import ArchiveError, ArchiveMemberNotFoundError
+from archivey.exceptions import ArchiveError, ArchiveIOError, ArchiveMemberNotFoundError
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember, MemberType
 
 logger = logging.getLogger(__name__)
@@ -150,10 +150,7 @@ class FolderReader(BaseArchiveReader):
         try:
             return full_path.open("rb")
         except OSError as e:
-            raise ArchiveError(
-                # TODO: better exception type
-                f"Cannot open member '{member_name}': {e}"
-            ) from e
+            raise ArchiveIOError(f"Cannot open member '{member_name}': {e}") from e
 
     def get_archive_info(self) -> ArchiveInfo:
         return ArchiveInfo(

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -596,18 +596,7 @@ class SevenZipReader(BaseArchiveReader):
         self._start_streaming_iteration()
 
         # Don't apply the filter now, as the link members may not have the extracted path.
-        # logger.info(f"iter members arg: {members}")
         member_filter_func = _build_iterator_filter(members, None)
-        # logger.info(f"members: {self.get_members()}")
-        # filtered_members = [m for m in self.get_members() if member_filter_func(m)]
-
-        # logger.info(f"filtered_members: {filtered_members}")  # TODO: remove
-
-        # logger.debug(f"extract_filename_to_member: {extract_filename_to_member}")
-
-        # member_included = _build_member_included_func(members)
-
-        # members_to_extract = [] #m for m in self.get_members() if member_included(m)]
         # extract_filename_to_member = {}
         # filenames_to_extract = []
 

--- a/tests/archivey/test_cli.py
+++ b/tests/archivey/test_cli.py
@@ -1,0 +1,49 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.archivey.sample_archives import BASIC_ARCHIVES
+from tests.archivey.testing_utils import skip_if_package_missing
+
+SAMPLE = BASIC_ARCHIVES[0]
+
+
+def _archive_path(tmpdir):
+    return SAMPLE.get_archive_path()
+
+
+def test_cli_list(capsys):
+    archive = _archive_path(None)
+    skip_if_package_missing(SAMPLE.creation_info.format, None)
+    result = subprocess.run(
+        [sys.executable, "-m", "archivey.cli", "--list", "--hide-progress", archive],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    assert SAMPLE.contents.files[0].name.split("/")[0] in result.stdout
+
+
+def test_cli_extract(tmp_path):
+    archive = _archive_path(None)
+    skip_if_package_missing(SAMPLE.creation_info.format, None)
+    dest = tmp_path / "out"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "archivey.cli",
+            "--extract",
+            "--dest",
+            str(dest),
+            "--hide-progress",
+            archive,
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0
+    expected = SAMPLE.contents.files[0].name.rstrip("/")
+    assert (dest / expected).exists()

--- a/tests/archivey/test_cli.py
+++ b/tests/archivey/test_cli.py
@@ -1,6 +1,4 @@
 import subprocess
-import sys
-from pathlib import Path
 
 from tests.archivey.sample_archives import BASIC_ARCHIVES
 from tests.archivey.testing_utils import skip_if_package_missing
@@ -16,7 +14,7 @@ def test_cli_list(capsys):
     archive = _archive_path(None)
     skip_if_package_missing(SAMPLE.creation_info.format, None)
     result = subprocess.run(
-        [sys.executable, "-m", "archivey.cli", "--list", "--hide-progress", archive],
+        ["archivey", "--list", "--hide-progress", archive],
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -31,9 +29,7 @@ def test_cli_extract(tmp_path):
     dest = tmp_path / "out"
     result = subprocess.run(
         [
-            sys.executable,
-            "-m",
-            "archivey.cli",
+            "archivey",
             "--extract",
             "--dest",
             str(dest),


### PR DESCRIPTION
## Summary
- add a section on command line usage in `README`
- list optional dependencies
- link README CLI section from docs index
- document `ArchiveyConfig` options
- remove `use_libarchive` flag from CLI and config
- clean up debug code and TODOs
- tighten tar integrity check and lazy stream hints
- use `ArchiveIOError` for folder reads
- improve single file name handling
- add basic CLI tests

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_68549d5c72b8832da96a89b4c9141e42