### PR TITLE
docs: document hatch lint and test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,29 +9,40 @@ versions and dependency sets (`tox -e <env>`).  Continuous integration executes
 these tox environments via the workflow in `.github/workflows/tox-tests.yml`.
 
 To help development, install **uv** and **hatch**. Also install the **unrar** tool
-and install tox via `uv` with the `tox-uv` plugin:
+and Node.js (required for `npx pyright` in the lint script). Install tox via `uv`
+with the `tox-uv` plugin:
 
 ```bash
 pip install uv hatch
 uv tool install tox --with tox-uv
-sudo apt-get install -y unrar
+sudo apt-get install -y unrar nodejs npm
 ```
 
 If you can't install unrar, the RAR-related tests may fail; just ignore them.
 
-## Running the tests
+## Linting and running tests
 
-To run the tests:
+Use the Hatch scripts defined in `pyproject.toml`.
+
+To run the linters (ruff and pyright):
 
 ```bash
-uv run --extra optional pytest
+hatch run lint
 ```
 
-To run a specific test or a subset of tests, pass `-k` with a pattern. For
-example, to run only tests related to zip archives:
+On the first run `npx` will download Pyright; accept the prompt if asked.
+
+To run the full test suite:
 
 ```bash
-uv run --extra optional pytest -k .zip
+hatch run test
+```
+
+To run a specific test or subset of tests, pass `-k` with a pattern. For example,
+to run only tests related to zip archives:
+
+```bash
+hatch run test -k .zip
 ```
 
 ## Updating test files

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -164,19 +164,30 @@ Tips:
 *   **Testing:** It's highly recommended to write tests that specifically trigger various error conditions in the underlying library to ensure your translator handles them correctly. This might involve creating corrupted or specially crafted archive files, passing wrong passwords etc. See the Testing section below.
 
 
-## Testing
+## Linting
 
-To run the full test suite use the same command as in CI:
+Ensure [Hatch](https://hatch.pypa.io/) and [uv](https://docs.astral.sh/uv/) are installed. The lint script runs
+[Ruff](https://docs.astral.sh/ruff/) and [Pyright](https://github.com/microsoft/pyright); the latter is executed via `npx`, so
+Node.js and `npm` must be available. Run the linters with:
 
 ```bash
-uv run --extra optional pytest
+hatch run lint
 ```
 
-You can run a subset of tests with the `-k` option, e.g. to run only ZIP related
-tests:
+On the first run `npx` may ask to download Pyright – answer `y` to continue.
+
+## Testing
+
+Run the tests through Hatch, which executes `pytest` via `uv` with the optional dependencies enabled:
 
 ```bash
-uv run --extra optional pytest -k .zip
+hatch run test
+```
+
+You can run a subset of tests with the `-k` option, e.g. to run only ZIP related tests:
+
+```bash
+hatch run test -k .zip
 ```
 
 Sample archives used by the tests are versioned in `tests/test_archives`.  If


### PR DESCRIPTION
## Summary
- document Node.js requirement and use of Hatch scripts for linting and tests
- note how to invoke `hatch run lint` and `hatch run test` in developer guide

## Testing
- `hatch run lint`
- `hatch run test tests/archivey/test_cli.py::test_cli_list`

------
https://chatgpt.com/codex/tasks/task_e_688d2c73cda0832d8735a1a89fcc3cfd