### PR TITLE
chore: clean up unused and noisy code

### DIFF
--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -168,14 +168,16 @@ def open_archive(
 
     if stream is not None:
         assert not stream.closed
-    logger.debug(
-        "open_archive: reader_class=%s stream=%s path=%s", reader_class, stream, path
-    )
     if stream is not None:
+        stream_seekable = stream.seekable()
+        stream_position = stream.tell() if stream_seekable else "N/A"
         logger.debug(
-            "open_archive: stream.seekable=%s stream.tell=%s",
-            stream.seekable(),
-            stream.tell() if stream.seekable() else "N/A",
+            "open_archive: reader_class=%s stream=%s path=%s stream.seekable=%s stream.tell=%s",
+            reader_class,
+            stream,
+            path,
+            stream_seekable,
+            stream_position,
         )
 
     with archivey_config(config):

--- a/src/archivey/filters.py
+++ b/src/archivey/filters.py
@@ -56,8 +56,6 @@ def _sanitize_name(
     member: ArchiveMember,
     dest_path: str | None,
 ) -> str:
-    # if member.is_dir:
-    #     assert member.filename.endswith("/")
     name = posixpath.normpath(member.filename.lstrip("/\\"))
     _check_target_inside_archive_root(name, dest_path, "Path")
 

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -13,15 +13,13 @@ from archivey.exceptions import (
 from archivey.formats.compressed_streams import get_stream_open_fn
 from archivey.formats.format_detection import EXTENSION_TO_FORMAT
 from archivey.internal.base_reader import BaseArchiveReader
-from archivey.internal.io_helpers import (  # Updated import
+from archivey.internal.io_helpers import (
     is_seekable,
     is_stream,
     open_if_file,
     read_exact,
     run_with_exception_translation,
 )
-
-# from archivey.internal.utils import open_if_file # Removed
 from archivey.types import (
     ArchiveFormat,
     ArchiveInfo,
@@ -204,9 +202,6 @@ def read_xz_metadata(path: str | BinaryIO, member: ArchiveMember):
             total_uncompressed_size += uncompressed_size
 
         member.file_size = total_uncompressed_size
-        logger.debug(
-            f"XZ metadata: total_size={total_uncompressed_size}, num_blocks={number_of_blocks}, blocks={blocks}"
-        )
 
 
 class SingleFileReader(BaseArchiveReader):

--- a/src/archivey/internal/archive_stream.py
+++ b/src/archivey/internal/archive_stream.py
@@ -60,9 +60,6 @@ class ArchiveStream(io.RawIOBase, BinaryIO):
 
         super().__init__()
 
-        logger.debug(
-            f"ArchiveStream.__init__: open_fn={open_fn} exception_translator={exception_translator} lazy={lazy} archive_path={archive_path} member_name={member_name} seekable={seekable}"
-        )
         self._translate = exception_translator
 
         self._inner: BinaryIO | None = None
@@ -104,11 +101,6 @@ class ArchiveStream(io.RawIOBase, BinaryIO):
         if translated is not None:
             translated.archive_path = self.archive_path
             translated.member_name = self.member_name
-            logger.debug(
-                "Translated exception: %r -> %r",
-                e,
-                translated,
-            )
 
             raise translated from e
 
@@ -141,15 +133,6 @@ class ArchiveStream(io.RawIOBase, BinaryIO):
             self._translate_exception(e)
 
     def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
-        if self.seekable():
-            logger.debug(
-                f"ArchiveStream for {self.archive_path}:{self.member_name} seek({offset}, {whence}) (prev_pos={self.tell()}) (inner={self._inner})"
-            )
-        else:
-            logger.debug(
-                f"ArchiveStream for {self.archive_path}:{self.member_name} seek({offset}, {whence}) (not seekable) (inner={self._inner})"
-            )
-
         try:
             return self._ensure_open().seek(offset, whence)
         except Exception as e:  # noqa: BLE001
@@ -178,7 +161,6 @@ class ArchiveStream(io.RawIOBase, BinaryIO):
         raise NotImplementedError("ArchiveStream is not writable.")
 
     def close(self) -> None:
-        logger.debug(f"ArchiveStream.close: inner={self._inner}")
         if self._inner is not None:
             try:
                 self._inner.close()

--- a/src/archivey/internal/extraction_helper.py
+++ b/src/archivey/internal/extraction_helper.py
@@ -398,11 +398,6 @@ class ExtractionHelper:
         logger.error("Unexpected member type: %s", member.type)
         return False
 
-    # def process_external_extraction(self, member: ArchiveMember, rel_path: str) -> None:
-    #     """Called for files that were extracted by an external library."""
-    #     full_path = os.path.realpath(os.path.join(self.root_path, rel_path))
-    #     self.process_file_extracted(member, full_path)
-
     def get_pending_extractions(self) -> list[ArchiveMember]:
         logger.info(
             "Getting pending extractions: %s",

--- a/src/archivey/internal/io_helpers.py
+++ b/src/archivey/internal/io_helpers.py
@@ -235,23 +235,6 @@ def is_stream(obj: Any) -> TypeGuard[BinaryIO]:
     missing_properties = {p for p in ALL_IO_PROPERTIES if not hasattr(obj, p)}
     has_all_interface = not missing_methods and not missing_properties
 
-    if not isinstance(obj, (str, bytes, os.PathLike)) and not has_all_interface:
-        logger.debug(
-            "Object %r does not match the BinaryIO protocol: missing methods %r, "
-            "missing properties %r",
-            obj,
-            missing_methods,
-            missing_properties,
-        )
-
-    if is_iobase != has_all_interface:
-        logger.debug(
-            "Object %r : is_iobase=%r, has_all_interface=%r",
-            obj,
-            is_iobase,
-            has_all_interface,
-        )
-
     return is_iobase or has_all_interface
 
 
@@ -262,10 +245,6 @@ def ensure_binaryio(obj: BinaryStreamLike) -> BinaryIO:
     if is_stream(obj):
         return obj
 
-    logger.debug(
-        "Object %r does not match the BinaryIO protocol, wrapping in BinaryIOWrapper.",
-        obj,
-    )
     return BinaryIOWrapper(obj)
 
 
@@ -347,11 +326,6 @@ def run_with_exception_translation(
         if translated is not None:
             translated.archive_path = archive_path
             translated.member_name = member_name
-            logger.debug(
-                "Translated exception: %r -> %r",
-                e,
-                translated,
-            )
             raise translated from e
         raise e
 


### PR DESCRIPTION
## Summary
- remove lingering commented-out code
- trim overly verbose debug logging
- consolidate open_archive logging

## Testing
- `hatch run lint`
- `hatch run test` *(fails: test_open_archive_from_member on various compressed tar.Z cases)*

------
https://chatgpt.com/codex/tasks/task_e_689d5f8b32a0832d8811f36dca5d12a0