### PR TITLE
Refactor readers to centralize exception translation

### DIFF
--- a/src/archivey/formats/sevenzip_reader.py
+++ b/src/archivey/formats/sevenzip_reader.py
@@ -718,12 +718,13 @@ class SevenZipReader(BaseArchiveReader):
     ) -> str:
         self.check_archive_open()
         assert self._archive is not None
+        archive = self._archive
 
         member_obj = self.get_member(member)
 
         def _do_extract() -> None:
             with self._temporary_password(pwd):
-                self._archive.extract(path=path, targets=[member_obj.filename])
+                archive.extract(path=path, targets=[member_obj.filename])
 
         run_with_exception_translation(
             _do_extract,
@@ -741,6 +742,7 @@ class SevenZipReader(BaseArchiveReader):
         paths_to_extract = [member.filename for member in pending_extractions]
         # Perform a regular extraction
         assert self._archive is not None
+        archive = self._archive
 
         canonical_path = pathlib.Path(os.getcwd()).joinpath(path)
 
@@ -756,9 +758,10 @@ class SevenZipReader(BaseArchiveReader):
         factory = ExtractWriterFactory(path, pending_extractions_to_member)
 
         logger.info(f"Extracting {paths_to_extract} to {path}")
+
         def _do_extract() -> None:
             with self._temporary_password(pwd):
-                self._archive.extract(
+                archive.extract(
                     path, targets=paths_to_extract, recursive=False, factory=factory
                 )
 

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -37,11 +37,10 @@ class TarReader(BaseArchiveReader):
     def _exception_translator(self, e: Exception) -> Optional[ArchiveError]:
         if isinstance(e, tarfile.ReadError):
             if "unexpected end of data" in str(e).lower():
-                exc: ArchiveError = ArchiveEOFError("TAR archive is truncated")
+                return ArchiveEOFError("TAR archive is truncated")
             else:
-                exc = ArchiveCorruptedError(f"Error reading TAR archive: {e}")
-            exc.__cause__ = e
-            return exc
+                return ArchiveCorruptedError(f"Error reading TAR archive: {e}")
+
         return None
 
     def __init__(

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -132,9 +132,7 @@ class TarReader(BaseArchiveReader):
             self._exception_translator,
             archive_path=str(archive_path),
         )
-        logger.debug(
-            f"Tar opened: {self._archive} seekable={self._fileobj.seekable()}"
-        )
+        logger.debug(f"Tar opened: {self._archive} seekable={self._fileobj.seekable()}")
 
     def _close_archive(self) -> None:
         """Close the archive and release any resources."""

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -202,11 +202,17 @@ class ZipReader(BaseArchiveReader):
         for_iteration: bool,
     ) -> BinaryIO:
         assert self._archive is not None
+        archive = self._archive
 
         def _open_stream() -> BinaryIO:
-            return self._archive.open(
-                cast(zipfile.ZipInfo, member.raw_info),
-                pwd=str_to_bytes(pwd if pwd is not None else self.get_archive_password()),
+            return cast(
+                BinaryIO,
+                archive.open(
+                    cast(zipfile.ZipInfo, member.raw_info),
+                    pwd=str_to_bytes(
+                        pwd if pwd is not None else self.get_archive_password()
+                    ),
+                ),
             )
 
         return ExceptionTranslatingIO(

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -86,8 +86,8 @@ class ZipReader(BaseArchiveReader):
             return ArchiveCorruptedError("Error reading ZIP archive")
         if isinstance(e, RuntimeError) and "password required" in str(e).lower():
             return ArchiveEncryptedError("Password required")
-        if isinstance(e, RuntimeError):
-            return ArchiveError(f"Error reading ZIP archive: {e}")
+        if isinstance(e, RuntimeError) and "Bad password" in str(e):
+            return ArchiveEncryptedError("Wrong password specified")
         if isinstance(e, io.UnsupportedOperation) and (
             "seek" in str(e) or "non" in str(e)
         ):


### PR DESCRIPTION
## Summary
- implement `_exception_translator` helper in ZipReader, TarReader and SevenZipReader
- use `run_with_exception_translation` and `ExceptionTranslatingIO` throughout the readers
- remove scattered try/except blocks

## Testing
- `hatch run test`

------
https://chatgpt.com/codex/tasks/task_e_6862f8001d40832d85f9bfdf9e88eecc