### PR TITLE
Remove debug logging from extractall tests

### DIFF
--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -46,11 +45,7 @@ def test_extractall(
     dest.mkdir()
 
     with open_archive(sample_archive_path) as archive:
-        print("Before extractall")
-        subprocess.run(["ls", "-lR", dest])
         archive.extractall(dest)
-        print("After extractall")
-        subprocess.run(["ls", "-lR", dest])
 
     for info in remove_duplicate_files(sample_archive.contents.files):
         path = dest / info.name.rstrip("/")


### PR DESCRIPTION
## Summary
- clean up `tests/archivey/test_extractall.py`

## Testing
- `uv run --extra optional pytest -k test_extractall`

------
https://chatgpt.com/codex/tasks/task_e_6855e0bdd7d8832d8da78aca7e3b67cc