### PR TITLE
Move CLI pattern filter helper to filters module

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,10 @@ You can filter member names using shell patterns placed after `--`:
 archivey --list my_archive.zip -- "*.txt"
 ```
 
+In Python code you can create the same filter using
+`[build_pattern_filter][archivey.filters.build_pattern_filter]` and pass it to
+`iter_members_with_io` or `extractall`.
+
 ---
 
 ## Documentation

--- a/src/archivey/filters.py
+++ b/src/archivey/filters.py
@@ -17,7 +17,8 @@ import functools
 import logging
 import os
 import posixpath
-from typing import Any
+import fnmatch
+from typing import Any, Callable
 
 from archivey.config import ExtractionFilter
 from archivey.exceptions import ArchiveFilterError
@@ -28,6 +29,23 @@ from archivey.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def build_pattern_filter(patterns: list[str]) -> Callable[[ArchiveMember], bool] | None:
+    """Create a filename filter based on shell-style patterns.
+
+    The returned callable checks if an :class:`~archivey.types.ArchiveMember`
+    ``filename`` matches any of the given patterns using :func:`fnmatch.fnmatch`.
+    If ``patterns`` is empty, ``None`` is returned.
+    """
+
+    if not patterns:
+        return None
+
+    def _match(member: ArchiveMember) -> bool:
+        return any(fnmatch.fnmatch(member.filename, pat) for pat in patterns)
+
+    return _match
 
 
 def _check_target_inside_archive_root(

--- a/src/archivey/internal/cli.py
+++ b/src/archivey/internal/cli.py
@@ -1,6 +1,5 @@
 import argparse
 import builtins
-import fnmatch
 import hashlib
 import logging
 import os
@@ -8,7 +7,7 @@ import sys
 import zlib
 from datetime import datetime
 from importlib.metadata import version as package_version
-from typing import IO, BinaryIO, Callable, Tuple, cast
+from typing import IO, BinaryIO, Tuple, cast
 
 from tqdm import tqdm
 
@@ -20,6 +19,7 @@ from archivey.internal.dependency_checker import (
     format_dependency_versions,
     get_dependency_versions,
 )
+from archivey.filters import build_pattern_filter
 from archivey.internal.io_helpers import IOStats, StatsIO
 from archivey.types import ArchiveMember, MemberType
 
@@ -51,17 +51,6 @@ def get_member_checksums(member_file: BinaryIO) -> Tuple[int, str]:
         crc32_value = zlib.crc32(block, crc32_value)
         sha256.update(block)
     return crc32_value & 0xFFFFFFFF, sha256.hexdigest()
-
-
-def build_pattern_filter(patterns: list[str]) -> Callable[[ArchiveMember], bool] | None:
-    """Create a filter function for member names based on shell-style patterns."""
-    if not patterns:
-        return None
-
-    def _match(member: ArchiveMember) -> bool:
-        return any(fnmatch.fnmatch(member.filename, pat) for pat in patterns)
-
-    return _match
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- move the CLI pattern filter helper into `archivey.filters`
- import it from the CLI
- mention `build_pattern_filter` in the docs

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b8a39cc10832d9a89ca9cec0be0d2