### PR TITLE
Fix warning text punctuation

### DIFF
--- a/src/archivey/base_reader.py
+++ b/src/archivey/base_reader.py
@@ -925,7 +925,7 @@ class BaseArchiveReader(ArchiveReader):
 
         # Fall back to extractall().
         logger.warning(
-            "extract() may be slow for streaming archives, use extractall instead if possible. ()"
+            "extract() may be slow for streaming archives, use extractall instead if possible."
         )
         d = self.extractall(
             path=path,


### PR DESCRIPTION
## Summary
- remove stray parentheses from streaming extract warning

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_685752e04680832da6ec0b12f4c5bc3a