### PR TITLE
Refine docs and tighten exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to Archivey
+
+Thanks for your interest in improving Archivey!
+
+See the [Developer Guide](docs/developer_guide.md) for details on the package layout and how to implement new readers.
+
+## Getting started
+
+1. Install Python 3.10 or newer and clone the repository.
+2. Install optional dependencies and tools:
+   ```bash
+   pip install uv hatch
+   sudo apt-get install -y unrar  # optional, for RAR tests
+   ```
+3. Run the tests with:
+   ```bash
+   uv run --extra optional pytest
+   ```
+   Use `-k` to run a subset of tests.
+
+Pull requests are welcome. Please follow the guidelines in `AGENTS.md` and keep the code simple and well typed.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 Archivey is a library for reading many common archive formats through a simple, consistent interface. It uses several builtin modules and optional external packages for handling different formats, and also adds some features that are missing from them.
 
+The full documentation is kept under [`docs/`](docs/) and published via MkDocs.
+
 ## Features
 
 - Automatic file format detection
-- Support for ZIP, TAR (including compressed tar variants), RAR and 7z files, and single-file compressed formats
+- Support for ZIP, TAR (including `.tar.gz`, `.tar.bz2`, etc.), RAR and 7z archives
+- Support for single-file compressed formats like gzip, bzip2, xz, zstd and lz4
 - Optimized streaming access reading of archive members
 - Consistent handling of symlinks, file times, permissions, and passwords
 - Consistent exception hierarchy
@@ -91,11 +94,21 @@ with open_archive("example.zip", streaming_only=True) as archive:
 You can enable optional features and libraries by passing an `ArchiveyConfig` to `open_archive` and `open_compressed_stream`.
 
 ```python
-from archivey import open_archive, ArchiveyConfig
+from archivey import (
+    open_archive,
+    ArchiveyConfig,
+    ExtractionFilter,
+    OverwriteMode,
+)
 
-config = ArchiveyConfig(use_rar_stream=True, use_rapidgzip=True)
+config = ArchiveyConfig(
+    use_rar_stream=True,
+    use_rapidgzip=True,
+    overwrite_mode=OverwriteMode.SKIP,
+    extraction_filter=ExtractionFilter.TAR,
+)
 with open_archive("file.rar", config=config) as archive:
-    ...
+    archive.extractall("out_dir")
 ```
 
 ### Command line usage
@@ -136,3 +149,4 @@ For more detailed information on using and extending `archivey`, please refer to
 *   Archive writing support
 *   Bug: ZIP filename decoding can be wrong in some cases (see [sample archive](tests/test_archives_external/encoding_infozip_jules.zip))
 *   Split the [IO wrappers](src/archivey/internal/io_helpers.py) into a separate library, as it seems to be generally useful
+*   Improve hard link handling and add tests for RAR4 and duplicate filenames

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -191,3 +191,19 @@ uv run --extra optional python -m tests.create_archives [pattern]
 Omit the optional pattern to rebuild all archives.  RAR tests require the
 `unrar` tool.  If it's missing those tests will fail and can be ignored.
 
