### PR TITLE
Add streaming reader comments

### DIFF
--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -372,9 +372,11 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
             super().close()
 
 
-# Streams file data by running ``unrar p`` in a subprocess. The external
-# command outputs the contents of all archive members sequentially, allowing us
-# to provide streaming access even when the ``rarfile`` library cannot.
+# Streams archive data once by running ``unrar p`` in a subprocess.
+# ``rarfile`` only extracts one file at a time, which in a solid archive would
+# require re-decompressing all earlier members for each ``open()`` call. By
+# invoking the external ``unrar p`` command we decompress sequentially a single
+# time and yield the file streams one after another.
 class RarStreamReader:
     def __init__(
         self,

--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -372,6 +372,9 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
             super().close()
 
 
+# Streams file data by running ``unrar p`` in a subprocess. The external
+# command outputs the contents of all archive members sequentially, allowing us
+# to provide streaming access even when the ``rarfile`` library cannot.
 class RarStreamReader:
     def __init__(
         self,

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -617,6 +617,14 @@ class SevenZipReader(BaseArchiveReader):
         filter: IteratorFilterFunc | ExtractionFilter | None = None,
         close_streams: bool = True,
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
+        """Yield members and their associated streams using a background extractor.
+
+        py7zr exposes file data only through ``extract`` calls that write to a
+        ``WriterFactory``. To stream contents lazily we spawn a worker thread
+        that performs the extraction and sends each created stream through a
+        ``Queue``. This generator consumes from that queue so the caller can
+        process members while extraction continues.
+        """
         if self._archive is None:
             raise ValueError("Archive is closed")
 

--- a/src/archivey/sevenzip_reader.py
+++ b/src/archivey/sevenzip_reader.py
@@ -617,13 +617,13 @@ class SevenZipReader(BaseArchiveReader):
         filter: IteratorFilterFunc | ExtractionFilter | None = None,
         close_streams: bool = True,
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
-        """Yield members and their associated streams using a background extractor.
+        """Yield members and their streams using a worker thread and queue.
 
-        py7zr exposes file data only through ``extract`` calls that write to a
-        ``WriterFactory``. To stream contents lazily we spawn a worker thread
-        that performs the extraction and sends each created stream through a
-        ``Queue``. This generator consumes from that queue so the caller can
-        process members while extraction continues.
+        ``py7zr`` expects a ``WriterFactory`` to collect extracted files at
+        once. To provide a true iterator that lazily returns ``BinaryIO``
+        streams, we spin up a background thread that performs the extraction and
+        places each stream into a ``Queue``. This generator consumes from the
+        queue so callers can process files as they are decompressed.
         """
         if self._archive is None:
             raise ValueError("Archive is closed")


### PR DESCRIPTION
## Summary
- document the queue/thread approach in `SevenZipReader.iter_members_with_io`
- clarify that `RarStreamReader` spawns an external `unrar` process for streaming

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_685752f13f78832d9c0b516b1d99fac2