### PR TITLE
Fix allow failures for 3.13t/3.14

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -14,6 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14-dev", "3.14t-dev"]
+        include:
+          - python-version: "3.13t"
+            allow-failure: true
+          - python-version: "3.14-dev"
+            allow-failure: true
+          - python-version: "3.14t-dev"
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Summary
- update the tox workflow so preview Python environments can fail without failing CI

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6872d6dd7e4c832da8dc463ffb714760