+## Building the documentation
+
+The API reference is generated with [pdoc](https://pdoc.dev) and then
+assembled into a static site using [MkDocs](https://www.mkdocs.org).
+Run the provided script to rebuild everything:
+
+```bash
+sh docs/generate_api_docs.sh
+```
+
+It copies the project `README.md` to `docs/index.md`, runs pdoc to
+create HTML under `docs/api`, and finally builds the MkDocs site into the
+`site/` directory.  Ensure the optional development dependencies are
+installed (e.g. `pip install -e .[dev]`) so the `mkdocs-pdoc-plugin` is
+available.
+

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,6 +1,6 @@
 # archivey Developer Guide: Creating New ArchiveReaders
 
-This guide explains how to extend `archivey` by creating custom `ArchiveReader` classes for new archive formats.
+This guide explains how to extend `archivey` by creating custom [`ArchiveReader`](pdoc:archivey.api.archive_reader.ArchiveReader) classes for new archive formats.
 
 ## Overview
 
@@ -9,7 +9,7 @@ The library's modules are organized into these packages:
 * [`archivey.internal`](../src/archivey/internal/) (base classes and helpers)
 * [`archivey.formats`](../src/archivey/formats/) (format-specific readers)
 
-The library exposes an [`ArchiveReader`](../src/archivey/api/types.py) abstract base class for users with the public API. The actual format readers extend from the helper class [`BaseArchiveReader`](../src/archivey/internal/base_reader.py), which implements most of the public API by delegating to some simpler methods that the readers must implement. New readers will almost always want to inherit from `BaseArchiveReader`.
+The library exposes an [`ArchiveReader`](pdoc:archivey.api.archive_reader.ArchiveReader) abstract base class for users with the public API. The actual format readers extend from the helper class [`BaseArchiveReader`](pdoc:archivey.internal.base_reader.BaseArchiveReader), which implements most of the public API by delegating to some simpler methods that the readers must implement. New readers will almost always want to inherit from `BaseArchiveReader`.
 
 ## Registering Your Reader
 
@@ -18,7 +18,7 @@ For your reader to be called, you'll need to:
 *   add the format(s) your reader handles to [archivey.api.ArchiveFormat](../src/archivey/api/types.py);
 *   detect archives of these formats by signature and/or filename, in [format_detection.py](../src/archivey/formats/format_detection.py);
 *   create your reader class, see below;
-*   modify [`archivey.api.core.open_archive`](../src/archivey/api/core.py) to associate the archive format with your reader.
+*   modify [`open_archive`](pdoc:archivey.api.core.open_archive) to associate the archive format with your reader.
 
 
 ## Creating a new format reader
@@ -30,7 +30,7 @@ Your reader should implement a few required methods, and may also implement some
 
 ### Constructor (`__init__`):
 
-Should accept the same parameters as other `ArchiveReader`s, so it can be called from [`open_archive`](../src/archivey/api/core.py):
+Should accept the same parameters as other `ArchiveReader`s, so it can be called from [`open_archive`](pdoc:archivey.api.core.open_archive):
 
 ```python
     def __init__(

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -168,5 +168,26 @@ Tips:
 
 ## Testing
 
-TODO: fill this section
+To run the full test suite use the same command as in CI:
+
+```bash
+uv run --extra optional pytest
+```
+
+You can run a subset of tests with the `-k` option, e.g. to run only ZIP related
+tests:
+
+```bash
+uv run --extra optional pytest -k .zip
+```
+
+Sample archives used by the tests are versioned in `tests/test_archives`.  If
+you add new archives or change them, regenerate the files with:
+
+```bash
+uv run --extra optional python -m tests.create_archives [pattern]
+```
+
+Omit the optional pattern to rebuild all archives.  RAR tests require the
+`unrar` tool.  If it's missing those tests will fail and can be ignored.
 

--- a/docs/generate_api_docs.sh
+++ b/docs/generate_api_docs.sh
@@ -4,6 +4,9 @@
 # Ensure the output directory exists
 mkdir -p docs/api
 
+# Copy the README so MkDocs can use it as the landing page
+cp README.md docs/index.md
+
 # Run pdoc using the current Python interpreter
 # Modern versions of pdoc no longer use the --html flag, we simply
 # specify the output directory with ``-o``.
@@ -17,3 +20,8 @@ sed -i '/_archive_id/d' docs/api/archivey.html
 sed -i '/_edited_by_filter/d' docs/api/archivey.html
 
 echo "API documentation generated in docs/api"
+
+# Build the static site with MkDocs if available
+if command -v mkdocs >/dev/null 2>&1; then
+    mkdocs build -d site
+fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,1 @@
-# Archivey Documentation
-
-Archivey offers a unified way to read and extract common archive formats such as ZIP, TAR, RAR, 7z and ISO. It works in streaming or random access mode and provides a small command line interface.
-
-See the [README](../README.md) for installation instructions and quick examples.
-The README also describes the [command line interface](../README.md#command-line-usage),
-which is mainly intended for testing the library.
-
-- [User Guide](user_guide.md)
-- [Developer Guide](developer_guide.md)
-- [API Reference](api/archivey.html)
+<!-- This file is generated from ../README.md by docs/generate_api_docs.sh -->

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -22,12 +22,12 @@ except ArchiveError as e:
 
 ```
 
-`open_archive` takes the path to an archive file as its main argument (or an IO stream) and returns an `ArchiveReader` when the format is recognized. You can also pass an optional `config` object or set `streaming_only=True` to force sequential access.
+`[open_archive](pdoc:archivey.api.core.open_archive)` takes the path to an archive file (or an IO stream) and returns an [`ArchiveReader`](pdoc:archivey.api.archive_reader.ArchiveReader) when the format is recognized. You can also pass an optional `config` object or set `streaming_only=True` to force sequential access.
 
 ## Opening a Compressed Stream
 
 Archivey can also handle single-file compressed formats such as gzip, bzip2, xz,
-zstd and lz4. Use `open_compressed_stream()` to obtain an uncompressed binary
+zstd and lz4. Use `[open_compressed_stream](pdoc:archivey.api.core.open_compressed_stream)` to obtain an uncompressed binary
 stream:
 
 ```python
@@ -201,4 +201,4 @@ except ArchiveError as e:
     print(f"Error: {e}")
 ```
 
-This guide provides a basic overview. For more detailed information on specific classes and methods, please refer to the [API documentation](./api/archivey.html).
+This guide provides a basic overview. For more detailed information on specific classes and methods, please refer to the [API documentation](pdoc:archivey).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,3 +4,7 @@ nav:
   - User Guide: user_guide.md
   - Developer Guide: developer_guide.md
   - API Reference: api/archivey.html
+plugins:
+  - search
+  - pdoc:
+      api_path: api

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: Archivey
+nav:
+  - Home: index.md
+  - User Guide: user_guide.md
+  - Developer Guide: developer_guide.md
+  - API Reference: api/archivey.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dev = [
     "pytest-parallel>=0.1.1",
     # Required to make pytest-parallel work with current pytest version, see
     # https://github.com/kevlened/pytest-parallel/issues/118
-    "py>=1.11.0",  
+    "py>=1.11.0",
+    "mkdocs>=1.5.3",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     # https://github.com/kevlened/pytest-parallel/issues/118
     "py>=1.11.0",
     "mkdocs>=1.5.3",
+    "mkdocs-pdoc-plugin @ git+https://github.com/spirali/mkdocs-pdoc-plugin",
 ]
 
 [tool.pytest.ini_options]

--- a/src/archivey/formats/sevenzip_reader.py
+++ b/src/archivey/formats/sevenzip_reader.py
@@ -573,11 +573,15 @@ class SevenZipReader(BaseArchiveReader):
                 with self._temporary_password(pwd):
                     self._archive.extract(targets=extract_targets, factory=factory)
                     factory.finish()
-            except Exception as e:
-                # Here we do want to catch all exceptions, not just ArchiveError
-                # subclasses, as any exception raised in this thread would be silently
-                # ignored. We send them through the queue so that the main thread
-                # doesn't wait forever, and can treat and/or re-raise them.
+            except (
+                ArchiveError,
+                py7zr.exceptions.ArchiveError,
+                py7zr.PasswordRequired,
+                lzma.LZMAError,
+                OSError,
+                EOFError,
+                struct.error,
+            ) as e:
                 q.put(e)
 
         thread = Thread(target=extractor)
@@ -605,7 +609,15 @@ class SevenZipReader(BaseArchiveReader):
                 yield member_info, stream
 
             # TODO: the extractor may skip non-files or files with errors. Yield all remaining members. (but yield dirs before files?)
-        except Exception as e:
+        except (
+            ArchiveError,
+            py7zr.exceptions.ArchiveError,
+            py7zr.PasswordRequired,
+            lzma.LZMAError,
+            OSError,
+            EOFError,
+            struct.error,
+        ) as e:
             translated = self._exception_translator(e)
             if translated is not None:
                 raise translated from e

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -302,7 +302,7 @@ class TarReader(BaseArchiveReader):
 
             if self.config.tar_check_integrity and tarinfo is not None:
                 self._check_tar_integrity(tarinfo)
-        except Exception as e:
+        except (tarfile.TarError, OSError) as e:
             translated = self._exception_translator(e)
             if translated is not None:
                 raise translated from e


### PR DESCRIPTION
## Summary
- add MkDocs config and copy README when generating docs
- replace broad `Exception` catches with library-specific ones
- document how to run tests in the developer guide
- link developer docs via CONTRIBUTING file
- show configuration options for filters and overwrite mode
- ignore `uv.lock`

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6864f5307b38832d9bdeaa5b5ae2eac7