### PR TITLE
Fix folder reader path checks

### DIFF
--- a/src/archivey/formats/folder_reader.py
+++ b/src/archivey/formats/folder_reader.py
@@ -161,7 +161,7 @@ class FolderReader(BaseArchiveReader):
         # to prevent potential directory traversal issues if member_name contains '..'
         try:
             resolved_full_path = full_path.resolve()
-            archive_root = Path(self.path_str).resolve()
+            archive_root = self.path
 
             # Verify the resolved path stays within the archive root. Using
             # pathlib's ``is_relative_to`` avoids issues with string prefix

--- a/tests/archivey/test_path_traversal.py
+++ b/tests/archivey/test_path_traversal.py
@@ -1,10 +1,12 @@
 import pytest
+from pathlib import Path
 
 from archivey import open_archive
 from archivey.api.exceptions import (
     ArchiveMemberCannotBeOpenedError,
     ArchiveMemberNotFoundError,
 )
+from archivey.api.types import ArchiveFormat
 from tests.archivey.sample_archives import SAMPLE_ARCHIVES, filter_archives, SampleArchive
 from tests.archivey.testing_utils import skip_if_package_missing
 
@@ -15,10 +17,19 @@ SANITIZE_ALL_ARCHIVES = filter_archives(SAMPLE_ARCHIVES, prefixes=["sanitize"])
 def test_open_symlink_outside(sample_archive: SampleArchive, sample_archive_path: str):
     """Opening a symlink that points outside the archive should fail."""
     skip_if_package_missing(sample_archive.creation_info.format, None)
+
+    # For folder archives ensure the link target exists so failures are due to
+    # the path check, not a missing file.
+    if sample_archive.creation_info.format == ArchiveFormat.FOLDER:
+        folder_root = Path(sample_archive_path)
+        (folder_root.parent / "escape.txt").write_text("outside")
+
     with open_archive(sample_archive_path) as archive:
         members = {m.filename: m for m in archive.get_members()}
         member = members.get("link_outside")
         assert member is not None, "test archive missing link_outside"
-        with pytest.raises((ArchiveMemberCannotBeOpenedError, ArchiveMemberNotFoundError)):
+        with pytest.raises(
+            (ArchiveMemberCannotBeOpenedError, ArchiveMemberNotFoundError)
+        ):
             archive.open(member)
 

--- a/tests/archivey/test_path_traversal.py
+++ b/tests/archivey/test_path_traversal.py
@@ -1,0 +1,24 @@
+import pytest
+
+from archivey import open_archive
+from archivey.api.exceptions import (
+    ArchiveMemberCannotBeOpenedError,
+    ArchiveMemberNotFoundError,
+)
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES, filter_archives, SampleArchive
+from tests.archivey.testing_utils import skip_if_package_missing
+
+SANITIZE_ALL_ARCHIVES = filter_archives(SAMPLE_ARCHIVES, prefixes=["sanitize"])
+
+
+@pytest.mark.parametrize("sample_archive", SANITIZE_ALL_ARCHIVES, ids=lambda a: a.filename)
+def test_open_symlink_outside(sample_archive: SampleArchive, sample_archive_path: str):
+    """Opening a symlink that points outside the archive should fail."""
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+    with open_archive(sample_archive_path) as archive:
+        members = {m.filename: m for m in archive.get_members()}
+        member = members.get("link_outside")
+        assert member is not None, "test archive missing link_outside"
+        with pytest.raises((ArchiveMemberCannotBeOpenedError, ArchiveMemberNotFoundError)):
+            archive.open(member)
+


### PR DESCRIPTION
## Summary
- ensure FolderReader checks archive root path with `Path.is_relative_to`
- prevent directory traversal when opening members
- add tests for symlink path escaping

## Testing
- `uv run --extra optional pytest tests/archivey/test_path_traversal.py -q`
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_686678321dec832da0647dcef2407adb