### PR TITLE
Add windows/macos tox job

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -74,3 +74,26 @@ jobs:
 
       - name: Run tox environment
         run: tox -e py${{ matrix.python-version }}-${{ matrix.tox_env }}
+
+  py313-newlibs-other-os:
+    name: Tox - py3.13-newlibs (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run tox environment
+        run: tox -e py3.13-newlibs

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Install tox
         run: pip install tox
+        working-directory: ${{ github.workspace }}
 
       - name: Run tox environment
         run: tox -e py3.13-newlibs
+        working-directory: ${{ github.workspace }}

--- a/tox.ini
+++ b/tox.ini
@@ -56,12 +56,16 @@ deps =
     rarfile_no_crypto: rarfile
 
 commands =
-    sh -c 'if ! command -v unrar >/dev/null; then \
-        echo "⚠️  'unrar' is not installed. Installing it requires sudo access."; \
-        echo "⏳  Enter your password if prompted."; \
-        sudo apt-get update && sudo apt-get install -y unrar; \
+    sh -c 'if command -v apt-get >/dev/null; then \
+        if ! command -v unrar >/dev/null; then \
+            echo "⚠️  'unrar' is not installed. Installing it requires sudo access."; \
+            echo "⏳  Enter your password if prompted."; \
+            sudo apt-get update && sudo apt-get install -y unrar; \
+        else \
+            echo "✅  'unrar' is already installed."; \
+        fi; \
     else \
-        echo "✅  'unrar' is already installed."; \
+        echo "ℹ️  skipping unrar installation; apt-get unavailable"; \
     fi'
     pytest --no-cov {posargs}
 


### PR DESCRIPTION
## Summary
- add a job to run the `py3.13-newlibs` tox factor on Windows and macOS runners

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874fd83d7d4832d905534a3d23ff1ee