### PR TITLE
Ensure full reads from streams

### DIFF
--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -1,5 +1,6 @@
 """Core functionality for opening and interacting with archives."""
 
+import io
 import os
 from typing import BinaryIO
 
@@ -29,6 +30,8 @@ def _normalize_archive_path(
     archive_path: BinaryIO | str | bytes | os.PathLike,
 ) -> BinaryIO | str:
     if hasattr(archive_path, "read"):
+        if not isinstance(archive_path, io.BufferedReader):
+            archive_path = io.BufferedReader(archive_path)  # type: ignore[arg-type]
         return archive_path  # type: ignore[return-value]
     if isinstance(archive_path, os.PathLike):
         return str(archive_path)

--- a/src/archivey/formats/format_detection.py
+++ b/src/archivey/formats/format_detection.py
@@ -5,6 +5,7 @@ import zipfile
 from typing import IO, TYPE_CHECKING, BinaryIO, cast
 
 from archivey.config import get_archivey_config
+from archivey.internal.io_helpers import read_exact
 from archivey.types import (
     COMPRESSION_FORMAT_TO_TAR_FORMAT,
     SINGLE_FILE_COMPRESSED_FORMATS,
@@ -44,7 +45,7 @@ def _is_executable(stream: IO[bytes]) -> bool:
     }
 
     stream.seek(0)
-    header = stream.read(16)
+    header = read_exact(stream, 16)
     return any(header.startswith(magic) for magic in EXECUTABLE_MAGICS.values())
 
 
@@ -106,7 +107,7 @@ def detect_archive_format_by_signature(
         for magics, offset, fmt in SIGNATURES:
             bytes_to_read = max(len(magic) for magic in magics)
             f.seek(offset)
-            data = f.read(bytes_to_read)
+            data = read_exact(f, bytes_to_read)
             if any(data.startswith(magic) for magic in magics):
                 detected_format = fmt
                 break

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -54,6 +54,7 @@ from archivey.internal.io_helpers import (
     ErrorIOStream,
     ExceptionTranslatingIO,
     ensure_binaryio,
+    read_exact,
     run_with_exception_translation,
 )
 from archivey.internal.utils import (
@@ -327,7 +328,7 @@ class RarStreamMemberFile(io.RawIOBase, BinaryIO):
                 return b""
 
             to_read = self._remaining if n < 0 else min(self._remaining, n)
-            data = self._stream.read(to_read)
+            data = read_exact(self._stream, to_read)
             if not data:
                 raise EOFError(f"Unexpected EOF while reading {self._filename}")
             self._remaining -= len(data)

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -19,6 +19,7 @@ from archivey.internal.base_reader import (
 )
 from archivey.internal.io_helpers import (
     ExceptionTranslatingIO,
+    read_exact,
     run_with_exception_translation,
 )
 from archivey.types import (
@@ -220,7 +221,7 @@ class TarReader(BaseArchiveReader):
             remaining = next_member_offset - self._archive.fileobj.tell()  # type: ignore
 
             if remaining > 0:
-                data = self._fileobj.read(remaining)
+                data = read_exact(self._fileobj, remaining)
                 assert len(data) == remaining, (
                     f"Expected {remaining} bytes, got {len(data)}"
                 )
@@ -230,7 +231,7 @@ class TarReader(BaseArchiveReader):
                 return
 
         expected_zeroes = 512 * 2
-        data = self._fileobj.read(expected_zeroes)
+        data = read_exact(self._fileobj, expected_zeroes)
         if len(data) < expected_zeroes:
             raise ArchiveCorruptedError(
                 f"Missing data after last tarinfo: {len(data)} bytes"

--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -37,6 +37,25 @@ def is_seekable(stream: io.IOBase | IO[bytes]) -> bool:
         return False
 
 
+def read_exact(stream: IO[bytes], n: int) -> bytes:
+    """Read exactly ``n`` bytes from ``stream``.
+
+    Continues reading until ``n`` bytes are returned or raises ``EOFError``
+    if the stream ends prematurely.
+    """
+
+    if n < 0:
+        raise ValueError("n must be non-negative")
+
+    data = bytearray()
+    while len(data) < n:
+        chunk = stream.read(n - len(data))
+        if not chunk:
+            raise EOFError(f"Expected {n} bytes, got {len(data)}")
+        data.extend(chunk)
+    return bytes(data)
+
+
 @runtime_checkable
 class ReadableBinaryStream(Protocol):
     def read(self, n: int = -1, /) -> bytes: ...

--- a/tests/archivey/test_small_read_wrapper.py
+++ b/tests/archivey/test_small_read_wrapper.py
@@ -1,0 +1,52 @@
+import io
+
+import pytest
+
+from archivey.core import open_archive
+from archivey.types import ArchiveFormat
+from tests.archivey.sample_archives import (
+    BASIC_ARCHIVES,
+    SampleArchive,
+    filter_archives,
+)
+from tests.archivey.testing_utils import skip_if_package_missing
+
+
+class OneByteReader(io.BytesIO):
+    def read(self, n: int = -1) -> bytes:  # type: ignore[override]
+        if n == -1:
+            return super().read()
+        if n == 0:
+            return b""
+        return super().read(1)
+
+    def readinto(self, b: bytearray | memoryview) -> int:  # type: ignore[override]
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+
+@pytest.mark.parametrize(
+    "sample_archive",
+    filter_archives(
+        BASIC_ARCHIVES,
+        custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
+    ),
+    ids=lambda a: a.filename,
+)
+def test_open_archive_small_reads(
+    sample_archive: SampleArchive, sample_archive_path: str
+):
+    skip_if_package_missing(sample_archive.creation_info.format, None)
+    with open(sample_archive_path, "rb") as f:
+        data = f.read()
+
+    stream = OneByteReader(data)
+    with open_archive(stream) as archive:
+        has_member = False
+        for member, member_stream in archive.iter_members_with_io():
+            has_member = True
+            if member_stream is not None:
+                member_stream.read()
+        assert has_member


### PR DESCRIPTION
## Summary
- add `read_exact` to guarantee requested bytes are returned
- use `read_exact` when parsing archive headers
- wrap input streams in `io.BufferedReader` during archive opening
- test reading archives with a stream that returns one byte at a time

## Testing
- `ruff check src/archivey/core.py src/archivey/formats/format_detection.py src/archivey/formats/single_file_reader.py src/archivey/formats/tar_reader.py src/archivey/formats/rar_reader.py src/archivey/internal/io_helpers.py tests/archivey/test_small_read_wrapper.py --fix`
- `uv run --extra optional pytest tests/archivey/test_small_read_wrapper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686806e57548832dba53394a1656e8a1