### PR TITLE
Fix binary stream typing

### DIFF
--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -1,7 +1,7 @@
 import bz2
 import gzip
 import lzma
-from typing import TYPE_CHECKING, BinaryIO, Optional
+from typing import TYPE_CHECKING, BinaryIO, Optional, cast
 
 from archivey.api.config import ArchiveyConfig
 from archivey.api.types import ArchiveFormat
@@ -63,7 +63,12 @@ def _translate_gzip_exception(e: Exception) -> Optional[ArchiveError]:
 
 
 def open_gzip_stream(path: str | BinaryIO) -> BinaryIO:
-    return ExceptionTranslatingIO(gzip.open(path, mode="rb"), _translate_gzip_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, gzip.open(path, mode="rb")), _translate_gzip_exception
+        ),
+    )
 
 
 def _translate_rapidgzip_exception(e: Exception) -> Optional[ArchiveError]:
@@ -88,8 +93,12 @@ def _translate_rapidgzip_exception(e: Exception) -> Optional[ArchiveError]:
 
 
 def open_rapidgzip_stream(path: str | BinaryIO) -> BinaryIO:
-    return ExceptionTranslatingIO(
-        rapidgzip.open(path, parallelization=0), _translate_rapidgzip_exception
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, rapidgzip.open(path, parallelization=0)),
+            _translate_rapidgzip_exception,
+        ),
     )
 
 
@@ -105,7 +114,12 @@ def _translate_bz2_exception(e: Exception) -> Optional[ArchiveError]:
 
 
 def open_bzip2_stream(path: str | BinaryIO) -> BinaryIO:
-    return ExceptionTranslatingIO(bz2.open(path), _translate_bz2_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, bz2.open(path)), _translate_bz2_exception
+        ),
+    )
 
 
 def _translate_indexed_bzip2_exception(e: Exception) -> Optional[ArchiveError]:
@@ -120,8 +134,12 @@ def _translate_indexed_bzip2_exception(e: Exception) -> Optional[ArchiveError]:
 
 
 def open_indexed_bzip2_stream(path: str | BinaryIO) -> BinaryIO:
-    return ExceptionTranslatingIO(
-        indexed_bzip2.open(path, parallelization=0), _translate_indexed_bzip2_exception
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            indexed_bzip2.open(path, parallelization=0),
+            _translate_indexed_bzip2_exception,
+        ),
     )
 
 
@@ -134,7 +152,12 @@ def _translate_lzma_exception(e: Exception) -> Optional[ArchiveError]:
 
 
 def open_lzma_stream(path: str | BinaryIO) -> BinaryIO:
-    return ExceptionTranslatingIO(lzma.open(path), _translate_lzma_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, lzma.open(path)), _translate_lzma_exception
+        ),
+    )
 
 
 def _translate_python_xz_exception(e: Exception) -> Optional[ArchiveError]:
@@ -153,7 +176,13 @@ def open_python_xz_stream(path: str | BinaryIO) -> BinaryIO:
             "python-xz package is not installed, required for XZ archives"
         ) from None  # pragma: no cover -- lz4 is installed for main tests
 
-    return ExceptionTranslatingIO(lambda: xz.open(path), _translate_python_xz_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            lambda: cast(BinaryIO, xz.open(path)),
+            _translate_python_xz_exception,
+        ),
+    )
 
 
 def _translate_zstandard_exception(e: Exception) -> Optional[ArchiveError]:
@@ -167,7 +196,13 @@ def open_zstandard_stream(path: str | BinaryIO) -> BinaryIO:
         raise PackageNotInstalledError(
             "zstandard package is not installed, required for Zstandard archives"
         ) from None  # pragma: no cover -- lz4 is installed for main tests
-    return ExceptionTranslatingIO(zstandard.open(path), _translate_zstandard_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, zstandard.open(path)),
+            _translate_zstandard_exception,
+        ),
+    )
 
 
 def _translate_pyzstd_exception(e: Exception) -> Optional[ArchiveError]:
@@ -183,7 +218,12 @@ def open_pyzstd_stream(path: str | BinaryIO) -> BinaryIO:
         raise PackageNotInstalledError(
             "pyzstd package is not installed, required for Zstandard archives"
         ) from None  # pragma: no cover -- pyzstd is installed for main tests
-    return ExceptionTranslatingIO(pyzstd.open(path), _translate_pyzstd_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, pyzstd.open(path)), _translate_pyzstd_exception
+        ),
+    )
 
 
 def _translate_lz4_exception(e: Exception) -> Optional[ArchiveError]:
@@ -200,7 +240,12 @@ def open_lz4_stream(path: str | BinaryIO) -> BinaryIO:
             "lz4 package is not installed, required for LZ4 archives"
         ) from None  # pragma: no cover -- lz4 is installed for main tests
 
-    return ExceptionTranslatingIO(lz4.frame.open(path), _translate_lz4_exception)
+    return cast(
+        BinaryIO,
+        ExceptionTranslatingIO(
+            cast(BinaryIO, lz4.frame.open(path)), _translate_lz4_exception
+        ),
+    )
 
 
 def open_stream(

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -428,11 +428,19 @@ class RarStreamReader:
             == PasswordCheckResult.INCORRECT
         ):
             # unrar silently skips encrypted files with incorrect passwords
