### PR TITLE
Jules: Refactor ArchiveFormat

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,8 @@
       - ArchiveInfo
       - ArchiveMember
       - ArchiveFormat
+      - ContainerFormat
+      - StreamFormat
       - MemberType
       - ExtractionFilter
       - ArchiveyConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dependencies = [
 features = ["optional"]
 
 [tool.hatch.envs.default.scripts]
-lint = "ruff check --fix . && ruff format . && npx pyright ."
+lint = "ruff check --fix . && ruff format . && npx pyright . && python scripts/check_api_doc.py"
 test = "uv run pytest --workers auto {args}"
 docs = "sh docs/generate_api_docs.sh"
 pyrefly = "uvx pyrefly check src/"

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -11,8 +11,10 @@ from archivey.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    ContainerFormat,
     ExtractionFilter,
     MemberType,
+    StreamFormat,
 )
 
 __all__ = [
@@ -24,6 +26,8 @@ __all__ = [
     "ArchiveMember",
     # Enums
     "ArchiveFormat",
+    "ContainerFormat",
+    "StreamFormat",
     "MemberType",
     "ExtractionFilter",
     # Config

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -24,11 +24,7 @@ from archivey.internal.io_helpers import (
     is_stream,
 )
 from archivey.internal.utils import ensure_not_none
-from archivey.types import (
-    SINGLE_FILE_COMPRESSED_FORMATS,
-    TAR_COMPRESSED_FORMATS,
-    ArchiveFormat,
-)
+from archivey.types import ArchiveFormat, ContainerFormat
 
 
 def _normalize_path_or_stream(
@@ -52,13 +48,23 @@ _FORMAT_TO_READER: dict[ArchiveFormat, Callable[..., ArchiveReader]] = {
     ArchiveFormat.SEVENZIP: SevenZipReader,
     ArchiveFormat.TAR: TarReader,
     ArchiveFormat.FOLDER: FolderReader,
+    # Compressed TAR formats
+    ArchiveFormat.TAR_GZ: TarReader,
+    ArchiveFormat.TAR_BZ2: TarReader,
+    ArchiveFormat.TAR_XZ: TarReader,
+    ArchiveFormat.TAR_ZSTD: TarReader,
+    ArchiveFormat.TAR_LZ4: TarReader,
+    ArchiveFormat.TAR_Z: TarReader,
+    # Single file compressed formats
+    ArchiveFormat.GZIP: SingleFileReader,
+    ArchiveFormat.BZIP2: SingleFileReader,
+    ArchiveFormat.XZ: SingleFileReader,
+    ArchiveFormat.ZSTD: SingleFileReader,
+    ArchiveFormat.LZ4: SingleFileReader,
+    ArchiveFormat.ZLIB: SingleFileReader,
+    ArchiveFormat.BROTLI: SingleFileReader,
+    ArchiveFormat.UNIX_COMPRESS: SingleFileReader,
 }
-
-for format in TAR_COMPRESSED_FORMATS:
-    _FORMAT_TO_READER[format] = TarReader
-
-for format in SINGLE_FILE_COMPRESSED_FORMATS:
-    _FORMAT_TO_READER[format] = SingleFileReader
 
 
 def open_archive(
@@ -240,7 +246,7 @@ def open_compressed_stream(
     if rewindable_wrapper is not None:
         stream = rewindable_wrapper.get_rewinded_stream()
 
-    if format not in SINGLE_FILE_COMPRESSED_FORMATS:
+    if format.container != ContainerFormat.RAW_STREAM:
         raise ArchiveNotSupportedError(
             f"Unsupported single-file compressed format: {format}"
         )

--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -17,7 +17,7 @@ from archivey.internal.io_helpers import (
     is_seekable,
     is_stream,
 )
-from archivey.types import ArchiveFormat
+from archivey.types import StreamFormat
 
 if TYPE_CHECKING:
     import brotli
@@ -592,47 +592,47 @@ def open_uncompresspy_stream(path: str | BinaryIO) -> BinaryIO:
 
 
 def get_stream_open_fn(
-    format: ArchiveFormat, config: ArchiveyConfig | None = None
+    format: StreamFormat, config: ArchiveyConfig | None = None
 ) -> tuple[Callable[[str | BinaryIO], BinaryIO], ExceptionTranslatorFn]:
     if config is None:
         config = get_archivey_config()
-    if format == ArchiveFormat.GZIP:
+    if format == StreamFormat.GZIP:
         if config.use_rapidgzip:
             return open_rapidgzip_stream, _translate_rapidgzip_exception
         return open_gzip_stream, _translate_gzip_exception
 
-    if format == ArchiveFormat.BZIP2:
+    if format == StreamFormat.BZIP2:
         if config.use_indexed_bzip2:
             return open_indexed_bzip2_stream, _translate_indexed_bzip2_exception
         return open_bzip2_stream, _translate_bz2_exception
 
-    if format == ArchiveFormat.XZ:
+    if format == StreamFormat.XZ:
         if config.use_python_xz:
             return open_python_xz_stream, _translate_python_xz_exception
         return open_lzma_stream, _translate_lzma_exception
 
-    if format == ArchiveFormat.LZ4:
+    if format == StreamFormat.LZ4:
         return open_lz4_stream, _translate_lz4_exception
 
-    if format == ArchiveFormat.ZLIB:
+    if format == StreamFormat.ZLIB:
         return open_zlib_stream, _translate_zlib_exception
 
-    if format == ArchiveFormat.BROTLI:
+    if format == StreamFormat.BROTLI:
         return open_brotli_stream, _translate_brotli_exception
 
-    if format == ArchiveFormat.ZSTD:
+    if format == StreamFormat.ZSTD:
         if config.use_zstandard:
             return open_zstandard_stream, _translate_zstandard_exception
         return open_pyzstd_stream, _translate_pyzstd_exception
 
-    if format == ArchiveFormat.UNIX_COMPRESS:
+    if format == StreamFormat.UNIX_COMPRESS:
         return open_uncompresspy_stream, _translate_uncompresspy_exception
 
     raise ValueError(f"Unsupported archive format: {format}")  # pragma: no cover
 
 
 def open_stream(
-    format: ArchiveFormat,
+    format: StreamFormat,
     path_or_stream: str | BinaryIO,
     config: ArchiveyConfig,
 ) -> BinaryIO:

--- a/src/archivey/formats/format_detection.py
+++ b/src/archivey/formats/format_detection.py
@@ -29,7 +29,7 @@ else:
         brotli = None  # type: ignore[assignment]
 
 # Taken from the pycdlib code
-_ISO_MAGIC_BYTES = (
+_ISO_MAGIC_BYTES = [
     b"CD001",
     b"CDW02",
     b"BEA01",
@@ -37,7 +37,7 @@ _ISO_MAGIC_BYTES = (
     b"NSR03",
     b"TEA01",
     b"BOOT2",
-)
+]
 
 
 def _is_executable(stream: IO[bytes]) -> bool:
@@ -65,7 +65,7 @@ def is_uncompressed_tarfile(stream: IO[bytes]) -> bool:
 
 
 # [signature, ...], offset, format
-SIGNATURES = [
+SIGNATURES: list[tuple[list[bytes], int, ArchiveFormat]] = [
     ([b"\x50\x4b\x03\x04"], 0, ArchiveFormat.ZIP),
     (
         [
@@ -130,7 +130,7 @@ def detect_archive_format_by_signature(
         return ArchiveFormat.FOLDER
 
     with open_if_file(path_or_file) as f:
-        detected_format = None
+        detected_format: ArchiveFormat | None = None
         for magics, offset, fmt in SIGNATURES:
             bytes_to_read = max(len(magic) for magic in magics)
             f.seek(offset)
@@ -146,11 +146,10 @@ def detect_archive_format_by_signature(
             detect_compressed_tar
             and detected_format is not None
             and detected_format.container == ContainerFormat.RAW_STREAM
-            and detected_format.stream is not None
         ):
             assert detected_format is not None
             with open_stream(
-                detected_format, f, get_archivey_config()
+                detected_format.stream, f, get_archivey_config()
             ) as decompressed_stream:
                 if is_uncompressed_tarfile(decompressed_stream):
                     detected_format = ArchiveFormat(

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -282,7 +282,7 @@ class SingleFileReader(BaseArchiveReader):
         # To avoid opening the file twice, we'll store the reference and return it
         # on the first open() call.
         self._opener, self._exception_translator = get_stream_open_fn(
-            self.format, self.config
+            self.format.stream, self.config
         )
 
         self.fileobj: BinaryIO | None = run_with_exception_translation(

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -20,10 +20,10 @@ from archivey.internal.io_helpers import (  # Updated import
 
 # from archivey.internal.utils import open_if_file # Removed
 from archivey.types import (
-    SINGLE_FILE_COMPRESSED_FORMATS,
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    ContainerFormat,
     CreateSystem,
     MemberType,
 )
@@ -225,7 +225,7 @@ class SingleFileReader(BaseArchiveReader):
             format: The format of the archive. If None, will be detected from the file extension.
             **kwargs: Additional options (ignored)
         """
-        if format not in SINGLE_FILE_COMPRESSED_FORMATS:
+        if format.container != ContainerFormat.RAW_STREAM:
             raise ValueError(f"Unsupported archive format: {format}")
 
         if pwd is not None:
@@ -268,7 +268,7 @@ class SingleFileReader(BaseArchiveReader):
             compress_size=compress_size,
             mtime_with_tz=mtime,
             type=MemberType.FILE,
-            compression_method=self.format.value,
+            compression_method=self.format.file_extension(),
             crc32=None,
         )
 

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -79,10 +79,9 @@ class TarReader(BaseArchiveReader):
             streaming_only,
         )
 
-        if format.stream and format.stream != StreamFormat.UNCOMPRESSED:
+        if format.stream != StreamFormat.UNCOMPRESSED:
             self.compression_method = str(format.stream.value)
-            stream_format = ArchiveFormat(ContainerFormat.RAW_STREAM, format.stream)
-            self._fileobj = open_stream(stream_format, archive_path, self.config)
+            self._fileobj = open_stream(format.stream, archive_path, self.config)
             self._close_fileobj = True
             logger.debug(
                 "Compressed tar opened: %s seekable=%s",

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -54,9 +54,24 @@ class StreamFormat(StrEnum):
     UNCOMPRESSED = "uncompressed"
 
 
-@dataclass(eq=True)
+@dataclass(frozen=True)
 class ArchiveFormat:
     """Supported archive and compression formats."""
+
+    container: ContainerFormat
+    stream: StreamFormat
+
+    def file_extension(self) -> str:
+        """Return the file extension for the archive format."""
+        parts = []
+        if self.container != ContainerFormat.RAW_STREAM:
+            parts.append(self.container.value)
+        if self.stream != StreamFormat.UNCOMPRESSED:
+            parts.append(self.stream.value)
+        return ".".join(parts)
+
+    def __str__(self) -> str:
+        return self.file_extension()
 
     ZIP: ClassVar["ArchiveFormat"]
     RAR: ClassVar["ArchiveFormat"]
@@ -80,36 +95,13 @@ class ArchiveFormat:
     FOLDER: ClassVar["ArchiveFormat"]
     UNKNOWN: ClassVar["ArchiveFormat"]
 
-    container: ContainerFormat
-    stream: Optional[StreamFormat] = None
-
-    def file_extension(self) -> str:
-        """Return the file extension for the archive format."""
-        if (
-            self.container == ContainerFormat.TAR
-            and self.stream
-            and self.stream != StreamFormat.UNCOMPRESSED
-        ):
-            return f"{self.container.value}.{self.stream.value}"
-        if (
-            self.container == ContainerFormat.RAW_STREAM
-            and self.stream
-            and self.stream != StreamFormat.UNCOMPRESSED
-        ):
-            return self.stream.value
-        return self.container.value
-
-    def __str__(self) -> str:
-        return self.file_extension()
-
-    def __hash__(self) -> int:
-        return hash((self.container, self.stream))
-
 
 # For backward compatibility
-ArchiveFormat.ZIP = ArchiveFormat(ContainerFormat.ZIP)
-ArchiveFormat.RAR = ArchiveFormat(ContainerFormat.RAR)
-ArchiveFormat.SEVENZIP = ArchiveFormat(ContainerFormat.SEVENZIP)
+ArchiveFormat.ZIP = ArchiveFormat(ContainerFormat.ZIP, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.RAR = ArchiveFormat(ContainerFormat.RAR, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.SEVENZIP = ArchiveFormat(
+    ContainerFormat.SEVENZIP, StreamFormat.UNCOMPRESSED
+)
 ArchiveFormat.GZIP = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.GZIP)
 ArchiveFormat.BZIP2 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BZIP2)
 ArchiveFormat.XZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.XZ)
@@ -120,16 +112,18 @@ ArchiveFormat.BROTLI = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BR
 ArchiveFormat.UNIX_COMPRESS = ArchiveFormat(
     ContainerFormat.RAW_STREAM, StreamFormat.UNIX_COMPRESS
 )
-ArchiveFormat.TAR = ArchiveFormat(ContainerFormat.TAR)
+ArchiveFormat.TAR = ArchiveFormat(ContainerFormat.TAR, StreamFormat.UNCOMPRESSED)
 ArchiveFormat.TAR_GZ = ArchiveFormat(ContainerFormat.TAR, StreamFormat.GZIP)
 ArchiveFormat.TAR_BZ2 = ArchiveFormat(ContainerFormat.TAR, StreamFormat.BZIP2)
 ArchiveFormat.TAR_XZ = ArchiveFormat(ContainerFormat.TAR, StreamFormat.XZ)
 ArchiveFormat.TAR_ZSTD = ArchiveFormat(ContainerFormat.TAR, StreamFormat.ZSTD)
 ArchiveFormat.TAR_LZ4 = ArchiveFormat(ContainerFormat.TAR, StreamFormat.LZ4)
 ArchiveFormat.TAR_Z = ArchiveFormat(ContainerFormat.TAR, StreamFormat.UNIX_COMPRESS)
-ArchiveFormat.ISO = ArchiveFormat(ContainerFormat.ISO)
-ArchiveFormat.FOLDER = ArchiveFormat(ContainerFormat.FOLDER)
-ArchiveFormat.UNKNOWN = ArchiveFormat(ContainerFormat.UNKNOWN)
+ArchiveFormat.ISO = ArchiveFormat(ContainerFormat.ISO, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.FOLDER = ArchiveFormat(ContainerFormat.FOLDER, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.UNKNOWN = ArchiveFormat(
+    ContainerFormat.UNKNOWN, StreamFormat.UNCOMPRESSED
+)
 
 
 class MemberType(StrEnum):

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -24,15 +24,48 @@ else:
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import IntEnum
-from typing import Any, Optional, Tuple
+from typing import Any, ClassVar, Optional, Tuple
 
 
-class ArchiveFormat(StrEnum):
-    """Supported archive and compression formats."""
+class _ArchiveFormatBase:
+    ZIP: ClassVar["ArchiveFormat"]
+    RAR: ClassVar["ArchiveFormat"]
+    SEVENZIP: ClassVar["ArchiveFormat"]
+    GZIP: ClassVar["ArchiveFormat"]
+    BZIP2: ClassVar["ArchiveFormat"]
+    XZ: ClassVar["ArchiveFormat"]
+    ZSTD: ClassVar["ArchiveFormat"]
+    LZ4: ClassVar["ArchiveFormat"]
+    ZLIB: ClassVar["ArchiveFormat"]
+    BROTLI: ClassVar["ArchiveFormat"]
+    UNIX_COMPRESS: ClassVar["ArchiveFormat"]
+    TAR: ClassVar["ArchiveFormat"]
+    TAR_GZ: ClassVar["ArchiveFormat"]
+    TAR_BZ2: ClassVar["ArchiveFormat"]
+    TAR_XZ: ClassVar["ArchiveFormat"]
+    TAR_ZSTD: ClassVar["ArchiveFormat"]
+    TAR_LZ4: ClassVar["ArchiveFormat"]
+    TAR_Z: ClassVar["ArchiveFormat"]
+    ISO: ClassVar["ArchiveFormat"]
+    FOLDER: ClassVar["ArchiveFormat"]
+    UNKNOWN: ClassVar["ArchiveFormat"]
+
+
+class ContainerFormat(StrEnum):
+    """Supported container formats."""
 
     ZIP = "zip"
     RAR = "rar"
     SEVENZIP = "7z"
+    TAR = "tar"
+    ISO = "iso"
+    FOLDER = "folder"
+    RAW_STREAM = "raw_stream"
+    UNKNOWN = "unknown"
+
+
+class StreamFormat(StrEnum):
+    """Supported stream formats."""
 
     GZIP = "gz"
     BZIP2 = "bz2"
@@ -42,45 +75,63 @@ class ArchiveFormat(StrEnum):
     ZLIB = "zz"
     BROTLI = "br"
     UNIX_COMPRESS = "Z"
-
-    TAR = "tar"
-    TAR_GZ = "tar.gz"
-    TAR_BZ2 = "tar.bz2"
-    TAR_XZ = "tar.xz"
-    TAR_ZSTD = "tar.zstd"
-    TAR_LZ4 = "tar.lz4"
-    TAR_Z = "tar.Z"
-
-    ISO = "iso"
-    FOLDER = "folder"
-
-    UNKNOWN = "unknown"
+    UNCOMPRESSED = "uncompressed"
 
 
-SINGLE_FILE_COMPRESSED_FORMATS = [
-    ArchiveFormat.GZIP,
-    ArchiveFormat.BZIP2,
-    ArchiveFormat.XZ,
-    ArchiveFormat.ZSTD,
-    ArchiveFormat.LZ4,
-    ArchiveFormat.ZLIB,
-    ArchiveFormat.BROTLI,
-    ArchiveFormat.UNIX_COMPRESS,
-]
+@dataclass(eq=True)
+class ArchiveFormat(_ArchiveFormatBase):
+    """Supported archive and compression formats."""
 
-COMPRESSION_FORMAT_TO_TAR_FORMAT = {
-    ArchiveFormat.GZIP: ArchiveFormat.TAR_GZ,
-    ArchiveFormat.BZIP2: ArchiveFormat.TAR_BZ2,
-    ArchiveFormat.XZ: ArchiveFormat.TAR_XZ,
-    ArchiveFormat.ZSTD: ArchiveFormat.TAR_ZSTD,
-    ArchiveFormat.LZ4: ArchiveFormat.TAR_LZ4,
-    ArchiveFormat.UNIX_COMPRESS: ArchiveFormat.TAR_Z,
-}
-TAR_COMPRESSED_FORMATS = list(COMPRESSION_FORMAT_TO_TAR_FORMAT.values())
+    container: ContainerFormat
+    stream: Optional[StreamFormat] = None
 
-TAR_FORMAT_TO_COMPRESSION_FORMAT = {
-    v: k for k, v in COMPRESSION_FORMAT_TO_TAR_FORMAT.items()
-}
+    def file_extension(self) -> str:
+        """Return the file extension for the archive format."""
+        if (
+            self.container == ContainerFormat.TAR
+            and self.stream
+            and self.stream != StreamFormat.UNCOMPRESSED
+        ):
+            return f"{self.container.value}.{self.stream.value}"
+        if (
+            self.container == ContainerFormat.RAW_STREAM
+            and self.stream
+            and self.stream != StreamFormat.UNCOMPRESSED
+        ):
+            return self.stream.value
+        return self.container.value
+
+    def __str__(self) -> str:
+        return self.file_extension()
+
+    def __hash__(self) -> int:
+        return hash((self.container, self.stream))
+
+
+# For backward compatibility
+ArchiveFormat.ZIP = ArchiveFormat(ContainerFormat.ZIP)
+ArchiveFormat.RAR = ArchiveFormat(ContainerFormat.RAR)
+ArchiveFormat.SEVENZIP = ArchiveFormat(ContainerFormat.SEVENZIP)
+ArchiveFormat.GZIP = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.GZIP)
+ArchiveFormat.BZIP2 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BZIP2)
+ArchiveFormat.XZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.XZ)
+ArchiveFormat.ZSTD = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZSTD)
+ArchiveFormat.LZ4 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.LZ4)
+ArchiveFormat.ZLIB = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZLIB)
+ArchiveFormat.BROTLI = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BROTLI)
+ArchiveFormat.UNIX_COMPRESS = ArchiveFormat(
+    ContainerFormat.RAW_STREAM, StreamFormat.UNIX_COMPRESS
+)
+ArchiveFormat.TAR = ArchiveFormat(ContainerFormat.TAR)
+ArchiveFormat.TAR_GZ = ArchiveFormat(ContainerFormat.TAR, StreamFormat.GZIP)
+ArchiveFormat.TAR_BZ2 = ArchiveFormat(ContainerFormat.TAR, StreamFormat.BZIP2)
+ArchiveFormat.TAR_XZ = ArchiveFormat(ContainerFormat.TAR, StreamFormat.XZ)
+ArchiveFormat.TAR_ZSTD = ArchiveFormat(ContainerFormat.TAR, StreamFormat.ZSTD)
+ArchiveFormat.TAR_LZ4 = ArchiveFormat(ContainerFormat.TAR, StreamFormat.LZ4)
+ArchiveFormat.TAR_Z = ArchiveFormat(ContainerFormat.TAR, StreamFormat.UNIX_COMPRESS)
+ArchiveFormat.ISO = ArchiveFormat(ContainerFormat.ISO)
+ArchiveFormat.FOLDER = ArchiveFormat(ContainerFormat.FOLDER)
+ArchiveFormat.UNKNOWN = ArchiveFormat(ContainerFormat.UNKNOWN)
 
 
 class MemberType(StrEnum):

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -27,30 +27,6 @@ from enum import IntEnum
 from typing import Any, ClassVar, Optional, Tuple
 
 
-class _ArchiveFormatBase:
-    ZIP: ClassVar["ArchiveFormat"]
-    RAR: ClassVar["ArchiveFormat"]
-    SEVENZIP: ClassVar["ArchiveFormat"]
-    GZIP: ClassVar["ArchiveFormat"]
-    BZIP2: ClassVar["ArchiveFormat"]
-    XZ: ClassVar["ArchiveFormat"]
-    ZSTD: ClassVar["ArchiveFormat"]
-    LZ4: ClassVar["ArchiveFormat"]
-    ZLIB: ClassVar["ArchiveFormat"]
-    BROTLI: ClassVar["ArchiveFormat"]
-    UNIX_COMPRESS: ClassVar["ArchiveFormat"]
-    TAR: ClassVar["ArchiveFormat"]
-    TAR_GZ: ClassVar["ArchiveFormat"]
-    TAR_BZ2: ClassVar["ArchiveFormat"]
-    TAR_XZ: ClassVar["ArchiveFormat"]
-    TAR_ZSTD: ClassVar["ArchiveFormat"]
-    TAR_LZ4: ClassVar["ArchiveFormat"]
-    TAR_Z: ClassVar["ArchiveFormat"]
-    ISO: ClassVar["ArchiveFormat"]
-    FOLDER: ClassVar["ArchiveFormat"]
-    UNKNOWN: ClassVar["ArchiveFormat"]
-
-
 class ContainerFormat(StrEnum):
     """Supported container formats."""
 
@@ -79,8 +55,30 @@ class StreamFormat(StrEnum):
 
 
 @dataclass(eq=True)
-class ArchiveFormat(_ArchiveFormatBase):
+class ArchiveFormat:
     """Supported archive and compression formats."""
+
+    ZIP: ClassVar["ArchiveFormat"]
+    RAR: ClassVar["ArchiveFormat"]
+    SEVENZIP: ClassVar["ArchiveFormat"]
+    GZIP: ClassVar["ArchiveFormat"]
+    BZIP2: ClassVar["ArchiveFormat"]
+    XZ: ClassVar["ArchiveFormat"]
+    ZSTD: ClassVar["ArchiveFormat"]
+    LZ4: ClassVar["ArchiveFormat"]
+    ZLIB: ClassVar["ArchiveFormat"]
+    BROTLI: ClassVar["ArchiveFormat"]
+    UNIX_COMPRESS: ClassVar["ArchiveFormat"]
+    TAR: ClassVar["ArchiveFormat"]
+    TAR_GZ: ClassVar["ArchiveFormat"]
+    TAR_BZ2: ClassVar["ArchiveFormat"]
+    TAR_XZ: ClassVar["ArchiveFormat"]
+    TAR_ZSTD: ClassVar["ArchiveFormat"]
+    TAR_LZ4: ClassVar["ArchiveFormat"]
+    TAR_Z: ClassVar["ArchiveFormat"]
+    ISO: ClassVar["ArchiveFormat"]
+    FOLDER: ClassVar["ArchiveFormat"]
+    UNKNOWN: ClassVar["ArchiveFormat"]
 
     container: ContainerFormat
     stream: Optional[StreamFormat] = None

--- a/tests/archivey/test_corrupted_archives.py
+++ b/tests/archivey/test_corrupted_archives.py
@@ -9,10 +9,7 @@ from archivey.exceptions import (
     ArchiveCorruptedError,
     ArchiveEOFError,
 )
-from archivey.types import (
-    SINGLE_FILE_COMPRESSED_FORMATS,
-    ArchiveFormat,
-)
+from archivey.types import ArchiveFormat, ContainerFormat
 from tests.archivey.sample_archives import (
     ALTERNATIVE_CONFIG,
     ALTERNATIVE_PACKAGES_FORMATS,
@@ -125,8 +122,8 @@ def test_read_corrupted_archives(
                 # .corrupted_xxx suffix that doesn't match the name in sample_archive,
                 # so we need to remove it.
                 if (
-                    sample_archive.creation_info.format
-                    in SINGLE_FILE_COMPRESSED_FORMATS
+                    sample_archive.creation_info.format.container
+                    == ContainerFormat.RAW_STREAM
                 ):
                     filename = os.path.splitext(filename)[0]
 

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -509,7 +509,7 @@ def test_ensure_bufferedio_with_raw_compressed_stream(
 
     skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    open_fn, _ = get_stream_open_fn(sample_archive.creation_info.format, config)
+    open_fn, _ = get_stream_open_fn(sample_archive.creation_info.format.stream, config)
     with open_fn(sample_archive_path) as f:
         buffered = ensure_bufferedio(f)
         assert buffered.read() == sample_archive.contents.files[0].contents

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -30,7 +30,7 @@ from tests.archivey.testing_utils import skip_if_package_missing
 def compress_file(src: str, dst: str, fmt: ArchiveFormat) -> str:
     opener = SINGLE_FILE_LIBRARY_OPENERS.get(fmt)
     if opener is None:
-        pytest.skip(f"Required library for {fmt.name} is not installed")
+        pytest.skip(f"Required library for {fmt.file_extension()} is not installed")
     with open(src, "rb") as f_in, opener(dst, "wb") as f_out:
         shutil.copyfileobj(f_in, f_out)
     return dst
@@ -107,7 +107,7 @@ def test_open_archive_from_compressed_stream(
 
     inner_path = inner_archive.get_archive_path()
     compressed_path = os.path.join(
-        tmp_path, os.path.basename(inner_path) + "." + outer_format.value
+        tmp_path, os.path.basename(inner_path) + "." + outer_format.file_extension()
     )
     compress_file(inner_path, compressed_path, outer_format)
 
@@ -161,7 +161,7 @@ def test_open_archive_from_member(
     skip_if_package_missing(inner_archive.creation_info.format, config)
 
     inner_path = inner_archive.get_archive_path()
-    outer_path = os.path.join(tmp_path, "outer." + outer_format.value)
+    outer_path = os.path.join(tmp_path, "outer." + outer_format.file_extension())
     try:
         create_archive_with_member(outer_format, inner_path, outer_path)
     except PackageNotInstalledError as exc:

--- a/tests/archivey/test_open_compressed_stream.py
+++ b/tests/archivey/test_open_compressed_stream.py
@@ -6,7 +6,7 @@ import pytest
 from archivey.config import ArchiveyConfig
 from archivey.core import open_compressed_stream
 from archivey.exceptions import ArchiveNotSupportedError
-from archivey.types import TAR_COMPRESSED_FORMATS
+from archivey.types import ContainerFormat
 from tests.archivey.sample_archives import (
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -140,7 +140,10 @@ def test_open_compressed_stream_from_archive(
 
     skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    if sample_archive.creation_info.format in TAR_COMPRESSED_FORMATS:
+    if (
+        sample_archive.creation_info.format.container == ContainerFormat.TAR
+        and sample_archive.creation_info.format.stream is not None
+    ):
         with open_compressed_stream(sample_archive_path, config=config) as f:
             data = f.read()
             assert data[257 : 257 + 5] == b"ustar"

--- a/tests/archivey/test_open_compressed_stream.py
+++ b/tests/archivey/test_open_compressed_stream.py
@@ -6,7 +6,7 @@ import pytest
 from archivey.config import ArchiveyConfig
 from archivey.core import open_compressed_stream
 from archivey.exceptions import ArchiveNotSupportedError
-from archivey.types import ContainerFormat
+from archivey.types import ContainerFormat, StreamFormat
 from tests.archivey.sample_archives import (
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -142,7 +142,7 @@ def test_open_compressed_stream_from_archive(
 
     if (
         sample_archive.creation_info.format.container == ContainerFormat.TAR
-        and sample_archive.creation_info.format.stream is not None
+        and sample_archive.creation_info.format.stream != StreamFormat.UNCOMPRESSED
     ):
         with open_compressed_stream(sample_archive_path, config=config) as f:
             data = f.read()

--- a/tests/archivey/test_streaming_modes.py
+++ b/tests/archivey/test_streaming_modes.py
@@ -5,7 +5,7 @@ import pytest
 
 from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
-from archivey.types import TAR_COMPRESSED_FORMATS, ArchiveFormat, MemberType
+from archivey.types import ContainerFormat, MemberType
 from tests.archivey.sample_archives import (
     SAMPLE_ARCHIVES,
     SYMLINK_ARCHIVES,
@@ -127,10 +127,7 @@ def test_streaming_only_mode(
             archive.open(first_file.name)
 
         info = archive.get_members_if_available()
-        if (
-            sample_archive.creation_info.format == ArchiveFormat.TAR
-            or sample_archive.creation_info.format in TAR_COMPRESSED_FORMATS
-        ):
+        if sample_archive.creation_info.format.container == ContainerFormat.TAR:
             assert info is None
         else:
             assert info is not None and len(info) >= 1

--- a/tests/archivey/testing_utils.py
+++ b/tests/archivey/testing_utils.py
@@ -82,27 +82,27 @@ def skip_if_package_missing(format: ArchiveFormat, config: Optional[ArchiveyConf
     if config is None:
         config = ArchiveyConfig()
 
-    if format == ArchiveFormat.SEVENZIP:
+    if format.container == ContainerFormat.SEVENZIP:
         pytest.importorskip("py7zr")
-    elif format == ArchiveFormat.RAR:
+    elif format.container == ContainerFormat.RAR:
         pytest.importorskip("rarfile")
         if get_dependency_versions().unrar_version is None:
             pytest.skip("unrar not installed, skipping RAR truncation test")
-    elif format == ArchiveFormat.LZ4:
+    elif format.stream == StreamFormat.LZ4:
         pytest.importorskip("lz4")
-    elif format == ArchiveFormat.GZIP and config.use_rapidgzip:
+    elif format.stream == StreamFormat.GZIP and config.use_rapidgzip:
         pytest.importorskip("rapidgzip")
-    elif format == ArchiveFormat.BZIP2 and config.use_indexed_bzip2:
+    elif format.stream == StreamFormat.BZIP2 and config.use_indexed_bzip2:
         pytest.importorskip("indexed_bzip2")
-    elif format == ArchiveFormat.XZ and config.use_python_xz:
+    elif format.stream == StreamFormat.XZ and config.use_python_xz:
         pytest.importorskip("xz")
-    elif format == ArchiveFormat.ZSTD and config.use_zstandard:
+    elif format.stream == StreamFormat.ZSTD and config.use_zstandard:
         pytest.importorskip("zstandard")
-    elif format == ArchiveFormat.ZSTD:
+    elif format.stream == StreamFormat.ZSTD:
         pytest.importorskip("pyzstd")
-    elif format == ArchiveFormat.BROTLI:
+    elif format.stream == StreamFormat.BROTLI:
         pytest.importorskip("brotli")
-    elif format == ArchiveFormat.UNIX_COMPRESS:
+    elif format.stream == StreamFormat.UNIX_COMPRESS:
         pytest.importorskip("uncompresspy")
 
 

--- a/tests/archivey/testing_utils.py
+++ b/tests/archivey/testing_utils.py
@@ -11,11 +11,7 @@ import pytest
 from archivey.config import ArchiveyConfig
 from archivey.internal.dependency_checker import get_dependency_versions
 from archivey.internal.utils import set_file_mtime, set_file_permissions
-from archivey.types import (
-    TAR_FORMAT_TO_COMPRESSION_FORMAT,
-    ArchiveFormat,
-    MemberType,
-)
+from archivey.types import ArchiveFormat, ContainerFormat, MemberType, StreamFormat
 
 if TYPE_CHECKING:
     from tests.archivey.sample_archives import (
@@ -80,7 +76,9 @@ def write_files_to_dir(dir: str | os.PathLike, files: list[FileInfo]):
 
 
 def skip_if_package_missing(format: ArchiveFormat, config: Optional[ArchiveyConfig]):
-    format = TAR_FORMAT_TO_COMPRESSION_FORMAT.get(format, format)
+    if format.stream and format.stream != StreamFormat.UNCOMPRESSED:
+        format = ArchiveFormat(ContainerFormat.RAW_STREAM, format.stream)
+
     if config is None:
         config = ArchiveyConfig()
 


### PR DESCRIPTION
was: Fix(tests): Correct dependency check for compressed tar formats

The `skip_if_package_missing` test utility function had incorrect logic for determining the required dependency for compressed tar archives (e.g., .tar.gz). It was attempting to construct an `ArchiveFormat` object incorrectly, which would lead to runtime errors.

This change corrects the logic to properly construct the corresponding raw stream format (e.g., GZIP for TAR_GZ) before checking for the dependency, ensuring that tests that rely on this utility are skipped correctly when a required package is not installed.