### PR TITLE
Fix docstring yields sections for proper docs

### DIFF
--- a/src/archivey/archive_reader.py
+++ b/src/archivey/archive_reader.py
@@ -123,12 +123,13 @@ class ArchiveReader(abc.ABC):
                 the member to include it, or ``None`` to skip.
 
         Yields:
-            Iterator[tuple[ArchiveMember, Optional[BinaryIO]]]: An iterator where each
-            item is a tuple containing the ArchiveMember object and a binary I/O
-            stream for reading its content. The stream is None for non-file entries.
-            Streams are closed automatically when iteration advances to the next
-            member or when the generator is closed, so they should be consumed
-            before requesting another member.
+            tuple[ArchiveMember, BinaryIO | None]:
+                Each yielded item is a tuple containing the ``ArchiveMember``
+                object and a binary I/O stream for reading its content.  The
+                stream is ``None`` for non-file entries.  Streams are closed
+                automatically when iteration advances to the next member or when
+                the generator is closed, so they should be consumed before
+                requesting another member.
 
         Raises:
             ArchiveEncryptedError: If a member is encrypted and `pwd` is incorrect

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -343,7 +343,7 @@ class BaseArchiveReader(ArchiveReader):
           to build its initial list of all members.
 
         Yields:
-            Iterator[ArchiveMember]: ArchiveMember instances from the archive.
+            ArchiveMember: ArchiveMember instances from the archive.
         """
         pass  # pragma: no cover
 
@@ -610,11 +610,14 @@ class BaseArchiveReader(ArchiveReader):
             pwd: Password to use for decryption, if needed and different from the one
             used when opening the archive. May not be supported by all archive formats.
 
-        Returns:
-            A (ArchiveMember, BinaryIO) iterator over the members. Each stream
-            should be consumed before advancing to the next member. Streams are
-            closed automatically when iteration continues or the generator is
-            closed. The stream may be None if the member is not a file.
+        Yields:
+            tuple[ArchiveMember, BinaryIO | None]:
+                A tuple where the first element is the ``ArchiveMember`` and the
+                second element is the opened stream for that member.  The stream
+                may be ``None`` for non-file members.  Each stream should be
+                fully consumed before advancing to the next member.  Streams are
+                closed automatically when iteration continues or the generator is
+                closed.
 
         Notes:
             If :meth:`has_random_access` returns ``False`` (streaming-only


### PR DESCRIPTION
## Summary
- clarify yields in `iter_members_with_io` docstrings
- fix `iter_members_for_registration` docstring
- document iterator tuple in `BaseArchiveReader.iter_members_with_io`

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_68710651e67c832dba6c671516f20fbe