### PR TITLE
Fix oldlibs segfault by bumping indexed_bzip2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     oldlibs: zstandard==0.17.0
     oldlibs: cryptography==37.0.0
     oldlibs: rapidgzip==0.14.3
-    oldlibs: indexed_bzip2==1.4.0
+    oldlibs: indexed_bzip2==1.6.0
     oldlibs: python-xz==0.3.0
 
     nolibs:


### PR DESCRIPTION
## Summary
- bump indexed_bzip2 min version to 1.6.0 for oldlibs tox env

## Testing
- `tox -e py3.13-oldlibs -vv`

------
https://chatgpt.com/codex/tasks/task_e_686164d25b68832db4d6a3da82436ce8