### PR TITLE
Add HTTP stream test for open_archive

### DIFF
--- a/tests/archivey/test_open_nonseekable.py
+++ b/tests/archivey/test_open_nonseekable.py
@@ -28,7 +28,7 @@ SKIPPABLE_FORMATS: set[ArchiveFormat] = {
 
 
 # Formats known to fail when opened from a non-seekable stream with default/alternative packages
-EXPECTED_FAILURES: set[tuple[ArchiveFormat, bool]] = {
+EXPECTED_NON_SEEKABLE_FAILURES: set[tuple[ArchiveFormat, bool]] = {
     (ArchiveFormat.GZIP, True),
     (ArchiveFormat.BZIP2, True),
     (ArchiveFormat.XZ, True),
@@ -96,7 +96,7 @@ def test_open_archive_nonseekable(
         ArchiveStreamNotSeekableError
     ) as exc:  # pragma: no cover - environment dependent
         key = (sample_archive.creation_info.format, alternative_packages)
-        if key in EXPECTED_FAILURES:
+        if key in EXPECTED_NON_SEEKABLE_FAILURES:
             pytest.xfail(
                 f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
             )
@@ -135,8 +135,8 @@ def test_open_compressed_stream_nonseekable(
     ) as exc:  # pragma: no cover - environment dependent
         key = (sample_archive.creation_info.format, alternative_packages)
         logger.error(f"key: {key}")
-        logger.error(f"EXPECTED_FAILURES: {EXPECTED_FAILURES}")
-        if key in EXPECTED_FAILURES:
+        logger.error(f"EXPECTED_FAILURES: {EXPECTED_NON_SEEKABLE_FAILURES}")
+        if key in EXPECTED_NON_SEEKABLE_FAILURES:
             pytest.xfail(
                 f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
             )

--- a/tests/archivey/test_open_url.py
+++ b/tests/archivey/test_open_url.py
@@ -1,0 +1,79 @@
+import functools
+import http.server
+import os
+import threading
+from urllib.request import urlopen
+
+import pytest
+
+from archivey.core import open_archive
+from archivey.exceptions import ArchiveStreamNotSeekableError
+from archivey.types import ArchiveFormat
+from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SAMPLE_ARCHIVES
+from tests.archivey.testing_utils import skip_if_package_missing
+
+# Select one sample archive for each format (except FOLDER and ISO)
+archives_by_format = {}
+for a in SAMPLE_ARCHIVES:
+    fmt = a.creation_info.format
+    if fmt in (ArchiveFormat.FOLDER, ArchiveFormat.ISO):
+        continue
+    archives_by_format.setdefault(fmt, a)
+
+# Formats expected to fail when reading from a non-seekable HTTP stream
+EXPECTED_FAILURES: set[tuple[ArchiveFormat, bool]] = {
+    (ArchiveFormat.GZIP, True),
+    (ArchiveFormat.BZIP2, True),
+    (ArchiveFormat.XZ, True),
+    (ArchiveFormat.TAR_GZ, True),
+    (ArchiveFormat.TAR_BZ2, True),
+    (ArchiveFormat.TAR_XZ, True),
+    (ArchiveFormat.ZIP, False),
+    (ArchiveFormat.ZIP, True),
+    (ArchiveFormat.RAR, False),
+    (ArchiveFormat.RAR, True),
+    (ArchiveFormat.SEVENZIP, False),
+    (ArchiveFormat.SEVENZIP, True),
+}
+
+
+def _serve_directory(directory: str):
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)
+    server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+@pytest.mark.parametrize("sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename)
+@pytest.mark.parametrize("alternative_packages", [False, True], ids=["defaultlibs", "altlibs"])
+def test_open_archive_via_http(sample_archive, alternative_packages):
+    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    skip_if_package_missing(sample_archive.creation_info.format, config)
+
+    path = sample_archive.get_archive_path()
+    server, thread = _serve_directory(directory=os.path.dirname(path))
+    try:
+        url = f"http://localhost:{server.server_address[1]}/{os.path.basename(path)}"
+        with urlopen(url) as response:
+            try:
+                with open_archive(response, streaming_only=True, config=config) as archive:
+                    has_member = False
+                    for member, stream in archive.iter_members_with_streams():
+                        has_member = True
+                        if stream is not None:
+                            stream.read()
+                    assert has_member
+            except ArchiveStreamNotSeekableError as exc:  # pragma: no cover - env dependent
+                key = (sample_archive.creation_info.format, alternative_packages)
+                if key in EXPECTED_FAILURES:
+                    pytest.xfail(
+                        f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+                    )
+                else:
+                    assert False, (
+                        f"Expected format {key} to work with HTTP streams, but it failed with {exc!r}"
+                    )
+    finally:
+        server.shutdown()
+        thread.join()

--- a/tests/archivey/test_open_url.py
+++ b/tests/archivey/test_open_url.py
@@ -9,44 +9,38 @@ import pytest
 from archivey.core import open_archive
 from archivey.exceptions import ArchiveStreamNotSeekableError
 from archivey.types import ArchiveFormat
-from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SAMPLE_ARCHIVES
+from tests.archivey.sample_archives import (
+    ALTERNATIVE_CONFIG,
+    BASIC_ARCHIVES,
+    SAMPLE_ARCHIVES,
+    SINGLE_FILE_ARCHIVES,
+    filter_archives,
+)
+from tests.archivey.test_open_nonseekable import EXPECTED_NON_SEEKABLE_FAILURES
 from tests.archivey.testing_utils import skip_if_package_missing
-
-# Select one sample archive for each format (except FOLDER and ISO)
-archives_by_format = {}
-for a in SAMPLE_ARCHIVES:
-    fmt = a.creation_info.format
-    if fmt in (ArchiveFormat.FOLDER, ArchiveFormat.ISO):
-        continue
-    archives_by_format.setdefault(fmt, a)
-
-# Formats expected to fail when reading from a non-seekable HTTP stream
-EXPECTED_FAILURES: set[tuple[ArchiveFormat, bool]] = {
-    (ArchiveFormat.GZIP, True),
-    (ArchiveFormat.BZIP2, True),
-    (ArchiveFormat.XZ, True),
-    (ArchiveFormat.TAR_GZ, True),
-    (ArchiveFormat.TAR_BZ2, True),
-    (ArchiveFormat.TAR_XZ, True),
-    (ArchiveFormat.ZIP, False),
-    (ArchiveFormat.ZIP, True),
-    (ArchiveFormat.RAR, False),
-    (ArchiveFormat.RAR, True),
-    (ArchiveFormat.SEVENZIP, False),
-    (ArchiveFormat.SEVENZIP, True),
-}
 
 
 def _serve_directory(directory: str):
-    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=directory
+    )
     server = http.server.ThreadingHTTPServer(("localhost", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server, thread
 
 
-@pytest.mark.parametrize("sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename)
-@pytest.mark.parametrize("alternative_packages", [False, True], ids=["defaultlibs", "altlibs"])
+@pytest.mark.parametrize(
+    "sample_archive",
+    filter_archives(
+        BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
+        custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
+    ),
+    ids=lambda a: a.filename,
+)
+@pytest.mark.parametrize(
+    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+)
 def test_open_archive_via_http(sample_archive, alternative_packages):
     config = ALTERNATIVE_CONFIG if alternative_packages else None
     skip_if_package_missing(sample_archive.creation_info.format, config)
@@ -57,16 +51,20 @@ def test_open_archive_via_http(sample_archive, alternative_packages):
         url = f"http://localhost:{server.server_address[1]}/{os.path.basename(path)}"
         with urlopen(url) as response:
             try:
-                with open_archive(response, streaming_only=True, config=config) as archive:
+                with open_archive(
+                    response, streaming_only=True, config=config
+                ) as archive:
                     has_member = False
                     for member, stream in archive.iter_members_with_streams():
                         has_member = True
                         if stream is not None:
                             stream.read()
                     assert has_member
-            except ArchiveStreamNotSeekableError as exc:  # pragma: no cover - env dependent
+            except (
+                ArchiveStreamNotSeekableError
+            ) as exc:  # pragma: no cover - env dependent
                 key = (sample_archive.creation_info.format, alternative_packages)
-                if key in EXPECTED_FAILURES:
+                if key in EXPECTED_NON_SEEKABLE_FAILURES:
                     pytest.xfail(
                         f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
                     )

--- a/tests/archivey/test_open_url.py
+++ b/tests/archivey/test_open_url.py
@@ -12,7 +12,6 @@ from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
     ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
-    SAMPLE_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
     filter_archives,
 )


### PR DESCRIPTION
## Summary
- add a test that serves sample archives over HTTP and opens them via `open_archive`

## Testing
- `uv run --extra optional pytest tests/archivey/test_open_url.py::test_open_archive_via_http -q`
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884f75ecb98832d9f9b00c4c3d9fb0c