### PR TITLE
Handle encrypted symlink targets

### DIFF
--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -701,6 +701,10 @@ class RarReader(BaseArchiveReader):
             )
             if link_target is not None:
                 member.link_target = link_target
+            else:
+                raise ArchiveEncryptedError(
+                    f"Cannot read link target for {member.filename}"
+                )
 
         member, filename = self._resolve_member_to_open(member)
 

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -688,7 +688,21 @@ class RarReader(BaseArchiveReader):
         # Link targets in RAR4 archives may be stored as file data. If that data
         # is encrypted and no password is available we simply return the member
         # contents when opened.
-        member, filename = self._resolve_member_to_open(member_or_filename)
+        member = self.get_member(member_or_filename)
+
+        if (
+            pwd is not None
+            and member.is_link
+            and member.link_target is None
+        ):
+            link_target = self._get_link_target(
+                cast(RarInfo, member.raw_info),
+                pwd=pwd,
+            )
+            if link_target is not None:
+                member.link_target = link_target
+
+        member, filename = self._resolve_member_to_open(member)
 
         if member.is_link and member.link_target is None:
             link_target = self._get_link_target(

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -477,10 +477,27 @@ class SevenZipReader(BaseArchiveReader):
             An IO object for the member.
         """
 
+
         if self._archive is None:
             raise ValueError("Archive is closed")
 
-        member, filename = self._resolve_member_to_open(member_or_filename)
+        member = self.get_member(member_or_filename)
+
+        if (
+            pwd is not None
+            and member.is_link
+            and member.link_target is None
+        ):
+            try:
+                list(
+                    self.iter_members_with_io(
+                        members=[member], pwd=pwd, close_streams=False
+                    )
+                )
+            except Exception:
+                pass
+
+        member, filename = self._resolve_member_to_open(member)
 
         try:
             it = list(

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -494,8 +494,18 @@ class SevenZipReader(BaseArchiveReader):
                         members=[member], pwd=pwd, close_streams=False
                     )
                 )
-            except Exception:
+            except (
+                ArchiveError,
+                py7zr.exceptions.ArchiveError,
+                py7zr.PasswordRequired,
+                lzma.LZMAError,
+                OSError,
+            ):
                 pass
+            if member.link_target is None:
+                raise ArchiveEncryptedError(
+                    f"Cannot read link target for {member.filename}"
+                )
 
         member, filename = self._resolve_member_to_open(member)
 

--- a/tests/archivey/test_encrypted_archives.py
+++ b/tests/archivey/test_encrypted_archives.py
@@ -313,3 +313,47 @@ def test_open_encrypted_symlink(
             assert fh.read() == encrypted_symlink.contents
         member = archive.get_member(encrypted_symlink.name)
         assert member.link_target == encrypted_symlink.link_target
+
+
+@pytest.mark.parametrize(
+    "sample_archive",
+    filter_archives(
+        SAMPLE_ARCHIVES,
+        prefixes=["encryption_with_symlinks"],
+        extensions=["rar", "7z"],
+    ),
+    ids=lambda a: a.filename,
+)
+def test_open_encrypted_symlink_wrong_password(
+    sample_archive: SampleArchive, sample_archive_path: str
+):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    symlink_name = "encrypted_link_to_secret.txt"
+
+    with open_archive(sample_archive_path) as archive:
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            with archive.open(symlink_name, pwd="wrong") as fh:
+                fh.read()
+
+
+@pytest.mark.parametrize(
+    "sample_archive",
+    filter_archives(
+        SAMPLE_ARCHIVES,
+        prefixes=["encryption_with_symlinks"],
+        extensions=["rar", "7z"],
+    ),
+    ids=lambda a: a.filename,
+)
+def test_open_encrypted_symlink_target_wrong_password(
+    sample_archive: SampleArchive, sample_archive_path: str
+):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    symlink_name = "encrypted_link_to_very_secret.txt"
+
+    with open_archive(sample_archive_path) as archive:
+        with pytest.raises((ArchiveEncryptedError, ArchiveError)):
+            with archive.open(symlink_name, pwd="pwd") as fh:
+                fh.read()


### PR DESCRIPTION
## Summary
- support decrypting symlink targets on open() for RAR and 7z files
- add regression test opening encrypted symlink

## Testing
- `uv run --extra optional pytest tests/archivey/test_encrypted_archives.py::test_open_encrypted_symlink -vv`
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854c2f5c3f0832d86465e75b2a07b89