### PR TITLE
Fix PyPI publish action

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,4 +1,4 @@
-name: Build and Publish
+name: Publish
 
 on:
   push:
@@ -26,16 +26,32 @@ jobs:
       - name: Build package
         run: hatch build
 
-      - name: Publish to PyPI
-        if: github.repository == 'davitf/archivey'
-        uses: pypa/gh-action-pypi-publish@v1
+      - uses: actions/upload-artifact@v4
         with:
+          path: ./dist
+
+  pypi-publish:
+    needs: ['build']
+    environment: 'publish'
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Publish package distributions to PyPI
+        if: github.repository == 'davitf/archivey'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: artifact
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Publish to TestPyPI
+      - name: Publish package distributions to TestPyPI
         if: github.repository == 'davitf/archivey-dev'
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages_dir: artifact
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 


### PR DESCRIPTION
## Summary
- update the publish workflow to use the official `release/v1` tag
- add an upload/download artifact step and separate publish job
- publish to TestPyPI if on `archivey-dev`, otherwise publish to real PyPI

## Testing
- `uv run --extra optional pytest -k "" -q`


------
https://chatgpt.com/codex/tasks/task_e_6874fafd932c832da89bdbaa164f6457