### PR TITLE
Add nested compressed archive tests

### DIFF
--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -154,7 +154,11 @@ class BinaryIOWrapper(io.RawIOBase, BinaryIO):
         # Don't close the underlying stream, as this may be a temporary wrapper.
 
     def flush(self):
-        if hasattr(self._raw, "flush"):
+        if (
+            hasattr(self._raw, "flush")
+            and hasattr(self._raw, "closed")
+            and not self._raw.closed  # type: ignore
+        ):
             return self._raw.flush()  # type: ignore
         return None
 

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -5,6 +5,9 @@ from unittest.mock import Mock
 
 import pytest
 
+from archivey.config import ArchiveyConfig
+from archivey.core import open_compressed_stream
+from archivey.formats.compressed_streams import get_stream_open_fn
 from archivey.internal.archive_stream import ArchiveStream
 from archivey.internal.io_helpers import (
     BinaryIOWrapper,
@@ -16,7 +19,9 @@ from archivey.internal.io_helpers import (
     is_stream,
     read_exact,
 )
+from tests.archivey.sample_archives import SINGLE_FILE_ARCHIVES
 from tests.archivey.test_open_nonseekable import NonSeekableBytesIO
+from tests.archivey.testing_utils import skip_if_package_missing
 
 
 # SlicingStream tests
@@ -466,6 +471,83 @@ def test_ensure_bufferedio():
     assert buffered is not stream
     assert isinstance(buffered, io.BufferedReader)
     assert buffered.read() == b"hello"
+
+
+@pytest.mark.parametrize(
+    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
+)
+@pytest.mark.parametrize(
+    "alternative_packages", [False, True], ids=["default", "altlibs"]
+)
+def test_ensure_bufferedio_with_compressed_stream(
+    sample_archive, sample_archive_path, alternative_packages
+):
+    if alternative_packages:
+        config = ArchiveyConfig(
+            use_rapidgzip=True,
+            use_indexed_bzip2=True,
+            use_python_xz=True,
+            use_zstandard=True,
+        )
+    else:
+        config = ArchiveyConfig()
+
+    skip_if_package_missing(sample_archive.creation_info.format, config)
+
+    with open_compressed_stream(sample_archive_path, config=config) as f:
+        buffered = ensure_bufferedio(f)
+        assert buffered.read() == sample_archive.contents.files[0].contents
+
+    buffer = bytearray(1024)
+    with open_compressed_stream(sample_archive_path, config=config) as f:
+        buffered = ensure_bufferedio(f)
+        bytes_read = buffered.readinto(buffer)
+        assert bytes_read == min(
+            len(buffer), len(sample_archive.contents.files[0].contents)
+        )
+        assert (
+            buffer[:bytes_read]
+            == sample_archive.contents.files[0].contents[:bytes_read]
+        )
+
+
+@pytest.mark.parametrize(
+    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
+)
+@pytest.mark.parametrize(
+    "alternative_packages", [False, True], ids=["default", "altlibs"]
+)
+def test_ensure_bufferedio_with_raw_compressed_stream(
+    sample_archive, sample_archive_path, alternative_packages
+):
+    if alternative_packages:
+        config = ArchiveyConfig(
+            use_rapidgzip=True,
+            use_indexed_bzip2=True,
+            use_python_xz=True,
+            use_zstandard=True,
+        )
+    else:
+        config = ArchiveyConfig()
+
+    skip_if_package_missing(sample_archive.creation_info.format, config)
+
+    open_fn, _ = get_stream_open_fn(sample_archive.creation_info.format, config)
+    with open_fn(sample_archive_path) as f:
+        buffered = ensure_bufferedio(f)
+        assert buffered.read() == sample_archive.contents.files[0].contents
+
+    buffer = bytearray(1024)
+    with open_fn(sample_archive_path) as f:
+        buffered = ensure_bufferedio(f)
+        bytes_read = buffered.readinto(buffer)
+        assert bytes_read == min(
+            len(buffer), len(sample_archive.contents.files[0].contents)
+        )
+        assert (
+            buffer[:bytes_read]
+            == sample_archive.contents.files[0].contents[:bytes_read]
+        )
 
 
 def test_is_stream(tmp_path: Path):

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from archivey.config import ArchiveyConfig
 from archivey.core import open_compressed_stream
 from archivey.formats.compressed_streams import get_stream_open_fn
 from archivey.internal.archive_stream import ArchiveStream
@@ -19,7 +18,7 @@ from archivey.internal.io_helpers import (
     is_stream,
     read_exact,
 )
-from tests.archivey.sample_archives import SINGLE_FILE_ARCHIVES
+from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SINGLE_FILE_ARCHIVES
 from tests.archivey.test_open_nonseekable import NonSeekableBytesIO
 from tests.archivey.testing_utils import skip_if_package_missing
 
@@ -366,12 +365,6 @@ class TestRecordableStream:
         stream.close()
         assert stream.closed
 
-    # def test_delegate_attributes(self):
-    #     inner = Mock(spec=io.BytesIO)
-    #     inner.custom_attr = "test_value"
-    #     stream = RecordableStream(inner)
-    #     assert stream.custom_attr == "test_value"
-
     def test_empty_stream(self):
         inner = io.BytesIO(b"")
         stream = RecordableStream(inner)
@@ -482,15 +475,7 @@ def test_ensure_bufferedio():
 def test_ensure_bufferedio_with_compressed_stream(
     sample_archive, sample_archive_path, alternative_packages
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    config = ALTERNATIVE_CONFIG if alternative_packages else None
 
     skip_if_package_missing(sample_archive.creation_info.format, config)
 
@@ -520,15 +505,7 @@ def test_ensure_bufferedio_with_compressed_stream(
 def test_ensure_bufferedio_with_raw_compressed_stream(
     sample_archive, sample_archive_path, alternative_packages
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    config = ALTERNATIVE_CONFIG if alternative_packages else None
 
     skip_if_package_missing(sample_archive.creation_info.format, config)
 

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -1,75 +1,30 @@
+import logging
 import os
 import shutil
 
 import pytest
 
 from archivey.core import open_archive, open_compressed_stream
+from archivey.exceptions import PackageNotInstalledError
 from archivey.types import ArchiveFormat
-
-from tests.archivey.sample_archives import (
-    BASIC_ARCHIVES,
-    ALTERNATIVE_CONFIG,
-    filter_archives,
-    ArchiveContents,
-    File,
-)
 from tests.archivey.create_archives import (
     SINGLE_FILE_LIBRARY_OPENERS,
-    create_zip_archive_with_zipfile,
-    create_rar_archive_with_command_line,
     create_7z_archive_with_py7zr,
+    create_rar_archive_with_command_line,
+    create_tar_archive_with_tarfile,
+    create_zip_archive_with_zipfile,
 )
+from tests.archivey.sample_archives import (
+    ALTERNATIVE_CONFIG,
+    BASIC_ARCHIVES,
+    SINGLE_FILE_ARCHIVES,
+    ArchiveContents,
+    File,
+    SampleArchive,
+    filter_archives,
+)
+from tests.archivey.test_open_nonseekable import EXPECTED_NON_SEEKABLE_FAILURES
 from tests.archivey.testing_utils import skip_if_package_missing
-from archivey.exceptions import PackageNotInstalledError
-
-# Select a representative archive for each inner format
-INNER_ARCHIVES = {
-    ArchiveFormat.ZIP: filter_archives(BASIC_ARCHIVES, extensions=["zip"])[0],
-    ArchiveFormat.RAR: filter_archives(BASIC_ARCHIVES, extensions=["rar"])[0],
-    ArchiveFormat.SEVENZIP: filter_archives(BASIC_ARCHIVES, extensions=["7z"])[0],
-    ArchiveFormat.TAR: filter_archives(BASIC_ARCHIVES, extensions=["tar"])[0],
-}
-
-# Map compression format to output extension
-COMPRESSION_EXT = {
-    ArchiveFormat.GZIP: ".gz",
-    ArchiveFormat.BZIP2: ".bz2",
-    ArchiveFormat.XZ: ".xz",
-    ArchiveFormat.ZSTD: ".zst",
-    ArchiveFormat.LZ4: ".lz4",
-}
-
-# Extension for archive containers
-ARCHIVE_EXT = {
-    ArchiveFormat.ZIP: ".zip",
-    ArchiveFormat.RAR: ".rar",
-    ArchiveFormat.SEVENZIP: ".7z",
-}
-
-# Pair outer compression formats with inner archives. This ensures all formats
-# appear at least once as outer and inner archives.
-TEST_PAIRS = [
-    (ArchiveFormat.GZIP, INNER_ARCHIVES[ArchiveFormat.ZIP]),
-    (ArchiveFormat.BZIP2, INNER_ARCHIVES[ArchiveFormat.RAR]),
-    (ArchiveFormat.XZ, INNER_ARCHIVES[ArchiveFormat.SEVENZIP]),
-    (ArchiveFormat.ZSTD, INNER_ARCHIVES[ArchiveFormat.TAR]),
-    (ArchiveFormat.LZ4, INNER_ARCHIVES[ArchiveFormat.ZIP]),
-]
-
-PAIR_IDS = [f"{outer.name}_of_{inner.filename}" for outer, inner in TEST_PAIRS]
-
-# Pairs of archive container formats with compressed tar members
-TAR_MEMBER_PAIRS = [
-    (ArchiveFormat.ZIP, filter_archives(BASIC_ARCHIVES, extensions=["tar.gz"])[0]),
-    (ArchiveFormat.RAR, filter_archives(BASIC_ARCHIVES, extensions=["tar.bz2"])[0]),
-    (ArchiveFormat.SEVENZIP, filter_archives(BASIC_ARCHIVES, extensions=["tar.xz"])[0]),
-]
-
-TAR_MEMBER_IDS = [
-    "zip_tar_gz",
-    "rar_tar_bz2",
-    "7z_tar_xz",
-]
 
 
 def compress_file(src: str, dst: str, fmt: ArchiveFormat) -> str:
@@ -85,27 +40,52 @@ def create_archive_with_member(
     outer_format: ArchiveFormat, inner_path: str, dst: str
 ) -> str:
     data = open(inner_path, "rb").read()
-    contents = ArchiveContents(file_basename="outer", files=[File(os.path.basename(inner_path), 1, data)])
+    contents = ArchiveContents(
+        file_basename="outer", files=[File(os.path.basename(inner_path), 1, data)]
+    )
+
     if outer_format == ArchiveFormat.ZIP:
         create_zip_archive_with_zipfile(dst, contents, ArchiveFormat.ZIP)
     elif outer_format == ArchiveFormat.RAR:
         create_rar_archive_with_command_line(dst, contents, ArchiveFormat.RAR)
     elif outer_format == ArchiveFormat.SEVENZIP:
         create_7z_archive_with_py7zr(dst, contents, ArchiveFormat.SEVENZIP)
+    elif outer_format in [
+        ArchiveFormat.TAR_GZ,
+        ArchiveFormat.TAR_BZ2,
+        ArchiveFormat.TAR_XZ,
+        ArchiveFormat.TAR_ZSTD,
+        ArchiveFormat.TAR_LZ4,
+        ArchiveFormat.TAR,
+    ]:
+        create_tar_archive_with_tarfile(dst, contents, outer_format)
     else:
         raise AssertionError(f"Unsupported outer format {outer_format}")
     return dst
 
 
+logger = logging.getLogger(__name__)
+
+
 @pytest.mark.parametrize(
-    "outer_format, inner_archive",
-    TEST_PAIRS,
-    ids=PAIR_IDS,
+    "outer_format",
+    SINGLE_FILE_LIBRARY_OPENERS.keys(),
 )
-@pytest.mark.parametrize("alternative_packages", [False, True], ids=["default", "altlibs"])
+@pytest.mark.parametrize(
+    "inner_archive",
+    filter_archives(
+        BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
+        custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
+    ),
+    # TAR_MEMBER_PAIRS,
+    ids=lambda a: a.filename,
+)
+@pytest.mark.parametrize(
+    "alternative_packages", [False, True], ids=["default", "altlibs"]
+)
 def test_open_archive_from_compressed_stream(
     outer_format: ArchiveFormat,
-    inner_archive,
+    inner_archive: SampleArchive,
     tmp_path,
     alternative_packages: bool,
 ):
@@ -114,12 +94,20 @@ def test_open_archive_from_compressed_stream(
     skip_if_package_missing(outer_format, config)
     skip_if_package_missing(inner_archive.creation_info.format, config)
 
-    if outer_format == ArchiveFormat.XZ and alternative_packages:
-        pytest.xfail("python_xz does not support readinto")
+    if (
+        alternative_packages
+        and outer_format == ArchiveFormat.BZIP2
+        and inner_archive.filename.endswith(".bz2")
+    ):
+        pytest.xfail("prevent segfault")
+
+    logger.info(
+        f"alternative_packages: {alternative_packages}, outer_format: {outer_format}, inner_archive.filename: {inner_archive.filename}"
+    )
 
     inner_path = inner_archive.get_archive_path()
     compressed_path = os.path.join(
-        tmp_path, os.path.basename(inner_path) + COMPRESSION_EXT[outer_format]
+        tmp_path, os.path.basename(inner_path) + "." + outer_format.value
     )
     compress_file(inner_path, compressed_path, outer_format)
 
@@ -135,14 +123,35 @@ def test_open_archive_from_compressed_stream(
 
 
 @pytest.mark.parametrize(
-    "outer_format, inner_archive",
-    TAR_MEMBER_PAIRS,
-    ids=TAR_MEMBER_IDS,
+    "outer_format",
+    [
+        ArchiveFormat.TAR_GZ,
+        ArchiveFormat.TAR_BZ2,
+        ArchiveFormat.TAR_XZ,
+        ArchiveFormat.TAR_ZSTD,
+        ArchiveFormat.TAR_LZ4,
+        ArchiveFormat.TAR,
+        ArchiveFormat.ZIP,
+        ArchiveFormat.RAR,
+        ArchiveFormat.SEVENZIP,
+    ],
+    # ids=TAR_MEMBER_IDS,
 )
-@pytest.mark.parametrize("alternative_packages", [False, True], ids=["default", "altlibs"])
+@pytest.mark.parametrize(
+    "inner_archive",
+    filter_archives(
+        BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
+        custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
+    ),
+    # TAR_MEMBER_PAIRS,
+    ids=lambda a: a.filename,
+)
+@pytest.mark.parametrize(
+    "alternative_packages", [False, True], ids=["default", "altlibs"]
+)
 def test_open_archive_from_member(
     outer_format: ArchiveFormat,
-    inner_archive,
+    inner_archive: SampleArchive,
     tmp_path,
     alternative_packages: bool,
 ):
@@ -151,13 +160,8 @@ def test_open_archive_from_member(
     skip_if_package_missing(outer_format, config)
     skip_if_package_missing(inner_archive.creation_info.format, config)
 
-    if inner_archive.creation_info.format == ArchiveFormat.TAR_XZ and alternative_packages:
-        pytest.xfail("python_xz does not support readinto")
-    if inner_archive.creation_info.format == ArchiveFormat.TAR_GZ and alternative_packages:
-        pytest.xfail("rapidgzip does not support non-seekable streams")
-
     inner_path = inner_archive.get_archive_path()
-    outer_path = os.path.join(tmp_path, "outer" + ARCHIVE_EXT[outer_format])
+    outer_path = os.path.join(tmp_path, "outer." + outer_format.value)
     try:
         create_archive_with_member(outer_format, inner_path, outer_path)
     except PackageNotInstalledError as exc:
@@ -166,6 +170,15 @@ def test_open_archive_from_member(
     with open_archive(outer_path, config=config, streaming_only=True) as outer:
         for member, stream in outer.iter_members_with_streams():
             assert member.filename.endswith(os.path.basename(inner_path))
+            assert stream is not None
+
+            if (
+                not stream.seekable()
+                and (inner_archive.creation_info.format, alternative_packages)
+                in EXPECTED_NON_SEEKABLE_FAILURES
+            ):
+                pytest.xfail("Non-seekable stream not supported")
+
             with open_archive(stream, config=config, streaming_only=True) as archive:
                 assert archive.format == inner_archive.creation_info.format
                 for _ in archive.iter_members_with_streams():

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -1,0 +1,173 @@
+import os
+import shutil
+
+import pytest
+
+from archivey.core import open_archive, open_compressed_stream
+from archivey.types import ArchiveFormat
+
+from tests.archivey.sample_archives import (
+    BASIC_ARCHIVES,
+    ALTERNATIVE_CONFIG,
+    filter_archives,
+    ArchiveContents,
+    File,
+)
+from tests.archivey.create_archives import (
+    SINGLE_FILE_LIBRARY_OPENERS,
+    create_zip_archive_with_zipfile,
+    create_rar_archive_with_command_line,
+    create_7z_archive_with_py7zr,
+)
+from tests.archivey.testing_utils import skip_if_package_missing
+from archivey.exceptions import PackageNotInstalledError
+
+# Select a representative archive for each inner format
+INNER_ARCHIVES = {
+    ArchiveFormat.ZIP: filter_archives(BASIC_ARCHIVES, extensions=["zip"])[0],
+    ArchiveFormat.RAR: filter_archives(BASIC_ARCHIVES, extensions=["rar"])[0],
+    ArchiveFormat.SEVENZIP: filter_archives(BASIC_ARCHIVES, extensions=["7z"])[0],
+    ArchiveFormat.TAR: filter_archives(BASIC_ARCHIVES, extensions=["tar"])[0],
+}
+
+# Map compression format to output extension
+COMPRESSION_EXT = {
+    ArchiveFormat.GZIP: ".gz",
+    ArchiveFormat.BZIP2: ".bz2",
+    ArchiveFormat.XZ: ".xz",
+    ArchiveFormat.ZSTD: ".zst",
+    ArchiveFormat.LZ4: ".lz4",
+}
+
+# Extension for archive containers
+ARCHIVE_EXT = {
+    ArchiveFormat.ZIP: ".zip",
+    ArchiveFormat.RAR: ".rar",
+    ArchiveFormat.SEVENZIP: ".7z",
+}
+
+# Pair outer compression formats with inner archives. This ensures all formats
+# appear at least once as outer and inner archives.
+TEST_PAIRS = [
+    (ArchiveFormat.GZIP, INNER_ARCHIVES[ArchiveFormat.ZIP]),
+    (ArchiveFormat.BZIP2, INNER_ARCHIVES[ArchiveFormat.RAR]),
+    (ArchiveFormat.XZ, INNER_ARCHIVES[ArchiveFormat.SEVENZIP]),
+    (ArchiveFormat.ZSTD, INNER_ARCHIVES[ArchiveFormat.TAR]),
+    (ArchiveFormat.LZ4, INNER_ARCHIVES[ArchiveFormat.ZIP]),
+]
+
+PAIR_IDS = [f"{outer.name}_of_{inner.filename}" for outer, inner in TEST_PAIRS]
+
+# Pairs of archive container formats with compressed tar members
+TAR_MEMBER_PAIRS = [
+    (ArchiveFormat.ZIP, filter_archives(BASIC_ARCHIVES, extensions=["tar.gz"])[0]),
+    (ArchiveFormat.RAR, filter_archives(BASIC_ARCHIVES, extensions=["tar.bz2"])[0]),
+    (ArchiveFormat.SEVENZIP, filter_archives(BASIC_ARCHIVES, extensions=["tar.xz"])[0]),
+]
+
+TAR_MEMBER_IDS = [
+    "zip_tar_gz",
+    "rar_tar_bz2",
+    "7z_tar_xz",
+]
+
+
+def compress_file(src: str, dst: str, fmt: ArchiveFormat) -> str:
+    opener = SINGLE_FILE_LIBRARY_OPENERS.get(fmt)
+    if opener is None:
+        pytest.skip(f"Required library for {fmt.name} is not installed")
+    with open(src, "rb") as f_in, opener(dst, "wb") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return dst
+
+
+def create_archive_with_member(
+    outer_format: ArchiveFormat, inner_path: str, dst: str
+) -> str:
+    data = open(inner_path, "rb").read()
+    contents = ArchiveContents(file_basename="outer", files=[File(os.path.basename(inner_path), 1, data)])
+    if outer_format == ArchiveFormat.ZIP:
+        create_zip_archive_with_zipfile(dst, contents, ArchiveFormat.ZIP)
+    elif outer_format == ArchiveFormat.RAR:
+        create_rar_archive_with_command_line(dst, contents, ArchiveFormat.RAR)
+    elif outer_format == ArchiveFormat.SEVENZIP:
+        create_7z_archive_with_py7zr(dst, contents, ArchiveFormat.SEVENZIP)
+    else:
+        raise AssertionError(f"Unsupported outer format {outer_format}")
+    return dst
+
+
+@pytest.mark.parametrize(
+    "outer_format, inner_archive",
+    TEST_PAIRS,
+    ids=PAIR_IDS,
+)
+@pytest.mark.parametrize("alternative_packages", [False, True], ids=["default", "altlibs"])
+def test_open_archive_from_compressed_stream(
+    outer_format: ArchiveFormat,
+    inner_archive,
+    tmp_path,
+    alternative_packages: bool,
+):
+    config = ALTERNATIVE_CONFIG if alternative_packages else None
+
+    skip_if_package_missing(outer_format, config)
+    skip_if_package_missing(inner_archive.creation_info.format, config)
+
+    if outer_format == ArchiveFormat.XZ and alternative_packages:
+        pytest.xfail("python_xz does not support readinto")
+
+    inner_path = inner_archive.get_archive_path()
+    compressed_path = os.path.join(
+        tmp_path, os.path.basename(inner_path) + COMPRESSION_EXT[outer_format]
+    )
+    compress_file(inner_path, compressed_path, outer_format)
+
+    with open_compressed_stream(compressed_path, config=config) as stream:
+        with open_archive(stream, config=config, streaming_only=True) as archive:
+            assert archive.format == inner_archive.creation_info.format
+            has_member = False
+            for _, member_stream in archive.iter_members_with_streams():
+                has_member = True
+                if member_stream is not None:
+                    member_stream.read()
+            assert has_member
+
+
+@pytest.mark.parametrize(
+    "outer_format, inner_archive",
+    TAR_MEMBER_PAIRS,
+    ids=TAR_MEMBER_IDS,
+)
+@pytest.mark.parametrize("alternative_packages", [False, True], ids=["default", "altlibs"])
+def test_open_archive_from_member(
+    outer_format: ArchiveFormat,
+    inner_archive,
+    tmp_path,
+    alternative_packages: bool,
+):
+    config = ALTERNATIVE_CONFIG if alternative_packages else None
+
+    skip_if_package_missing(outer_format, config)
+    skip_if_package_missing(inner_archive.creation_info.format, config)
+
+    if inner_archive.creation_info.format == ArchiveFormat.TAR_XZ and alternative_packages:
+        pytest.xfail("python_xz does not support readinto")
+    if inner_archive.creation_info.format == ArchiveFormat.TAR_GZ and alternative_packages:
+        pytest.xfail("rapidgzip does not support non-seekable streams")
+
+    inner_path = inner_archive.get_archive_path()
+    outer_path = os.path.join(tmp_path, "outer" + ARCHIVE_EXT[outer_format])
+    try:
+        create_archive_with_member(outer_format, inner_path, outer_path)
+    except PackageNotInstalledError as exc:
+        pytest.skip(str(exc))
+
+    with open_archive(outer_path, config=config, streaming_only=True) as outer:
+        for member, stream in outer.iter_members_with_streams():
+            assert member.filename.endswith(os.path.basename(inner_path))
+            with open_archive(stream, config=config, streaming_only=True) as archive:
+                assert archive.format == inner_archive.creation_info.format
+                for _ in archive.iter_members_with_streams():
+                    break
+            break


### PR DESCRIPTION
## Summary
- add regression tests for archives nested inside single-file compression
- pair all compression formats with representative inner archives
- ensure altlibs xz is xfailed due to missing readinto support
- verify nested archives within archive containers (tar.gz in zip, tar.bz2 in rar, tar.xz in 7z)

## Testing
- `uv run --extra optional pytest -q tests/archivey/test_nested_compressed_archives.py -q`
- `uv run --extra optional pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858db65af0832db3ab60e0d7697143