### PR TITLE
Add unified open implementation

### DIFF
--- a/src/archivey/rar_reader.py
+++ b/src/archivey/rar_reader.py
@@ -299,14 +299,13 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
         )
         self._actual_crc = 0
         self._lock = lock
-        self._closed = False
         self._filename = member.filename
         self._fully_read = False
         self._member = member
         self._crc_checked = False
 
     def read(self, n: int = -1) -> bytes:
-        if self._closed:
+        if self.closed:
             raise ValueError(f"Cannot read from closed/expired file: {self._filename}")
 
         with self._lock:
@@ -355,7 +354,7 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
         raise io.UnsupportedOperation("writelines")  # pragma: no cover
 
     def close(self) -> None:
-        if self._closed:
+        if self.closed:
             return
         try:
             with self._lock:
@@ -368,7 +367,6 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
 
             self._check_crc()
         finally:
-            self._closed = True
             super().close()
 
 

--- a/src/archivey/single_file_reader.py
+++ b/src/archivey/single_file_reader.py
@@ -287,20 +287,20 @@ class SingleFileReader(BaseArchiveReader):
             extra=None,
         )
 
-    def open(
-        self, member_or_filename: ArchiveMember | str, *, pwd: bytes | None = None
+    def _open_member(
+        self,
+        member: ArchiveMember,
+        *,
+        pwd: bytes | None = None,
+        for_iteration: bool = False,
     ) -> BinaryIO:
         if pwd is not None:
             raise ValueError("Compressed files do not support password protection")
-
-        member, filename = self._resolve_member_to_open(member_or_filename)
 
         if self.fileobj is None:
             return open_stream(self.format, self.archive_path, self.config)
 
         else:
-            # If there's an open file already, return it, but set the class field
-            # to None so that further open() calls will open new streams.
             fileobj = self.fileobj
             self.fileobj = None
             return fileobj

--- a/tests/archivey/test_streaming_modes.py
+++ b/tests/archivey/test_streaming_modes.py
@@ -113,7 +113,7 @@ def test_streaming_only_mode(
     else:
         config = ArchiveyConfig()
 
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, config)
 
     first_file = _first_regular_file(sample_archive)
     with open_archive(


### PR DESCRIPTION
## Summary
- centralize open() handling in `BaseArchiveReader`
- implement `_open_member` hooks in readers
- adjust tar and rar readers to check streaming mode and link targets via new hook
- keep behaviour of iter_members

## Testing
- `ruff check --fix .`
- `ruff format .`
- `pyright`
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685977af5cc0832d9b2c0a22f40fc927