### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,46 @@
+name: Build and Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Build package
+        run: hatch build
+
+      - name: Publish to PyPI
+        if: github.repository == 'davitf/archivey'
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish to TestPyPI
+        if: github.repository == 'davitf/archivey-dev'
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Fail on unexpected repository
+        if: github.repository != 'davitf/archivey' && github.repository != 'davitf/archivey-dev'
+        run: |
+          echo "Repository ${{ github.repository }} is not allowed to publish" >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add GitHub action for publishing to PyPI
- use `hatch build` for packaging

## Testing
- `uv run --extra optional pytest -k "" -q`


------
https://chatgpt.com/codex/tasks/task_e_6874fafd932c832da89bdbaa164f6457