### PR TITLE
Fix py3.13-oldlibs segfault by updating deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,8 @@ deps =
     newlibs: lz4==4.4.4
     newlibs: zstandard==0.23.0
     newlibs: cryptography==45.0.3
-    newlibs: rapidgzip==0.14.3
-    newlibs: indexed_bzip2==1.6.0
+    newlibs: rapidgzip==0.14.5
+    newlibs: indexed_bzip2==1.7.0
     newlibs: python-xz==0.5.0
 
     freethreaded: .[optional-freethreaded]
@@ -51,8 +51,8 @@ deps =
     oldlibs: lz4==4.0.0
     oldlibs: zstandard==0.17.0
     oldlibs: cryptography==37.0.0
-    oldlibs: rapidgzip==0.14.3
-    oldlibs: indexed_bzip2==1.6.0
+    oldlibs: rapidgzip==0.14.4
+    oldlibs: indexed_bzip2==1.7.0
     oldlibs: python-xz==0.3.0
 
     nolibs:


### PR DESCRIPTION
## Summary
- bump rapidgzip and indexed_bzip2 versions in tox.ini

## Testing
- `uv run --extra optional pytest`
- `tox -e py3.13-oldlibs -vv -- -k test_open_archive_from_compressed_stream -x`

------
https://chatgpt.com/codex/tasks/task_e_6886aea8c740832d96b439013d11994d