-            return ErrorIOStream(
-                ArchiveEncryptedError(f"Wrong password specified for {member.filename}")
+            return cast(
+                BinaryIO,
+                ErrorIOStream(
+                    ArchiveEncryptedError(
+                        f"Wrong password specified for {member.filename}"
+                    )
+                ),
             )
 
-        return RarStreamMemberFile(member, self._stream, self._lock, pwd=pwd_bytes)
+        return cast(
+            BinaryIO,
+            RarStreamMemberFile(member, self._stream, self._lock, pwd=pwd_bytes),
+        )
 
     def close(self):
         self._proc.terminate()
@@ -762,7 +770,10 @@ class RarReader(BaseArchiveReader):
 
         try:
             inner: BinaryIO = self._archive.open(member.raw_info, pwd=bytes_to_str(pwd))  # type: ignore[arg-type]
-            return ExceptionTranslatingIO(inner, self._exception_translator)
+            return cast(
+                BinaryIO,
+                ExceptionTranslatingIO(inner, self._exception_translator),
+            )
         except rarfile.BadRarFile as e:
             raise ArchiveCorruptedError(
                 f"Error reading member {member.filename}"

--- a/src/archivey/formats/sevenzip_reader.py
+++ b/src/archivey/formats/sevenzip_reader.py
@@ -690,7 +690,7 @@ class SevenZipReader(BaseArchiveReader):
             logger.error(f"Error in iter_members_with_io: {e}")
             # Yield any remaining members that were not extracted, with the error.
             for member in pending_files_by_id.values():
-                yield member, ErrorIOStream(e)
+                yield member, cast(BinaryIO, ErrorIOStream(e))
             # raise e
 
         for member in pending_links_by_id.values():

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -3,7 +3,7 @@ import os
 import stat
 import tarfile
 from datetime import datetime, timezone
-from typing import IO, BinaryIO, Iterator, List, Optional, cast
+from typing import BinaryIO, Iterator, List, Optional, cast
 
 from archivey.api.exceptions import (
     ArchiveCorruptedError,
@@ -230,17 +230,20 @@ class TarReader(BaseArchiveReader):
 
         tarinfo = cast(tarfile.TarInfo, member.raw_info)
 
-        def _open_stream() -> IO[bytes]:
+        def _open_stream() -> BinaryIO:
             assert self._archive is not None
             stream = self._archive.extractfile(tarinfo)
             if stream is None:
                 raise ArchiveMemberCannotBeOpenedError(
                     f"Member {member.filename} cannot be opened"
                 )
-            return stream
+            return cast(BinaryIO, stream)
 
         try:
-            return ExceptionTranslatingIO(_open_stream, _translate_tar_exception)
+            return cast(
+                BinaryIO,
+                ExceptionTranslatingIO(_open_stream, _translate_tar_exception),
+            )
 
         except tarfile.ReadError as e:
             translated = _translate_tar_exception(e)

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -209,13 +209,16 @@ class ZipReader(BaseArchiveReader):
                 ),
             )
 
-            return ExceptionTranslatingIO(
-                cast(BinaryIO, stream),
-                lambda e: ArchiveCorruptedError(
-                    f"Error reading member {member.filename}: {e}"
-                )
-                if isinstance(e, zipfile.BadZipFile)
-                else None,
+            return cast(
+                BinaryIO,
+                ExceptionTranslatingIO(
+                    cast(BinaryIO, stream),
+                    lambda e: ArchiveCorruptedError(
+                        f"Error reading member {member.filename}: {e}"
+                    )
+                    if isinstance(e, zipfile.BadZipFile)
+                    else None,
+                ),
             )
         except RuntimeError as e:
             if "password required" in str(e):

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -601,16 +601,19 @@ class BaseArchiveReader(ArchiveReader):
             try:
                 stream = (
                     self._track_stream(
-                        LazyOpenIO(
-                            self._open_internal,
-                            member,
-                            pwd=pwd,
-                            for_iteration=True,
-                            # Some backends are optimized for seeking inside files.
-                            # Most others support seeking, but need to re-read the file from
-                            # the beginning when seeking backwards.
-                            # TODO: should we make these streams non-seekable?
-                            seekable=not self._streaming_only,  # LazyOpenIO kwarg
+                        cast(
+                            BinaryIO,
+                            LazyOpenIO(
+                                self._open_internal,
+                                member,
+                                pwd=pwd,
+                                for_iteration=True,
+                                # Some backends are optimized for seeking inside files.
+                                # Most others support seeking, but need to re-read the file from
+                                # the beginning when seeking backwards.
+                                # TODO: should we make these streams non-seekable?
+                                seekable=not self._streaming_only,  # LazyOpenIO kwarg
+                            ),
                         )
                     )
                     if member.is_file


### PR DESCRIPTION
## Summary
- adjust io helper classes to stop subclassing BinaryIO
- cast third‑party streams to BinaryIO where necessary
- tighten LazyOpenIO and ExceptionTranslatingIO annotations

## Testing
- `hatch run lint`
- `hatch run test`

------
https://chatgpt.com/codex/tasks/task_e_685c6f5a1178832daaff1be48c6e4c47