### PR TITLE
Simplify non-seekable stream handling

### DIFF
--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -136,7 +136,7 @@ def open_archive(
         recorded_data = recordable.get_all_data()
         recordable.seek(len(recorded_data))
         archive_path_normalized = ConcatenationStream(
-            [io.BytesIO(recorded_data), recordable]
+            [io.BytesIO(recorded_data), recordable._inner]
         )
     if format == ArchiveFormat.UNKNOWN:
         raise ArchiveNotSupportedError(
@@ -195,7 +195,7 @@ def open_compressed_stream(
         recorded_data = recordable.get_all_data()
         recordable.seek(len(recorded_data))
         archive_path_normalized = ConcatenationStream(
-            [io.BytesIO(recorded_data), recordable]
+            [io.BytesIO(recorded_data), recordable._inner]
         )
 
     if format not in SINGLE_FILE_COMPRESSED_FORMATS:

--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -68,6 +68,8 @@ def _translate_gzip_exception(e: Exception) -> Optional[ArchiveError]:
         return ArchiveCorruptedError(f"Error reading GZIP archive: {repr(e)}")
     if isinstance(e, EOFError):
         return ArchiveEOFError(f"GZIP file is truncated: {repr(e)}")
+    if isinstance(e, io.UnsupportedOperation):
+        return ArchiveStreamNotSeekableError("rapidgzip does not support non-seekable streams")
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
@@ -117,6 +119,8 @@ def _translate_rapidgzip_exception(e: Exception) -> Optional[ArchiveError]:
         in exc_text
     ):
         return ArchiveEOFError(f"Possibly truncated GZIP stream: {repr(e)}")
+    if isinstance(e, io.UnsupportedOperation):
+        return ArchiveStreamNotSeekableError("rapidgzip does not support non-seekable streams")
     return None  # pragma: no cover -- all possible exceptions should have been handled
 
 
@@ -152,6 +156,10 @@ def _translate_indexed_bzip2_exception(e: Exception) -> Optional[ArchiveError]:
     if isinstance(e, ValueError) and "has no valid fileno" in exc_text:
         # Indexed BZIP2 tries to look at the underlying stream's fileno if it's not
         # seekable.
+        return ArchiveStreamNotSeekableError(
+            "Indexed BZIP2 does not support non-seekable streams"
+        )
+    if isinstance(e, io.UnsupportedOperation):
         return ArchiveStreamNotSeekableError(
             "Indexed BZIP2 does not support non-seekable streams"
         )

--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -527,76 +527,47 @@ class StatsIO(io.RawIOBase, BinaryIO):
         return getattr(self._inner, item)
 
 
-class RewindableNonSeekableStream(io.RawIOBase, BinaryIO):
-    """Wrap a non-seekable stream that supports seeking via an internal buffer."""
+class RecordableStream(io.RawIOBase, BinaryIO):
+    """Wrap a stream, caching all data read from it."""
 
     def __init__(self, inner: IO[bytes]):
         super().__init__()
         self._inner = inner
         self._buffer = bytearray()
         self._pos = 0
-        self._stream_pos = 0
-        self._recording = True
 
-    def stop_recording(self) -> None:
-        """Stop storing new data into the rewind buffer."""
-        self._recording = False
-
-    def _read_from_stream(self, n: int) -> bytes:
-        chunk = self._inner.read(n)
-        if self._recording:
-            self._buffer.extend(chunk)
-        self._stream_pos += len(chunk)
-        return chunk
-
-    def _advance_stream_to(self, target: int) -> None:
-        while self._stream_pos < target:
-            chunk = self._read_from_stream(target - self._stream_pos)
-            if not chunk:
-                break
+    def get_all_data(self) -> bytes:
+        """Return all data read so far."""
+        return bytes(self._buffer)
 
     # Basic IO methods -------------------------------------------------
     def read(self, n: int = -1) -> bytes:
-        endpos = self._pos + n
-        if n >= 0 and endpos <= len(self._buffer):
-            # The data is fully in the buffer, so we can return it directly.
-            data = bytes(self._buffer[self._pos : endpos])
-            self._pos += n
-            return data
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
 
-        data = bytearray()
+        if n == -1:
+            data = self._buffer[self._pos :]
+            self._pos = len(self._buffer)
+            chunk = self._inner.read()
+            self._buffer.extend(chunk)
+            self._pos = len(self._buffer)
+            return bytes(data) + chunk
+
         remaining = n
+        data = bytearray()
 
-        if self._pos < len(self._buffer):
-            # Take the previously-read data from the buffer.
-            data.extend(self._buffer[self._pos :])
-            self._pos += len(data)
-            if remaining != -1:
-                remaining -= len(data)
+        available = len(self._buffer) - self._pos
+        if available > 0:
+            take = min(available, remaining)
+            data.extend(self._buffer[self._pos : self._pos + take])
+            self._pos += take
+            remaining -= take
 
-        if self._pos < self._stream_pos:
-            raise io.UnsupportedOperation(
-                "cannot read from non buffered region. "
-                f"pos={self._pos}, stream_pos={self._stream_pos}, buffer_size={len(self._buffer)}"
-            )
-
-        if self._pos > self._stream_pos:
-            self._advance_stream_to(self._pos)
-
-        assert self._stream_pos == self._pos
-
-        if remaining == -1:
-            while True:
-                chunk = self._read_from_stream(-1)
-                if not chunk:
-                    break
-                self._pos += len(chunk)
-                data.extend(chunk)
-            return bytes(data)
-
-        chunk = self._read_from_stream(remaining)
-        self._pos += len(chunk)
-        data.extend(chunk)
+        if remaining > 0:
+            chunk = self._inner.read(remaining)
+            self._buffer.extend(chunk)
+            self._pos += len(chunk)
+            data.extend(chunk)
 
         return bytes(data)
 
@@ -608,25 +579,25 @@ class RewindableNonSeekableStream(io.RawIOBase, BinaryIO):
 
     # Seek/Tell --------------------------------------------------------
     def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
-        if whence == io.SEEK_END:
-            raise io.UnsupportedOperation("seek to end")
         if whence == io.SEEK_CUR:
             offset = self._pos + offset
+        elif whence == io.SEEK_END:
+            offset = len(self._buffer) + offset
         elif whence != io.SEEK_SET:
             raise ValueError(f"Invalid whence: {whence}")
 
         if offset < 0:
-            raise io.UnsupportedOperation("seek to negative position")
+            raise io.UnsupportedOperation("seek outside recorded region")
+        while offset > len(self._buffer):
+            chunk = self._inner.read(offset - len(self._buffer))
+            if not chunk:
+                break
+            self._buffer.extend(chunk)
 
-        if offset >= len(self._buffer) and offset < self._stream_pos:
-            raise io.UnsupportedOperation(
-                f"seek into non-cached region: buf={len(self._buffer)}, offset={offset}, stream={self._stream_pos}"
-            )
+        if offset > len(self._buffer):
+            raise io.UnsupportedOperation("seek outside recorded region")
 
-        if offset > self._stream_pos:
-            self._advance_stream_to(offset)
-
-        self._pos = offset if offset <= self._stream_pos else self._stream_pos
+        self._pos = offset
         return self._pos
 
     def tell(self) -> int:
@@ -640,10 +611,9 @@ class RewindableNonSeekableStream(io.RawIOBase, BinaryIO):
         return False
 
     def seekable(self) -> bool:  # pragma: no cover - trivial
-        return self._recording
+        return True
 
     # Control methods --------------------------------------------------
-
     def close(self) -> None:  # pragma: no cover - simple delegation
         self._inner.close()
         super().close()
@@ -651,3 +621,61 @@ class RewindableNonSeekableStream(io.RawIOBase, BinaryIO):
     # Delegate unknown attributes -------------------------------------
     def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple
         return getattr(self._inner, item)
+
+
+class ConcatenationStream(io.RawIOBase, BinaryIO):
+    """Concatenate multiple streams sequentially."""
+
+    def __init__(self, streams: list[IO[bytes]]):
+        super().__init__()
+        self._streams = streams
+        self._index = 0
+
+    # Basic IO methods -------------------------------------------------
+    def read(self, n: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+
+        data = bytearray()
+
+        while self._index < len(self._streams) and (n < 0 or len(data) < n):
+            stream = self._streams[self._index]
+            to_read = -1 if n < 0 else n - len(data)
+            chunk = stream.read(to_read)
+            if not chunk:
+                self._index += 1
+                continue
+            data.extend(chunk)
+
+        if n >= 0:
+            return bytes(data[:n])
+        return bytes(data)
+
+    def readinto(self, b: bytearray | memoryview) -> int:  # type: ignore[override]
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+    # Properties -------------------------------------------------------
+    def readable(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def writable(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def seekable(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def fileno(self) -> int:  # pragma: no cover - simple
+        raise OSError("fileno")
+
+    # Control methods --------------------------------------------------
+    def close(self) -> None:  # pragma: no cover - simple delegation
+        for stream in self._streams:
+            try:
+                stream.close()
+            except Exception:  # pragma: no cover - simple
+                pass
+        super().close()
+

--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -582,7 +582,7 @@ class RecordableStream(io.RawIOBase, BinaryIO):
         if whence == io.SEEK_CUR:
             offset = self._pos + offset
         elif whence == io.SEEK_END:
-            offset = len(self._buffer) + offset
+            raise io.UnsupportedOperation("seek to end")
         elif whence != io.SEEK_SET:
             raise ValueError(f"Invalid whence: {whence}")
 

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -79,6 +79,11 @@ class TestRecordableStream:
         assert stream.tell() == 5
         assert stream.read(2) == DATA[5:7]
 
+    def test_seek_end_unsupported(self):
+        stream = create_stream()
+        with pytest.raises(io.UnsupportedOperation, match="seek to end"):
+            stream.seek(0, io.SEEK_END)
+
     def test_readinto(self):
         stream = create_stream()
         buf = bytearray(5)

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -3,7 +3,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from archivey.internal.io_helpers import LazyOpenIO, RewindableNonSeekableStream
+from archivey.internal.io_helpers import (
+    ConcatenationStream,
+    LazyOpenIO,
+    RecordableStream,
+)
 from tests.archivey.test_open_nonseekable import NonSeekableBytesIO
 
 
@@ -39,25 +43,20 @@ def test_lazy_open_closes_inner_stream():
 DATA = b"0123456789abcdef"
 
 
-def create_stream() -> RewindableNonSeekableStream:
+def create_stream() -> RecordableStream:
     inner = NonSeekableBytesIO(DATA)
-    return RewindableNonSeekableStream(inner)
+    return RecordableStream(inner)
 
 
-# RewindableNonSeekableStream tests
-class TestRewindableNonSeekableStream:
+# RecordableStream tests
+class TestRecordableStream:
     def test_basic_read(self):
-        """Test basic reading functionality."""
         stream = create_stream()
-
         assert stream.read(5) == b"01234"
         assert stream.tell() == 5
-        assert stream.read(6) == b"56789a"
-        assert stream.tell() == 11
-        assert stream.read(-1) == b"bcdef"
-        assert stream.tell() == 16
-        assert stream.read(3) == b""
-        assert stream.tell() == 16
+        assert stream.read() == b"56789abcdef"
+        assert stream.tell() == len(DATA)
+        assert stream.get_all_data() == DATA
 
     def test_read_all(self):
         """Test reading entire stream."""
@@ -66,165 +65,67 @@ class TestRewindableNonSeekableStream:
         assert stream.read() == DATA
         assert stream.tell() == len(DATA)
 
-    def test_seek_within_buffer(self):
-        """Test seeking within already-read buffer."""
+    def test_seek_within_recorded(self):
         stream = create_stream()
-
-        # Read some data to populate buffer
-        assert stream.read(5) == b"01234"
-        assert stream.tell() == 5
-
-        # Seek back to beginning
+        stream.read(6)
         assert stream.seek(0) == 0
-        assert stream.tell() == 0
         assert stream.read(3) == b"012"
-        assert stream.read(7) == b"3456789"
+        assert stream.seek(4) == 4
+        assert stream.read(2) == b"45"
 
-        # Seek to middle
-        assert stream.tell() == 10
-        assert stream.seek(-8, 1) == 2
-        assert stream.read() == DATA[2:]
-
-    def test_seek_forward_beyond_buffer(self):
-        """Test seeking forward beyond current buffer."""
+    def test_seek_outside_recorded(self):
         stream = create_stream()
-
-        # Read some data
-        assert stream.read(5) == b"01234"
-
-        # Seek forward beyond buffer
-        assert stream.seek(8) == 8
-        assert stream.read(3) == b"89a"
-
-        assert stream.tell() == 11
-
-        # The stream is in recording mode, so the intermediate data is cached.
-        stream.seek(0)
-        assert stream.read() == b"0123456789abcdef"
+        stream.seek(5)
+        assert stream.tell() == 5
+        assert stream.read(2) == DATA[5:7]
 
     def test_readinto(self):
-        """Test readinto method."""
         stream = create_stream()
+        buf = bytearray(5)
+        assert stream.readinto(buf) == 5
+        assert bytes(buf) == b"01234"
 
-        buffer = bytearray(5)
-        assert stream.readinto(buffer) == 5
-        assert buffer == b"01234"
-        assert stream.tell() == 5
 
-    def test_stop_recording(self):
-        """Test stop_recording functionality."""
+    def test_properties_and_close(self):
         stream = create_stream()
-
-        # Read some data while recording
-        assert stream.read(5) == b"01234"
-        assert stream.seekable() is True
-
-        # Stop recording
-        stream.stop_recording()
-        assert stream.seekable() is False
-
-        # Can still read forward
-        assert stream.read(6) == b"56789a"
-        current_pos = stream.tell()
-        assert current_pos == 11
-
-        # Can re-read the buffered data after stopping recording
-        assert stream.seek(0) == 0
-        assert stream.read(2) == b"01"
-        assert stream.read(2) == b"23"
-        with pytest.raises(io.UnsupportedOperation):
-            stream.read(2)
-
-        # Seeking backwards from the current position to an unbuffered region.
-        with pytest.raises(io.UnsupportedOperation):
-            stream.seek(10)
-
-        # Seeking forward to an unbuffered region is supported.
-        stream.seek(12)
-        assert stream.read() == b"cdef"
-
-    def test_seek_to_end_unsupported(self):
-        """Test that seeking to end is not supported."""
-        stream = create_stream()
-
-        with pytest.raises(io.UnsupportedOperation, match="seek to end"):
-            stream.seek(0, io.SEEK_END)
-
-    def test_seek_negative_position(self):
-        """Test that seeking to negative position is not supported."""
-        stream = create_stream()
-
-        with pytest.raises(io.UnsupportedOperation, match="seek to negative position"):
-            stream.seek(-1)
-
-    def test_seek_invalid_whence(self):
-        """Test that invalid whence values raise ValueError."""
-        stream = create_stream()
-
-        with pytest.raises(ValueError, match="Invalid whence"):
-            stream.seek(0, 999)
-
-    def test_properties(self):
-        """Test stream properties."""
-        stream = create_stream()
-
         assert stream.readable() is True
         assert stream.writable() is False
         assert stream.seekable() is True
-
-        stream.stop_recording()
-        assert stream.seekable() is False
-
-    def test_close(self):
-        """Test closing the stream."""
-        inner = io.BytesIO(b"hello world")
-        stream = RewindableNonSeekableStream(inner)
-
         stream.close()
         assert stream.closed
-        assert inner.closed
 
     def test_delegate_attributes(self):
-        """Test that unknown attributes are delegated to inner stream."""
         inner = Mock(spec=io.BytesIO)
         inner.custom_attr = "test_value"
-        stream = RewindableNonSeekableStream(inner)
-
+        stream = RecordableStream(inner)
         assert stream.custom_attr == "test_value"
 
     def test_empty_stream(self):
-        """Test behavior with empty stream."""
         inner = io.BytesIO(b"")
-        stream = RewindableNonSeekableStream(inner)
-
+        stream = RecordableStream(inner)
         assert stream.read() == b""
         assert stream.tell() == 0
 
     def test_large_reads(self):
-        """Test reading large amounts of data."""
         data = b"x" * 10000
         inner = io.BytesIO(data)
-        stream = RewindableNonSeekableStream(inner)
-
-        # Read in chunks
+        stream = RecordableStream(inner)
         chunk1 = stream.read(3000)
         assert len(chunk1) == 3000
         assert stream.tell() == 3000
-
-        # Seek back
         stream.seek(1000)
-        assert stream.tell() == 1000
-
-        # Read more
-        chunk2 = stream.read(2000)
-        assert len(chunk2) == 2000
-        assert stream.tell() == 3000
+        assert stream.read(2000) == data[1000:3000]
 
     def test_read_after_close(self):
-        """Test reading after closing raises error."""
         stream = create_stream()
-
         stream.close()
-
         with pytest.raises(ValueError, match="I/O operation on closed file"):
             stream.read(5)
+
+
+def test_concatenation_stream():
+    s1 = io.BytesIO(b"abc")
+    s2 = io.BytesIO(b"de")
+    stream = ConcatenationStream([s1, s2])
+    assert stream.read(4) == b"abcd"
+    assert stream.read() == b"e"


### PR DESCRIPTION
## Summary
- implement `RecordableStream` and `ConcatenationStream`
- use these in `open_archive` and `open_compressed_stream`
- update rapidgzip and indexed_bzip2 translators
- rewrite IO helper tests for new streams

## Testing
- `uv run --extra optional pytest tests/archivey/test_io_helpers.py -q`
- `uv run --extra optional pytest tests/archivey/test_open_nonseekable.py::test_open_archive_nonseekable -q`
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c483c6844832d8df1024b33a51cc3