### PR TITLE
Add streamadapt library with ensure_stream

### DIFF
--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 from archivey.api.exceptions import ArchiveError
+from streamadapt import ensure_stream
 
 logger = logging.getLogger(__name__)
 
@@ -129,13 +130,8 @@ ALL_IO_METHODS = (
 
 
 def ensure_binaryio(obj: BinaryStreamLike) -> BinaryIO:
-    """Some libraries return an object that doesn't match the BinaryIO protocol,
-    so we need to ensure it does to make the type checker happy."""
-    if all(callable(getattr(obj, m, None)) for m in ALL_IO_METHODS):
-        return obj  # type: ignore
-
-    logger.info(f"Object {obj!r} does not match the BinaryIO protocol, wrapping it in BinaryIOWrapper")
-    return BinaryIOWrapper(obj)
+    """Ensure *obj* behaves like a :class:`BinaryIO`."""
+    return ensure_stream(obj, mode="binary")
 
 
 # def ensure_bufferedio(obj: Any) -> BinaryIO:

--- a/src/streamadapt/README.md
+++ b/src/streamadapt/README.md
@@ -1,0 +1,10 @@
+# streamadapt
+
+Robust, type-safe adaptation for binary and text streams in Python.
+
+## Features
+
+- `ensure_stream` – single entry point for binary and text streams
+- Detects mode using `read(0)`
+- Optionally wraps non-seekable streams in an in-memory wrapper
+- Works with sockets, pipes, `BytesIO`, `StringIO`, and files

--- a/src/streamadapt/__init__.py
+++ b/src/streamadapt/__init__.py
@@ -1,0 +1,22 @@
+"""Public API for streamadapt."""
+from .core import (
+    ensure_stream,
+    ensure_binaryio,
+    ensure_textio,
+    ensure_bufferedio,
+    ensure_buffered_textio,
+    ensure_seekable,
+    slice_stream,
+    detect_stream_mode,
+)
+
+__all__ = [
+    "ensure_stream",
+    "ensure_binaryio",
+    "ensure_textio",
+    "ensure_bufferedio",
+    "ensure_buffered_textio",
+    "ensure_seekable",
+    "slice_stream",
+    "detect_stream_mode",
+]

--- a/src/streamadapt/core.py
+++ b/src/streamadapt/core.py
@@ -1,0 +1,160 @@
+"""Core utilities for stream adaptation."""
+from __future__ import annotations
+
+import io
+from typing import (
+    BinaryIO,
+    TextIO,
+    overload,
+    Literal,
+)
+
+from .errors import StreamModeError
+from .types import BinaryStreamLike, TextStreamLike
+from .wrappers import BinaryIOWrapper, LimitedSeekableWrapper
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
+
+def detect_stream_mode(obj: BinaryStreamLike | TextStreamLike) -> Literal["binary", "text"]:
+    """Detect whether ``obj`` is binary or text by calling ``read(0)``."""
+    if not hasattr(obj, "read"):
+        raise StreamModeError("object has no read() method for mode detection")
+    try:
+        res = obj.read(0)  # type: ignore[arg-type]
+    except Exception as exc:  # pragma: no cover - rare edge cases
+        raise StreamModeError(f"unable to detect stream mode: {exc}") from exc
+    if isinstance(res, bytes):
+        return "binary"
+    if isinstance(res, str):
+        return "text"
+    raise StreamModeError("read(0) returned neither bytes nor str")
+
+
+# ---------------------------------------------------------------------------
+# Basic ensuring helpers
+# ---------------------------------------------------------------------------
+
+def ensure_binaryio(obj: BinaryStreamLike) -> BinaryIO:
+    """Ensure ``obj`` behaves like a ``BinaryIO``."""
+    needed = ("read", "write", "seek", "tell")
+    if all(callable(getattr(obj, m, None)) for m in needed):
+        return obj  # type: ignore[return-value]
+    return BinaryIOWrapper(obj)
+
+
+def ensure_textio(
+    obj: TextStreamLike | BinaryIO,
+    *,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+    newline: str | None = None,
+) -> TextIO:
+    if isinstance(obj, io.TextIOBase):
+        return obj
+    if isinstance(obj, io.BufferedIOBase) or isinstance(obj, io.RawIOBase) or isinstance(obj, BinaryIOWrapper):
+        return io.TextIOWrapper(obj, encoding=encoding, errors=errors, newline=newline)
+    # If it's TextStreamLike (e.g., custom object with write/read returning str)
+    if hasattr(obj, "read") or hasattr(obj, "write"):
+        return io.TextIOWrapper(ensure_binaryio(obj), encoding=encoding, errors=errors, newline=newline)
+    raise TypeError("object is not text stream compatible")
+
+
+def ensure_bufferedio(obj: BinaryIO) -> BinaryIO:
+    if isinstance(obj, io.BufferedIOBase):
+        return obj
+    has_read = hasattr(obj, "read")
+    has_write = hasattr(obj, "write")
+    if has_read and has_write:
+        return io.BufferedRWPair(obj, obj)
+    if has_read:
+        return io.BufferedReader(obj)
+    if has_write:
+        return io.BufferedWriter(obj)
+    raise TypeError("object cannot be buffered")
+
+
+def ensure_buffered_textio(obj: TextIO) -> TextIO:
+    if isinstance(obj, io.TextIOBase) and isinstance(obj.buffer, io.BufferedIOBase):
+        return obj
+    return io.TextIOWrapper(ensure_bufferedio(obj.buffer), encoding=obj.encoding or "utf-8")
+
+
+def ensure_seekable(obj: BinaryIO | TextIO, *, force_wrapper: bool = False):
+    if not force_wrapper and hasattr(obj, "seek") and hasattr(obj, "tell"):
+        try:
+            if obj.seekable():  # type: ignore[attr-defined]
+                return obj
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return LimitedSeekableWrapper(obj)  # type: ignore[arg-type]
+
+
+def slice_stream(stream: BinaryIO, offset: int, length: int) -> BinaryIO:
+    """Return a seekable view of a slice of *stream*."""
+    stream.seek(offset)
+    data = stream.read(length)
+    return io.BytesIO(data)
+
+
+# ---------------------------------------------------------------------------
+# Public high level helper
+# ---------------------------------------------------------------------------
+
+@overload
+def ensure_stream(
+    obj: BinaryStreamLike,
+    *,
+    mode: Literal["binary"],
+    buffered: bool = True,
+    seekable: bool = False,
+) -> BinaryIO:
+    ...
+
+
+@overload
+def ensure_stream(
+    obj: TextStreamLike | BinaryStreamLike,
+    *,
+    mode: Literal["text"],
+    encoding: str = "utf-8",
+    errors: str = "strict",
+    newline: str | None = None,
+    buffered: bool = True,
+    seekable: bool = False,
+) -> TextIO:
+    ...
+
+
+def ensure_stream(
+    obj: TextStreamLike | BinaryStreamLike,
+    *,
+    mode: Literal["binary", "text"] | None = None,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+    newline: str | None = None,
+    buffered: bool = True,
+    seekable: bool = False,
+):
+    if mode is None:
+        mode = detect_stream_mode(obj)
+
+    if mode == "binary":
+        stream = ensure_binaryio(obj)  # type: ignore[arg-type]
+        if buffered:
+            stream = ensure_bufferedio(stream)
+        if seekable:
+            stream = ensure_seekable(stream)
+        return stream
+    else:
+        text = ensure_textio(obj, encoding=encoding, errors=errors, newline=newline)  # type: ignore[arg-type]
+        if buffered:
+            # TextIOWrapper is already buffered; just ensure underlying buffer
+            if hasattr(text, "buffer") and not isinstance(text.buffer, io.BufferedIOBase):
+                text = ensure_textio(text.buffer, encoding=text.encoding or encoding)  # type: ignore[arg-type]
+        if seekable:
+            text = ensure_seekable(text)
+        return text
+

--- a/src/streamadapt/errors.py
+++ b/src/streamadapt/errors.py
@@ -1,0 +1,8 @@
+"""Exception classes used by streamadapt."""
+
+
+class StreamModeError(TypeError):
+    """Raised when stream mode cannot be determined or mismatched."""
+
+
+__all__ = ["StreamModeError"]

--- a/src/streamadapt/types.py
+++ b/src/streamadapt/types.py
@@ -1,0 +1,36 @@
+"""Protocol definitions for streamadapt."""
+from typing import Protocol, runtime_checkable, Union
+
+
+@runtime_checkable
+class ReadableBinaryStream(Protocol):
+    """Any object supporting ``read()`` that returns bytes."""
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+@runtime_checkable
+class WritableBinaryStream(Protocol):
+    """Any object supporting ``write()`` of bytes."""
+
+    def write(self, data: bytes) -> int: ...
+
+
+BinaryStreamLike = Union[ReadableBinaryStream, WritableBinaryStream]
+
+
+@runtime_checkable
+class ReadableTextStream(Protocol):
+    """Any object supporting ``read()`` that returns ``str``."""
+
+    def read(self, size: int = -1) -> str: ...
+
+
+@runtime_checkable
+class WritableTextStream(Protocol):
+    """Any object supporting ``write()`` of ``str``."""
+
+    def write(self, data: str) -> int: ...
+
+
+TextStreamLike = Union[ReadableTextStream, WritableTextStream]

--- a/src/streamadapt/wrappers.py
+++ b/src/streamadapt/wrappers.py
@@ -1,0 +1,133 @@
+"""Stream wrapper utilities used by :mod:`streamadapt`."""
+from __future__ import annotations
+
+import io
+from typing import BinaryIO, Any
+
+from .types import BinaryStreamLike
+
+
+class BinaryIOWrapper(io.IOBase, BinaryIO):
+    """Wraps a partially-implemented binary stream to satisfy ``BinaryIO``."""
+
+    def __init__(self, raw: BinaryStreamLike) -> None:
+        self._raw = raw
+
+    def read(self, size: int = -1) -> bytes:
+        if not hasattr(self._raw, "read"):
+            raise io.UnsupportedOperation("read not supported")
+        self.read = self._raw.read  # type: ignore[assignment]
+        return self._raw.read(size)  # type: ignore[arg-type]
+
+    def write(self, data: bytes) -> int:
+        if not hasattr(self._raw, "write"):
+            raise io.UnsupportedOperation("write not supported")
+        self.write = self._raw.write  # type: ignore[assignment]
+        return self._raw.write(data)  # type: ignore[arg-type]
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if not hasattr(self._raw, "seek"):
+            raise io.UnsupportedOperation("seek not supported")
+        self.seek = self._raw.seek  # type: ignore[assignment]
+        return self._raw.seek(offset, whence)  # type: ignore[arg-type]
+
+    def tell(self) -> int:
+        if not hasattr(self._raw, "tell"):
+            raise io.UnsupportedOperation("tell not supported")
+        self.tell = self._raw.tell  # type: ignore[assignment]
+        return self._raw.tell()  # type: ignore[arg-type]
+
+    def close(self) -> None:
+        if hasattr(self._raw, "close"):
+            self._raw.close()  # type: ignore[arg-type]
+
+    def flush(self) -> None:
+        if hasattr(self._raw, "flush"):
+            self._raw.flush()  # type: ignore[arg-type]
+
+    def readable(self) -> bool:
+        try:
+            return self._raw.readable()  # type: ignore[attr-defined]
+        except AttributeError:
+            return hasattr(self._raw, "read")
+
+    def writable(self) -> bool:
+        try:
+            return self._raw.writable()  # type: ignore[attr-defined]
+        except AttributeError:
+            return hasattr(self._raw, "write")
+
+    def seekable(self) -> bool:
+        try:
+            return self._raw.seekable()  # type: ignore[attr-defined]
+        except AttributeError:
+            return hasattr(self._raw, "seek")
+
+
+class LimitedSeekableWrapper(io.RawIOBase, BinaryIO):
+    """In-memory seekable wrapper for non-seekable binary streams."""
+
+    def __init__(self, inner: BinaryIO) -> None:
+        super().__init__()
+        self._inner = inner
+        self._buffer = bytearray()
+        self._pos = 0
+        self._eof = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure(self, end: int) -> None:
+        while len(self._buffer) < end and not self._eof:
+            chunk = self._inner.read(end - len(self._buffer))
+            if not chunk:
+                self._eof = True
+                break
+            self._buffer.extend(chunk)
+
+    # ------------------------------------------------------------------
+    # Basic IO methods
+    # ------------------------------------------------------------------
+    def read(self, size: int = -1) -> bytes:
+        if size == -1:
+            data = self._inner.read()
+            if data:
+                self._buffer.extend(data)
+            out = bytes(self._buffer[self._pos :])
+            self._pos = len(self._buffer)
+            return out
+
+        self._ensure(self._pos + size)
+        data = bytes(self._buffer[self._pos : self._pos + size])
+        self._pos += len(data)
+        return data
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if whence == io.SEEK_SET:
+            new_pos = offset
+        elif whence == io.SEEK_CUR:
+            new_pos = self._pos + offset
+        elif whence == io.SEEK_END:
+            self._buffer.extend(self._inner.read())
+            self._eof = True
+            new_pos = len(self._buffer) + offset
+        else:
+            raise ValueError(f"invalid whence: {whence}")
+
+        if new_pos < 0:
+            raise ValueError("negative seek position")
+        self._ensure(new_pos)
+        self._pos = new_pos
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def readable(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def writable(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def seekable(self) -> bool:  # pragma: no cover - trivial
+        return True

--- a/tests/streamadapt/test_core.py
+++ b/tests/streamadapt/test_core.py
@@ -1,0 +1,45 @@
+import io
+
+import pytest
+
+from streamadapt import ensure_stream
+
+
+class NonSeekable(io.BytesIO):
+    def seekable(self):
+        return False
+
+    def seek(self, *args, **kwargs):  # type: ignore[override]
+        raise io.UnsupportedOperation("seek not supported")
+
+    def tell(self):  # type: ignore[override]
+        raise io.UnsupportedOperation("tell not supported")
+
+
+def test_ensure_stream_binary_bytesio():
+    bio = io.BytesIO(b"abc")
+    s = ensure_stream(bio, mode="binary", seekable=True)
+    assert s.read(1) == b"a"
+    assert s.seek(0) == 0
+    assert s.read() == b"abc"
+
+
+def test_ensure_stream_text_from_binary():
+    bio = io.BytesIO(b"hello")
+    s = ensure_stream(bio, mode="text", encoding="utf-8")
+    assert s.read() == "hello"
+
+
+def test_detect_stream_mode():
+    sio = io.StringIO("xyz")
+    s = ensure_stream(sio)
+    assert isinstance(s, io.TextIOBase)
+    assert s.read() == "xyz"
+
+
+def test_seekable_wrapper():
+    ns = NonSeekable(b"123")
+    s = ensure_stream(ns, mode="binary", seekable=True)
+    assert s.read() == b"123"
+    assert s.seek(0) == 0
+    assert s.read(1) == b"1"


### PR DESCRIPTION
## Summary
- implement new `streamadapt` package
- add ensure_stream utilities and wrappers
- integrate `ensure_stream` in archivey internal helpers
- create tests for new library

## Testing
- `uv pip install -e .`
- `uv run --extra optional pytest tests/streamadapt -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc32737b8832db9dd0e979d46e1d9