### PR TITLE
Add uncompresspy to dependency checker

### DIFF
--- a/src/archivey/internal/dependency_checker.py
+++ b/src/archivey/internal/dependency_checker.py
@@ -20,6 +20,7 @@ class DependencyVersions:
     rapidgzip_version: Optional[str] = None
     indexed_bzip2_version: Optional[str] = None
     python_xz_version: Optional[str] = None
+    uncompresspy_version: Optional[str] = None
     unrar_version: Optional[str] = None
     pyzstd_version: Optional[str] = None
 
@@ -47,6 +48,7 @@ def get_dependency_versions() -> DependencyVersions:
         ("rapidgzip", "rapidgzip_version"),
         ("indexed_bzip2", "indexed_bzip2_version"),
         ("python-xz", "python_xz_version"),
+        ("uncompresspy", "uncompresspy_version"),
         ("pyzstd", "pyzstd_version"),
     ]:
         try:

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -59,6 +59,10 @@ BASIC_XZ_ARCHIVE = filter_archives(
     SAMPLE_ARCHIVES, prefixes=["single_file"], extensions=["xz"]
 )[0]
 
+BASIC_UNIX_COMPRESS_ARCHIVE = filter_archives(
+    SAMPLE_ARCHIVES, prefixes=["single_file"], extensions=["Z"]
+)[0]
+
 
 @pytest.mark.parametrize(
     ["library_name", "sample_archive", "alternative_packages"],
@@ -72,6 +76,7 @@ BASIC_XZ_ARCHIVE = filter_archives(
         ("pyzstd", BASIC_ZSTD_ARCHIVE, False),
         ("zstandard", BASIC_ZSTD_ARCHIVE, True),
         ("lz4", BASIC_LZ4_ARCHIVE, False),
+        ("uncompresspy", BASIC_UNIX_COMPRESS_ARCHIVE, False),
     ],
     ids=lambda x: os.path.basename(x) if isinstance(x, str) else x,
 )


### PR DESCRIPTION
## Summary
- include uncompresspy in the optional dependency list
- cover uncompresspy in missing package tests

## Testing
- `uv run --extra optional pytest`

------
https://chatgpt.com/codex/tasks/task_e_688981a0bef4832dab6ef0c13c7b4226