### PR TITLE
Add extractall return mapping check

### DIFF
--- a/src/archivey/internal/extraction_helper.py
+++ b/src/archivey/internal/extraction_helper.py
@@ -228,6 +228,8 @@ class ExtractionHelper:
                                 target.member_id,
                                 member.member_id,
                             )
+                            # This was technically extracted last.
+                            self.extracted_members_by_path[target_path] = target
                             continue
 
                         if not self.check_overwrites(member, target_path):

--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -55,8 +55,15 @@ def test_extractall(
     logger.info(f"Extracting {sample_archive_path} to {dest}")
 
     with open_archive(sample_archive_path) as archive:
-        # TODO: check the dict returned by extractall
-        archive.extractall(dest)
+        result = archive.extractall(dest)
+
+        # The returned mapping keys should be the absolute paths of the
+        # extracted members and values should be ``ArchiveMember`` objects whose
+        # filenames match those paths relative to the destination directory.
+        for path, member in result.items():
+            assert os.path.normpath(os.path.join(dest, member.filename)) == path
+            assert os.path.lexists(path)
+            assert hasattr(member, "filename")
 
     expected_files: set[str] = set()
 


### PR DESCRIPTION
## Summary
- ensure `extractall` return value contains extracted paths mapped to members
- update tests

## Testing
- `uv run --extra optional pytest tests/archivey/test_extractall.py::test_extractall -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa8ad993c832da2f2a7f593b3b56c