### PR TITLE
Implement seekable buffer wrapper

### DIFF
--- a/src/archivey/api/core.py
+++ b/src/archivey/api/core.py
@@ -127,8 +127,8 @@ def open_archive(
     format = detect_archive_format(archive_path_normalized)
 
     if wrapper is not None:
-        wrapper.rewind()
-        wrapper.disable_rewind()
+        wrapper.seek(0)
+        wrapper.stop_recording()
     if format == ArchiveFormat.UNKNOWN:
         raise ArchiveNotSupportedError(
             f"Unknown archive format for {archive_path_normalized}"
@@ -189,8 +189,8 @@ def open_compressed_stream(
     format = detect_archive_format(archive_path_normalized)
 
     if wrapper is not None:
-        wrapper.rewind()
-        wrapper.disable_rewind()
+        wrapper.seek(0)
+        wrapper.stop_recording()
 
     if format not in SINGLE_FILE_COMPRESSED_FORMATS:
         raise ArchiveNotSupportedError(

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -715,7 +715,9 @@ class RarReader(BaseArchiveReader):
             return PackageNotInstalledError("cryptography package is not installed")
         elif isinstance(e, rarfile.Error):
             return ArchiveError("Unknown error reading RAR archive")
-        elif isinstance(e, io.UnsupportedOperation) and "seek" in str(e):
+        elif isinstance(e, io.UnsupportedOperation) and (
+            "seek" in str(e) or "non buffered" in str(e)
+        ):
             return ArchiveStreamNotSeekableError(
                 "RAR archives do not support non-seekable streams"
             )


### PR DESCRIPTION
## Summary
- add seek-based buffering to `RewindableNonSeekableStream`
- update `open_archive` and `open_compressed_stream` to use new API

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861942496c8832dbbf0590ef0a7c8da