### PR TITLE
Refactor log calls to defer formatting

### DIFF
--- a/src/archivey/api/filters.py
+++ b/src/archivey/api/filters.py
@@ -116,7 +116,7 @@ def _get_filtered_member(
     except FilterError as e:
         if raise_on_error:
             raise
-        logger.warning(f"Filter error for {member.filename}: {e}")
+        logger.warning("Filter error for %s: %s", member.filename, e)
         return None
 
 

--- a/src/archivey/formats/folder_reader.py
+++ b/src/archivey/formats/folder_reader.py
@@ -112,7 +112,7 @@ class FolderReader(BaseArchiveReader):
             except OSError:
                 link_target = "Error reading link target"
 
-        logger.info(f"filename: {filename} member_type: {member_type}")
+        logger.info("filename: %s member_type: %s", filename, member_type)
         return ArchiveMember(
             filename=filename,
             file_size=stat_result.st_size,

--- a/src/archivey/formats/format_detection.py
+++ b/src/archivey/formats/format_detection.py
@@ -98,7 +98,7 @@ def detect_archive_format_by_signature(
         close_after = False
     else:
         # Not a path and not a stream
-        logger.warning(f"{path_or_file}: Not a path or stream")
+        logger.warning("%s: Not a path or stream", path_or_file)
         return ArchiveFormat.UNKNOWN
 
     try:
@@ -147,7 +147,7 @@ def detect_archive_format_by_signature(
         elif hasattr(f, "seek"):
             f.seek(0)
         else:
-            logger.warning(f"{path_or_file}: Not a path or stream")
+            logger.warning("%s: Not a path or stream", path_or_file)
 
 
 EXTENSION_TO_FORMAT = {
@@ -226,16 +226,20 @@ def detect_archive_format(filename: str | IO[bytes] | os.PathLike) -> ArchiveFor
         format_by_filename == ArchiveFormat.UNKNOWN
         and format_by_signature == ArchiveFormat.UNKNOWN
     ):
-        logger.warning(f"{filename}: Can't detect format by signature or filename")
+        logger.warning("%s: Can't detect format by signature or filename", filename)
         return ArchiveFormat.UNKNOWN
 
     if format_by_signature == ArchiveFormat.UNKNOWN:
         logger.warning(
-            f"{filename}: Couldn't detect format by signature. Assuming {format_by_filename}"
+            "%s: Couldn't detect format by signature. Assuming %s",
+            filename,
+            format_by_filename,
         )
         return format_by_filename
     elif format_by_filename == ArchiveFormat.UNKNOWN:
-        logger.warning(f"{filename}: Unknown extension. Detected {format_by_signature}")
+        logger.warning(
+            "%s: Unknown extension. Detected %s", filename, format_by_signature
+        )
     elif format_by_signature != format_by_filename:
         logger.warning(
             f"{filename}: Extension indicates {format_by_filename}, but detected ({format_by_signature})"

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -280,7 +280,7 @@ def check_rarinfo_crc(
         return computed_crc == rarinfo.CRC
 
     if password is None:
-        logger.warning(f"No password specified for checking {rarinfo.filename}")
+        logger.warning("No password specified for checking %s", rarinfo.filename)
         return False
 
     converted = convert_crc_to_encrypted(
@@ -413,7 +413,9 @@ class RarStreamReader:
             password_args = ["-p" + bytes_to_str(self._pwd)] if self._pwd else ["-p-"]
             cmd = [unrar_path, "p", "-inul", *password_args, self.archive_path]
             logger.debug(
-                f"Opening RAR archive {self.archive_path} with command: {' '.join(cmd)}"
+                "Opening RAR archive %s with command: %s",
+                self.archive_path,
+                " ".join(cmd),
             )
             self._proc = subprocess.Popen(
                 cmd,

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -65,7 +65,9 @@ def read_gzip_metadata(
                 mtime_timestamp, tz=timezone.utc
             )
             logger.info(
-                f"GZIP metadata: mtime_timestamp={mtime_timestamp}, mtime={extra_fields['mtime']}"
+                "GZIP metadata: mtime_timestamp=%s, mtime=%s",
+                mtime_timestamp,
+                extra_fields["mtime"],
             )
             if use_stored_metadata:
                 member.mtime_with_tz = extra_fields["mtime"]
@@ -136,20 +138,22 @@ XZ_STREAM_HEADER_MAGIC = b"\xfd7zXZ\x00"
 
 
 def read_xz_metadata(path: str, member: ArchiveMember):
-    logger.info(f"Reading XZ metadata for {path}")
+    logger.info("Reading XZ metadata for %s", path)
     with open(path, "rb") as f:
         f.seek(-12, 2)  # Footer is always 12 bytes
         footer = f.read(12)
 
         if footer[-2:] != XZ_MAGIC_FOOTER:
-            logger.warning(f"Invalid XZ footer, file possibly truncated: {path}")
+            logger.warning("Invalid XZ footer, file possibly truncated: %s", path)
             return
 
         # Backward Size (first 4 bytes) tells how far back the Index is, in 4-byte units minus 1
         backward_size_field = struct.unpack("<I", footer[4:8])[0]
         index_size = (backward_size_field + 1) * 4
         logger.info(
-            f"XZ metadata: index_size={index_size}, backward_size_field={backward_size_field}"
+            "XZ metadata: index_size=%s, backward_size_field=%s",
+            index_size,
+            backward_size_field,
         )
 
         f.seek(-12 - index_size, 2)
@@ -157,7 +161,7 @@ def read_xz_metadata(path: str, member: ArchiveMember):
 
         # Skip index indicator byte and reserved bits (first byte)
         if index_data[0] != 0x00:
-            logger.warning(f"Invalid XZ footer, file possibly corrupted: {path}")
+            logger.warning("Invalid XZ footer, file possibly corrupted: %s", path)
             return
 
         # Next 2–10 bytes are variable-length field counts and sizes

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -76,7 +76,12 @@ class TarReader(BaseArchiveReader):
         self._fileobj: BinaryIO | None = None
         self._close_fileobj: bool
 
-        logger.debug(f"TarReader init: {archive_path} {format} {streaming_only}")
+        logger.debug(
+            "TarReader init: %s %s %s",
+            archive_path,
+            format,
+            streaming_only,
+        )
 
         if format in TAR_FORMAT_TO_COMPRESSION_FORMAT:
             self.compression_method = TAR_FORMAT_TO_COMPRESSION_FORMAT[format]
@@ -85,7 +90,9 @@ class TarReader(BaseArchiveReader):
             )
             self._close_fileobj = True
             logger.debug(
-                f"Compressed tar opened: {self._fileobj} seekable={self._fileobj.seekable()}"
+                "Compressed tar opened: %s seekable=%s",
+                self._fileobj,
+                self._fileobj.seekable(),
             )
 
             # if streaming_only and not self._fileobj.seekable():
@@ -131,7 +138,11 @@ class TarReader(BaseArchiveReader):
             self._exception_translator,
             archive_path=str(archive_path),
         )
-        logger.debug(f"Tar opened: {self._archive} seekable={self._fileobj.seekable()}")
+        logger.debug(
+            "Tar opened: %s seekable=%s",
+            self._archive,
+            self._fileobj.seekable(),
+        )
 
     def _close_archive(self) -> None:
         """Close the archive and release any resources."""

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -67,14 +67,17 @@ def get_zipinfo_timestamp(zip_info: zipfile.ZipInfo) -> datetime:
                 if mod_time > 0:
                     extra_modtime = datetime.fromtimestamp(mod_time, tz=timezone.utc)
                     logger.debug(
-                        f"Modtime: main={main_modtime}, extra={extra_modtime} timestamp={mod_time}"
+                        "Modtime: main=%s, extra=%s timestamp=%s",
+                        main_modtime,
+                        extra_modtime,
+                        mod_time,
                     )
                     return extra_modtime
 
         # Skip this field: 4 bytes header + data_size
         pos += 4 + ln
 
-    logger.info(f"Modtime: main={main_modtime}")
+    logger.info("Modtime: main=%s", main_modtime)
     return main_modtime
 
 

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -270,7 +270,11 @@ class BaseArchiveReader(ArchiveReader):
         member._member_id = len(self._members)
         self._members.append(member)
 
-        logger.debug(f"Registering member {member.filename} ({member.member_id})")
+        logger.debug(
+            "Registering member %s (%s)",
+            member.filename,
+            member.member_id,
+        )
 
         members_with_filename = self._filename_to_members[member.filename]
         if member not in members_with_filename:
@@ -595,10 +599,10 @@ class BaseArchiveReader(ArchiveReader):
         )
 
         for member in self.iter_members():
-            logger.debug(f"iter_members_with_io member: {member}")
+            logger.debug("iter_members_with_io member: %s", member)
             filtered_member = filter_func(member)
             if filtered_member is None:
-                logger.debug(f"skipping {member.filename}")
+                logger.debug("skipping %s", member.filename)
                 continue
 
             try:
@@ -687,7 +691,7 @@ class BaseArchiveReader(ArchiveReader):
         extraction_helper: ExtractionHelper,
     ):
         for member, stream in self.iter_members_with_io(filter=filter_func, pwd=pwd):
-            logger.debug(f"Writing member {member.filename}")
+            logger.debug("Writing member %s", member.filename)
             extraction_helper.extract_member(member, stream)
             if stream:
                 stream.close()
@@ -751,7 +755,10 @@ class BaseArchiveReader(ArchiveReader):
 
         if member.is_link:
             logger.debug(
-                f"Resolving link target for {member.filename} {member.type} {member.member_id}"
+                "Resolving link target for %s %s %s",
+                member.filename,
+                member.type,
+                member.member_id,
             )
 
             # If the user is opening a link, open the target member instead.
@@ -762,11 +769,18 @@ class BaseArchiveReader(ArchiveReader):
                 )
             final_member = resolved_target
             logger.debug(
-                f"Resolved link {member.filename} to {final_member.filename} (ID: {final_member.member_id})"
+                "Resolved link %s to %s (ID: %s)",
+                member.filename,
+                final_member.filename,
+                final_member.member_id,
             )
 
         logger.debug(
-            f"Final member: orig {filename} {member.member_id} {final_member.filename} {final_member.type}"
+            "Final member: orig %s %s %s %s",
+            filename,
+            member.member_id,
+            final_member.filename,
+            final_member.type,
         )
         if not final_member.is_file:
             if final_member is not member:

--- a/src/archivey/internal/cli.py
+++ b/src/archivey/internal/cli.py
@@ -324,13 +324,16 @@ def main(argv: list[str] | None = None) -> None:
                         )
         except ArchiveError as e:
             print(f"Error processing {archive_path}: {e}")
-            logger.error(f"Error processing {archive_path}", exc_info=True)
+            logger.error("Error processing %s", archive_path, exc_info=True)
         if args.track_io:
             abs_path = os.path.abspath(archive_path)
             stats = stats_per_file.get(abs_path)
             if stats is not None:
                 logger.info(
-                    f"IO stats for {archive_path}: {stats.bytes_read} bytes read, {stats.seek_calls} seeks"
+                    "IO stats for %s: %s bytes read, %s seeks",
+                    archive_path,
+                    stats.bytes_read,
+                    stats.seek_calls,
                 )
 
     if args.track_io:

--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -33,7 +33,7 @@ def is_seekable(stream: io.IOBase | IO[bytes]) -> bool:
         # In the tarfile case specifically, _Stream actually does have a seek() method,
         # but calling seek() on the stream returned by tarfile will raise an exception,
         # as it's wrapped in a BufferedReader which calls seekable() when doing a seek().
-        logger.debug(f"Stream {stream} does not have a seekable method: {e}")
+        logger.debug("Stream %s does not have a seekable method: %s", stream, e)
         return False
 
 
@@ -222,7 +222,11 @@ def run_with_exception_translation(
         if translated is not None:
             translated.archive_path = archive_path
             translated.member_name = member_name
-            logger.debug(f"Translated exception: {repr(e)} -> {repr(translated)}")
+            logger.debug(
+                "Translated exception: %r -> %r",
+                e,
+                translated,
+            )
             raise translated from e
         raise e
 
@@ -278,12 +282,16 @@ class ExceptionTranslatingIO(io.RawIOBase, BinaryIO):
         if translated is not None:
             translated.archive_path = self.archive_path
             translated.member_name = self.member_name
-            logger.debug(f"Translated exception: {repr(e)} -> {repr(translated)}")
+            logger.debug(
+                "Translated exception: %r -> %r",
+                e,
+                translated,
+            )
 
             raise translated from e
 
         if not isinstance(e, ArchiveError):
-            logger.error(f"Unknown exception when reading IO: {e}", exc_info=e)
+            logger.error("Unknown exception when reading IO: %s", e, exc_info=e)
         raise e
 
     def read(self, n: int = -1) -> bytes:


### PR DESCRIPTION
## Summary
- update logging calls to use parameter placeholders
- keep string interpolation out of disabled log paths

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_68667847d488832d81bd2f97154a6ccc