### PR TITLE
Fix portable directory listing in test helper

### DIFF
--- a/tests/archivey/testing_utils.py
+++ b/tests/archivey/testing_utils.py
@@ -71,8 +71,8 @@ def write_files_to_dir(dir: str | os.PathLike, files: list[FileInfo]):
             perm = file.permissions or default_permissions_by_type[file.type]
             set_file_permissions(full_path, perm, file.type)
 
-    # List the files with ls
-    subprocess.run(["ls", "-alF", "-R", "--time-style=full-iso", dir], check=True)
+    # List the files with ls (for debugging) without GNU-specific options
+    subprocess.run(["ls", "-alF", "-R", "--", dir], check=True)
 
 
 def skip_if_package_missing(format: ArchiveFormat, config: Optional[ArchiveyConfig]):


### PR DESCRIPTION
## Summary
- keep `write_files_to_dir` compatible with non-GNU `ls`

## Testing
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829eac255c832d8723f82bbe2cac2f