### PR TITLE
Add open_compressed_stream helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ with open_archive("file.rar", config=config) as archive:
     ...
 ```
 
+### Single-file compressed streams
+
+To open a standalone compressed file (e.g., `.gz` or `.xz`) and work with the
+uncompressed data, use `open_compressed_stream`:
+
+```python
+from archivey import open_compressed_stream
+
+with open_compressed_stream("example.txt.gz") as f:
+    data = f.read()
+```
+
+Like `open_archive`, this helper accepts an optional `ArchiveyConfig` to enable
+alternative decompression libraries.
+
 See the user guide for more options.
 
 ## Command line usage

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -24,6 +24,22 @@ except ArchiveError as e:
 
 The `open_archive` function takes the path to the archive file as its primary argument. It can also accept an optional `config` object and `streaming_only` flag.
 
+## Opening a Compressed Stream
+
+Archivey can also handle single-file compressed formats such as gzip, bzip2, xz,
+zstd and lz4. Use `open_compressed_stream()` to obtain an uncompressed binary
+stream:
+
+```python
+from archivey import open_compressed_stream
+
+with open_compressed_stream("example.txt.gz") as f:
+    data = f.read()
+```
+
+`open_compressed_stream` accepts the same `ArchiveyConfig` object as
+`open_archive` for enabling alternative decompression libraries.
+
 ## The ArchiveReader Object
 
 When an archive is successfully opened, `open_archive` returns an `ArchiveReader` object. This object provides methods to interact with the archive's contents. It's recommended to use the `ArchiveReader` as a context manager (as shown above) to ensure resources are properly released.

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -4,7 +4,7 @@ from archivey.api.config import (
     get_default_config,
     set_default_config,
 )
-from archivey.api.core import open_archive
+from archivey.api.core import open_archive, open_compressed_stream
 from archivey.api.exceptions import (
     ArchiveCorruptedError,
     ArchiveEncryptedError,
@@ -30,6 +30,7 @@ from archivey.api.types import (
 
 __all__ = [
     "open_archive",
+    "open_compressed_stream",
     "ArchiveError",
     "ArchiveFormatError",
     "ArchiveCorruptedError",

--- a/tests/archivey/test_open_compressed_stream.py
+++ b/tests/archivey/test_open_compressed_stream.py
@@ -1,0 +1,51 @@
+import logging
+
+import pytest
+
+from archivey.api.core import open_compressed_stream
+from archivey.api.config import ArchiveyConfig
+from archivey.api.exceptions import ArchiveNotSupportedError
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES, filter_archives
+from tests.archivey.testing_utils import skip_if_package_missing
+
+
+# Select single-file archives for testing
+SINGLE_FILE_ARCHIVES = filter_archives(
+    SAMPLE_ARCHIVES, prefixes=["single_file", "single_file_with_metadata"]
+)
+
+BASIC_ZIP_ARCHIVE = filter_archives(
+    SAMPLE_ARCHIVES, prefixes=["basic_nonsolid"], extensions=["zip"]
+)[0]
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.parametrize("alternative_packages", [False, True], ids=["default", "altlibs"])
+def test_open_compressed_stream(sample_archive, sample_archive_path, alternative_packages):
+    if alternative_packages:
+        config = ArchiveyConfig(
+            use_rapidgzip=True,
+            use_indexed_bzip2=True,
+            use_python_xz=True,
+            use_zstandard=True,
+        )
+    else:
+        config = ArchiveyConfig()
+
+    skip_if_package_missing(sample_archive.creation_info.format, config)
+
+    with open_compressed_stream(sample_archive_path, config=config) as f:
+        data = f.read()
+
+    expected = sample_archive.contents.files[0].contents
+    assert data == expected
+
+
+def test_open_compressed_stream_wrong_format(tmp_path):
+    sample_archive = BASIC_ZIP_ARCHIVE
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+    path = sample_archive.get_archive_path()
+    with pytest.raises(ArchiveNotSupportedError):
+        open_compressed_stream(path)


### PR DESCRIPTION
## Summary
- implement `open_compressed_stream` in `core.py`
- expose the helper from the package root
- test compressed stream opening and format validation

## Testing
- `uv run --extra optional pytest tests/archivey/test_open_compressed_stream.py -q`
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f188b72cc832d9a34596ec8688238