### PR TITLE
Jules: Refactor test configuration to use a dynamic fixture

### DIFF
--- a/tests/archivey/conftest.py
+++ b/tests/archivey/conftest.py
@@ -1,13 +1,16 @@
 import logging
 import pathlib
+from typing import cast
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.exceptions import PackageNotInstalledError
 from archivey.internal.dependency_checker import (
     format_dependency_versions,
     get_dependency_versions,
 )
+from archivey.types import ContainerFormat, StreamFormat
 from tests.archivey.create_archives import create_archive
 from tests.archivey.sample_archives import SampleArchive
 
@@ -31,6 +34,33 @@ def sample_archive_path(
         pytest.skip(
             f"Required library for {sample_archive.filename} is not installed: {e}"
         )
+
+
+@pytest.fixture
+def archive_configs(request: pytest.FixtureRequest) -> list[ArchiveyConfig]:
+    """Provides all the configs that are relevant for a given archive type."""
+    # cast to SampleArchive as this fixture is only used in tests that have a sample_archive fixture
+    sample_archive = cast(SampleArchive, request.getfixturevalue("sample_archive"))
+
+    configs = [ArchiveyConfig()]  # Default config
+
+    stream_format = sample_archive.creation_info.format.stream
+    container_format = sample_archive.creation_info.format.container
+
+    if stream_format == StreamFormat.GZIP:
+        configs.append(ArchiveyConfig(use_rapidgzip=True))
+    elif stream_format == StreamFormat.BZIP2:
+        configs.append(ArchiveyConfig(use_indexed_bzip2=True))
+    elif stream_format == StreamFormat.XZ:
+        configs.append(ArchiveyConfig(use_python_xz=True))
+    elif stream_format == StreamFormat.ZSTD:
+        configs.append(ArchiveyConfig(use_zstandard=True))
+
+    if container_format == ContainerFormat.RAR:
+        # For RAR, we test both with and without use_rar_stream
+        configs.append(ArchiveyConfig(use_rar_stream=True))
+
+    return configs
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/archivey/sample_archives.py
+++ b/tests/archivey/sample_archives.py
@@ -1215,13 +1215,6 @@ SANITIZE_ARCHIVES = (
     )
 )
 
-ALTERNATIVE_CONFIG = ArchiveyConfig(
-    use_rapidgzip=True,
-    use_indexed_bzip2=True,
-    use_python_xz=True,
-    use_zstandard=True,
-)
-
 ALTERNATIVE_PACKAGES_FORMATS = (
     ArchiveFormat.GZIP,
     ArchiveFormat.BZIP2,

--- a/tests/archivey/test_corrupted_archives.py
+++ b/tests/archivey/test_corrupted_archives.py
@@ -10,8 +10,8 @@ from archivey.exceptions import (
     ArchiveEOFError,
 )
 from archivey.types import ArchiveFormat, ContainerFormat
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     ALTERNATIVE_PACKAGES_FORMATS,
     SAMPLE_ARCHIVES,
     SampleArchive,
@@ -59,16 +59,13 @@ def _prepare_corrupted_archive(
 )
 @pytest.mark.parametrize("corruption_type", ["random", "zeroes", "ffs"])
 @pytest.mark.parametrize("read_streams", [True, False], ids=["read", "noread"])
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_corrupted_archives(
     sample_archive: SampleArchive,
     sample_archive_path: str,
     tmp_path_factory: pytest.TempPathFactory,
     read_streams: bool,
-    alternative_packages: bool,
     corruption_type: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that reading generally corrupted archives raises ArchiveCorruptedError.
 
@@ -80,109 +77,117 @@ def test_read_corrupted_archives(
             - "zeroes": Byte range replaced with zeros
             - "ffs": Byte range replaced with 0xFF
     """
-    if alternative_packages:
-        if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
-            pytest.skip("No alternative package for this format, no need to test")
-        config = ALTERNATIVE_CONFIG
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    formats_without_redundancy_check = [
-        ArchiveFormat.LZ4,
-        ArchiveFormat.TAR,
-        ArchiveFormat.UNIX_COMPRESS,
-        ArchiveFormat.BROTLI,
-    ]
-
-    if sample_archive.creation_info.format == ArchiveFormat.FOLDER:
-        pytest.skip("Folder archives cannot be corrupted")
-
-    corrupted_archive_path = _prepare_corrupted_archive(
-        sample_archive,
-        sample_archive_path,
-        tmp_path_factory,
-        corruption_type,
-    )
-
-    try:
-        found_member_names = []
-        found_member_data = {}
-
-        with open_archive(
-            corrupted_archive_path, config=config, streaming_only=True
-        ) as archive:
-            for member, stream in archive.iter_members_with_streams():
-                logger.info(f"Reading member {member.filename}")
-                filename = member.filename
-
-                # Single file formats don't store the filename, and the reader derives
-                # it from the archive name. But here, the archive name has a
-                # .corrupted_xxx suffix that doesn't match the name in sample_archive,
-                # so we need to remove it.
-                if (
-                    sample_archive.creation_info.format.container
-                    == ContainerFormat.RAW_STREAM
-                ):
-                    filename = os.path.splitext(filename)[0]
-
-                if stream is not None and read_streams:
-                    data = stream.read()
-                    logger.info(f"Read {len(data)} bytes from member {filename}")
-
-                    found_member_data[filename] = data
-
-                found_member_names.append(filename)
-
-        expected_member_data = {
-            member.name: member.contents for member in sample_archive.contents.files
-        }
-        logger.info(f"{found_member_names=}, expected={expected_member_data.keys()}")
-
-        if (
-            not read_streams
-            and archive.format == ArchiveFormat.BZIP2
-            and sample_archive.creation_info.format == ArchiveFormat.TAR_BZ2
+    for config in archive_configs:
+        if any(
+            v
+            for k, v in config.__dict__.items()
+            if k != "use_single_file_stored_metadata"
         ):
-            # In some corrupted archives, bz2 can uncompress the data stream, but it's
-            # not a valid tar format. If we don't actually attempt to read the streams,
-            # we won't detect the corruption.
-            pytest.xfail(
-                "Bzip2 can uncompress the data stream, but it's not a valid tar format."
-            )
+            if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
+                pytest.skip("No alternative package for this format, no need to test")
 
-        # If no error was raised, it likely means that the corruption didn't affect the
-        # archive directory or member metadata, so at least all the members should have
-        # been read.
-        assert set(found_member_names) == set(expected_member_data.keys()), (
-            f"Archive {corrupted_archive_path} did not raise an error but did not read all members"
+        skip_if_package_missing(sample_archive.creation_info.format, config)
+
+        formats_without_redundancy_check = [
+            ArchiveFormat.LZ4,
+            ArchiveFormat.TAR,
+            ArchiveFormat.UNIX_COMPRESS,
+            ArchiveFormat.BROTLI,
+        ]
+
+        if sample_archive.creation_info.format == ArchiveFormat.FOLDER:
+            pytest.skip("Folder archives cannot be corrupted")
+
+        corrupted_archive_path = _prepare_corrupted_archive(
+            sample_archive,
+            sample_archive_path,
+            tmp_path_factory,
+            corruption_type,
         )
 
-        if read_streams:
-            assert (
-                sample_archive.creation_info.format in formats_without_redundancy_check
-            ), f"Archive {corrupted_archive_path} should have detected a corruption"
-            # If we read the streams and an error wasn't raised, it means the compressed
-            # stream was valid, but at least one member should have different data.
-            broken_files = [
-                name
-                for name, contents in expected_member_data.items()
-                if contents is not None and contents != found_member_data[name]
-            ]
-            assert len(broken_files) >= 1, (
-                f"Archive {corrupted_archive_path} should have at least one broken file"
+        try:
+            found_member_names = []
+            found_member_data = {}
+
+            with open_archive(
+                corrupted_archive_path, config=config, streaming_only=True
+            ) as archive:
+                for member, stream in archive.iter_members_with_streams():
+                    logger.info(f"Reading member {member.filename}")
+                    filename = member.filename
+
+                    # Single file formats don't store the filename, and the reader derives
+                    # it from the archive name. But here, the archive name has a
+                    # .corrupted_xxx suffix that doesn't match the name in sample_archive,
+                    # so we need to remove it.
+                    if (
+                        sample_archive.creation_info.format.container
+                        == ContainerFormat.RAW_STREAM
+                    ):
+                        filename = os.path.splitext(filename)[0]
+
+                    if stream is not None and read_streams:
+                        data = stream.read()
+                        logger.info(f"Read {len(data)} bytes from member {filename}")
+
+                        found_member_data[filename] = data
+
+                    found_member_names.append(filename)
+
+            expected_member_data = {
+                member.name: member.contents
+                for member in sample_archive.contents.files
+            }
+            logger.info(
+                f"{found_member_names=}, expected={expected_member_data.keys()}"
             )
-            # If this is a multi-file archive, which we corrupted in the middle,
-            # at least the first file should be good. The last may or may not be broken,
-            # depending on how the error was propagated.
-            if len(expected_member_data) >= 1:
-                assert len(broken_files) <= len(expected_member_data), (
-                    f"Archive {corrupted_archive_path} should have at least one good file"
+
+            if (
+                not read_streams
+                and archive.format == ArchiveFormat.BZIP2
+                and sample_archive.creation_info.format == ArchiveFormat.TAR_BZ2
+            ):
+                # In some corrupted archives, bz2 can uncompress the data stream, but it's
+                # not a valid tar format. If we don't actually attempt to read the streams,
+                # we won't detect the corruption.
+                pytest.xfail(
+                    "Bzip2 can uncompress the data stream, but it's not a valid tar format."
                 )
 
-    except (ArchiveCorruptedError, ArchiveEOFError):
-        logger.info(f"Archive {corrupted_archive_path} raised an error", exc_info=True)
+            # If no error was raised, it likely means that the corruption didn't affect the
+            # archive directory or member metadata, so at least all the members should have
+            # been read.
+            assert set(found_member_names) == set(expected_member_data.keys()), (
+                f"Archive {corrupted_archive_path} did not raise an error but did not read all members"
+            )
+
+            if read_streams:
+                assert (
+                    sample_archive.creation_info.format
+                    in formats_without_redundancy_check
+                ), f"Archive {corrupted_archive_path} should have detected a corruption"
+                # If we read the streams and an error wasn't raised, it means the compressed
+                # stream was valid, but at least one member should have different data.
+                broken_files = [
+                    name
+                    for name, contents in expected_member_data.items()
+                    if contents is not None and contents != found_member_data[name]
+                ]
+                assert len(broken_files) >= 1, (
+                    f"Archive {corrupted_archive_path} should have at least one broken file"
+                )
+                # If this is a multi-file archive, which we corrupted in the middle,
+                # at least the first file should be good. The last may or may not be broken,
+                # depending on how the error was propagated.
+                if len(expected_member_data) >= 1:
+                    assert len(broken_files) <= len(expected_member_data), (
+                        f"Archive {corrupted_archive_path} should have at least one good file"
+                    )
+
+        except (ArchiveCorruptedError, ArchiveEOFError):
+            logger.info(
+                f"Archive {corrupted_archive_path} raised an error", exc_info=True
+            )
 
 
 @pytest.mark.parametrize("corrupted_length", [16, 47, 0.1, 0.9])
@@ -197,49 +202,52 @@ def test_read_corrupted_archives(
     ids=lambda a: a.filename,
 )
 @pytest.mark.parametrize("read_streams", [True, False], ids=["read", "noread"])
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_truncated_archives(
     sample_archive: SampleArchive,
     corrupted_length: int | float,
     tmp_path_factory: pytest.TempPathFactory,
     read_streams: bool,
-    alternative_packages: bool,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that reading truncated archives raises appropriate errors."""
     if sample_archive.creation_info.format == ArchiveFormat.FOLDER:
         pytest.skip("Folder archives cannot be truncated")
 
-    if alternative_packages:
-        if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
-            pytest.skip("No alternative package for this format, no need to test")
-        config = ALTERNATIVE_CONFIG
-    else:
-        config = None
+    for config in archive_configs:
+        if any(
+            v
+            for k, v in config.__dict__.items()
+            if k != "use_single_file_stored_metadata"
+        ):
+            if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
+                pytest.skip("No alternative package for this format, no need to test")
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    filename = sample_archive.get_archive_name(variant=f"truncated_{corrupted_length}")
-    output_path = tmp_path_factory.mktemp("generated_archives") / filename
+        filename = sample_archive.get_archive_name(
+            variant=f"truncated_{corrupted_length}"
+        )
+        output_path = tmp_path_factory.mktemp("generated_archives") / filename
 
-    logger.info(
-        f"Testing truncated archive {output_path} with length {corrupted_length}"
-    )
+        logger.info(
+            f"Testing truncated archive {output_path} with length {corrupted_length}"
+        )
 
-    data = open(sample_archive.get_archive_path(), "rb").read()
-    if isinstance(corrupted_length, float):
-        corrupted_length = int(corrupted_length * len(data))
+        data = open(sample_archive.get_archive_path(), "rb").read()
+        if isinstance(corrupted_length, float):
+            corrupted_length = int(corrupted_length * len(data))
 
-    with open(output_path, "wb") as f:
-        f.write(data[:corrupted_length])
+        with open(output_path, "wb") as f:
+            f.write(data[:corrupted_length])
 
-    try:
-        with open_archive(output_path, config=config, streaming_only=True) as archive:
-            for member, stream in archive.iter_members_with_streams():
-                if stream is not None and read_streams:
-                    stream.read()
-        logger.warning(f"Archive {output_path} did not raise an error")
-    except (ArchiveCorruptedError, ArchiveEOFError):
-        # Test passes if one of the expected exceptions is raised
-        pass
+        try:
+            with open_archive(
+                output_path, config=config, streaming_only=True
+            ) as archive:
+                for member, stream in archive.iter_members_with_streams():
+                    if stream is not None and read_streams:
+                        stream.read()
+            logger.warning(f"Archive {output_path} did not raise an error")
+        except (ArchiveCorruptedError, ArchiveEOFError):
+            # Test passes if one of the expected exceptions is raised
+            pass

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -18,9 +18,10 @@ from archivey.internal.io_helpers import (
     is_stream,
     read_exact,
 )
-from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SINGLE_FILE_ARCHIVES
+from tests.archivey.sample_archives import SINGLE_FILE_ARCHIVES
 from tests.archivey.test_open_nonseekable import NonSeekableBytesIO
 from tests.archivey.testing_utils import skip_if_package_missing
+from archivey.config import ArchiveyConfig
 
 
 # SlicingStream tests
@@ -469,62 +470,56 @@ def test_ensure_bufferedio():
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_ensure_bufferedio_with_compressed_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open_compressed_stream(sample_archive_path, config=config) as f:
+            buffered = ensure_bufferedio(f)
+            assert buffered.read() == sample_archive.contents.files[0].contents
 
-    with open_compressed_stream(sample_archive_path, config=config) as f:
-        buffered = ensure_bufferedio(f)
-        assert buffered.read() == sample_archive.contents.files[0].contents
-
-    buffer = bytearray(1024)
-    with open_compressed_stream(sample_archive_path, config=config) as f:
-        buffered = ensure_bufferedio(f)
-        bytes_read = buffered.readinto(buffer)
-        assert bytes_read == min(
-            len(buffer), len(sample_archive.contents.files[0].contents)
-        )
-        assert (
-            buffer[:bytes_read]
-            == sample_archive.contents.files[0].contents[:bytes_read]
-        )
+        buffer = bytearray(1024)
+        with open_compressed_stream(sample_archive_path, config=config) as f:
+            buffered = ensure_bufferedio(f)
+            bytes_read = buffered.readinto(buffer)
+            assert bytes_read == min(
+                len(buffer), len(sample_archive.contents.files[0].contents)
+            )
+            assert (
+                buffer[:bytes_read]
+                == sample_archive.contents.files[0].contents[:bytes_read]
+            )
 
 
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_ensure_bufferedio_with_raw_compressed_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    open_fn, _ = get_stream_open_fn(sample_archive.creation_info.format.stream, config)
-    with open_fn(sample_archive_path) as f:
-        buffered = ensure_bufferedio(f)
-        assert buffered.read() == sample_archive.contents.files[0].contents
-
-    buffer = bytearray(1024)
-    with open_fn(sample_archive_path) as f:
-        buffered = ensure_bufferedio(f)
-        bytes_read = buffered.readinto(buffer)
-        assert bytes_read == min(
-            len(buffer), len(sample_archive.contents.files[0].contents)
+        open_fn, _ = get_stream_open_fn(
+            sample_archive.creation_info.format.stream, config
         )
-        assert (
-            buffer[:bytes_read]
-            == sample_archive.contents.files[0].contents[:bytes_read]
-        )
+        with open_fn(sample_archive_path) as f:
+            buffered = ensure_bufferedio(f)
+            assert buffered.read() == sample_archive.contents.files[0].contents
+
+        buffer = bytearray(1024)
+        with open_fn(sample_archive_path) as f:
+            buffered = ensure_bufferedio(f)
+            bytes_read = buffered.readinto(buffer)
+            assert bytes_read == min(
+                len(buffer), len(sample_archive.contents.files[0].contents)
+            )
+            assert (
+                buffer[:bytes_read]
+                == sample_archive.contents.files[0].contents[:bytes_read]
+            )
 
 
 def test_is_stream(tmp_path: Path):

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -9,8 +9,8 @@ from archivey.exceptions import (
     PackageNotInstalledError,
 )
 from archivey.internal.dependency_checker import get_dependency_versions
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     SAMPLE_ARCHIVES,
     SampleArchive,
     filter_archives,
@@ -69,26 +69,29 @@ BASIC_UNIX_COMPRESS_ARCHIVE = filter_archives(
 
 
 @pytest.mark.parametrize(
-    ["library_name", "sample_archive", "alternative_packages"],
+    ["library_name", "sample_archive", "config"],
     [
         # ("pycdlib", BASIC_ISO_ARCHIVE.get_archive_path(), None),
-        ("rarfile", BASIC_RAR_ARCHIVE, False),
-        ("py7zr", BASIC_7Z_ARCHIVE, False),
-        ("rapidgzip", BASIC_GZIP_ARCHIVE, True),
-        ("indexed_bzip2", BASIC_BZIP2_ARCHIVE, True),
-        ("python-xz", BASIC_XZ_ARCHIVE, True),
-        ("pyzstd", BASIC_ZSTD_ARCHIVE, False),
-        ("zstandard", BASIC_ZSTD_ARCHIVE, True),
-        ("lz4", BASIC_LZ4_ARCHIVE, False),
-        ("brotli", BASIC_BROTLI_ARCHIVE, False),
-        ("uncompresspy", BASIC_UNIX_COMPRESS_ARCHIVE, False),
+        ("rarfile", BASIC_RAR_ARCHIVE, None),
+        ("py7zr", BASIC_7Z_ARCHIVE, None),
+        ("rapidgzip", BASIC_GZIP_ARCHIVE, ArchiveyConfig(use_rapidgzip=True)),
+        (
+            "indexed_bzip2",
+            BASIC_BZIP2_ARCHIVE,
+            ArchiveyConfig(use_indexed_bzip2=True),
+        ),
+        ("python-xz", BASIC_XZ_ARCHIVE, ArchiveyConfig(use_python_xz=True)),
+        ("pyzstd", BASIC_ZSTD_ARCHIVE, None),
+        ("zstandard", BASIC_ZSTD_ARCHIVE, ArchiveyConfig(use_zstandard=True)),
+        ("lz4", BASIC_LZ4_ARCHIVE, None),
+        ("brotli", BASIC_BROTLI_ARCHIVE, None),
+        ("uncompresspy", BASIC_UNIX_COMPRESS_ARCHIVE, None),
     ],
     ids=lambda x: os.path.basename(x) if isinstance(x, str) else x,
 )
 def test_missing_package_raises_exception(
-    library_name: str, sample_archive: SampleArchive, alternative_packages: bool
+    library_name: str, sample_archive: SampleArchive, config: ArchiveyConfig | None
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
     archive_path = sample_archive.get_archive_path()
     dependencies = get_dependency_versions()
     library_version = getattr(dependencies, f"{library_name.replace('-', '_')}_version")

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -19,7 +19,6 @@ from tests.archivey.create_archives import (
     create_zip_archive_with_zipfile,
 )
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
     ArchiveContents,
@@ -89,12 +88,15 @@ def check_archive_iter_members(archive: ArchiveReader):
         assert has_member
 
 
+from archivey.config import ArchiveyConfig
+
+
 @pytest.mark.parametrize(
     "outer_stream_format",
     set(StreamFormat) - {StreamFormat.UNCOMPRESSED},
 )
 @pytest.mark.parametrize(
-    "inner_archive",
+    "sample_archive",
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
@@ -102,49 +104,51 @@ def check_archive_iter_members(archive: ArchiveReader):
     ids=lambda a: a.filename,
 )
 @pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
-@pytest.mark.parametrize(
     "open_inner_streaming_only",
     [False, True],
 )
 def test_open_archive_from_compressed_stream(
     outer_stream_format: StreamFormat,
-    inner_archive: SampleArchive,
+    sample_archive: SampleArchive,
     tmp_path,
-    alternative_packages: bool,
     open_inner_streaming_only: bool,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
     outer_format = ArchiveFormat(ContainerFormat.RAW_STREAM, outer_stream_format)
 
-    skip_if_package_missing(outer_format, config)
-    skip_if_package_missing(inner_archive.creation_info.format, config)
+    for config in archive_configs:
+        skip_if_package_missing(outer_format, config)
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    if (
-        alternative_packages
-        and outer_stream_format == StreamFormat.BZIP2
-        and inner_archive.filename.endswith(".bz2")
-    ):
-        pytest.xfail("prevent segfault")
+        if (
+            (
+                config.use_indexed_bzip2
+                or config.use_rapidgzip
+                or config.use_python_xz
+                or config.use_zstandard
+            )
+            and outer_stream_format == StreamFormat.BZIP2
+            and sample_archive.filename.endswith(".bz2")
+        ):
+            pytest.xfail("prevent segfault")
 
-    logger.info(
-        f"alternative_packages: {alternative_packages}, outer_format: {outer_stream_format}, inner_archive.filename: {inner_archive.filename}"
-    )
+        logger.info(
+            f"config: {config}, outer_format: {outer_stream_format}, inner_archive.filename: {sample_archive.filename}"
+        )
 
-    inner_path = inner_archive.get_archive_path()
-    compressed_path = os.path.join(
-        tmp_path,
-        os.path.basename(inner_path) + "." + outer_format.file_extension(),
-    )
-    compress_stream(inner_path, compressed_path, outer_stream_format)
+        inner_path = sample_archive.get_archive_path()
+        compressed_path = os.path.join(
+            tmp_path,
+            os.path.basename(inner_path) + "." + outer_format.file_extension(),
+        )
+        compress_stream(inner_path, compressed_path, outer_stream_format)
 
-    with open_compressed_stream(compressed_path, config=config) as stream:
-        with open_archive(
-            stream, config=config, streaming_only=open_inner_streaming_only
-        ) as archive:
-            assert archive.format == inner_archive.creation_info.format
-            check_archive_iter_members(archive)
+        with open_compressed_stream(compressed_path, config=config) as stream:
+            with open_archive(
+                stream, config=config, streaming_only=open_inner_streaming_only
+            ) as archive:
+                assert archive.format == sample_archive.creation_info.format
+                check_archive_iter_members(archive)
 
 
 ALL_TAR_FORMATS = [
@@ -170,15 +174,12 @@ def expect_raise_if(condition: bool, exc_type: type[Exception]):
     ids=lambda a: a.file_extension(),
 )
 @pytest.mark.parametrize(
-    "inner_archive",
+    "sample_archive",
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
     ),
     ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
 )
 @pytest.mark.parametrize(
     "open_outer_streaming_only",
@@ -187,82 +188,87 @@ def expect_raise_if(condition: bool, exc_type: type[Exception]):
 )
 def test_open_archive_from_member(
     outer_format: ArchiveFormat,
-    inner_archive: SampleArchive,
+    sample_archive: SampleArchive,
     tmp_path,
-    alternative_packages: bool,
     open_outer_streaming_only: bool,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(outer_format, config)
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(outer_format, config)
-    skip_if_package_missing(inner_archive.creation_info.format, config)
+        inner_path = sample_archive.get_archive_path()
+        outer_path = os.path.join(tmp_path, "outer." + outer_format.file_extension())
+        try:
+            create_archive_with_member(outer_format, inner_path, outer_path)
+        except PackageNotInstalledError as exc:
+            pytest.skip(str(exc))
 
-    inner_path = inner_archive.get_archive_path()
-    outer_path = os.path.join(tmp_path, "outer." + outer_format.file_extension())
-    try:
-        create_archive_with_member(outer_format, inner_path, outer_path)
-    except PackageNotInstalledError as exc:
-        pytest.skip(str(exc))
+        alternative_packages = (
+            config.use_indexed_bzip2
+            or config.use_rapidgzip
+            or config.use_python_xz
+            or config.use_zstandard
+        )
+        expect_non_seekable_failure = (
+            sample_archive.creation_info.format,
+            alternative_packages,
+        ) in EXPECTED_NON_SEEKABLE_FAILURES
 
-    expect_non_seekable_failure = (
-        inner_archive.creation_info.format,
-        alternative_packages,
-    ) in EXPECTED_NON_SEEKABLE_FAILURES
+        # Try opening the inner archive in random mode. It should work if the outer
+        # archive is seekable and it provides seekable streams (only 7z doesn't).
+        with open_archive(
+            outer_path, config=config, streaming_only=open_outer_streaming_only
+        ) as outer:
+            assert outer.get_archive_info().format == outer_format
 
-    # Try opening the inner archive in random mode. It should work if the outer
-    # archive is seekable and it provides seekable streams (only 7z doesn't).
-    with open_archive(
-        outer_path, config=config, streaming_only=open_outer_streaming_only
-    ) as outer:
-        assert outer.get_archive_info().format == outer_format
+            outer_has_member = False
+            for member, stream in outer.iter_members_with_streams():
+                assert member.filename.endswith(os.path.basename(inner_path))
+                assert stream is not None
+                outer_has_member = True
 
-        outer_has_member = False
-        for member, stream in outer.iter_members_with_streams():
-            assert member.filename.endswith(os.path.basename(inner_path))
-            assert stream is not None
-            outer_has_member = True
+                if open_outer_streaming_only:
+                    assert not stream.seekable()
 
-            if open_outer_streaming_only:
-                assert not stream.seekable()
+                with expect_raise_if(
+                    not stream.seekable(),
+                    ArchiveStreamNotSeekableError,
+                ):
+                    with open_archive(
+                        stream, config=config, streaming_only=False
+                    ) as archive:
+                        assert archive.format == sample_archive.creation_info.format
+                        assert archive.get_members() is not None
+                        check_archive_iter_members(archive)
 
-            with expect_raise_if(
-                not stream.seekable(),
-                ArchiveStreamNotSeekableError,
-            ):
-                with open_archive(
-                    stream, config=config, streaming_only=False
-                ) as archive:
-                    assert archive.format == inner_archive.creation_info.format
-                    assert archive.get_members() is not None
-                    check_archive_iter_members(archive)
+            assert outer_has_member
 
-        assert outer_has_member
+        # Try opening the inner archive in streaming mode. It should work if the stream is
+        # seekable or if the inner library support opening non-seekable streams in
+        # streaming mode.
+        with open_archive(
+            outer_path, config=config, streaming_only=open_outer_streaming_only
+        ) as outer:
+            assert outer.get_archive_info().format == outer_format
 
-    # Try opening the inner archive in streaming mode. It should work if the stream is
-    # seekable or if the inner library support opening non-seekable streams in
-    # streaming mode.
-    with open_archive(
-        outer_path, config=config, streaming_only=open_outer_streaming_only
-    ) as outer:
-        assert outer.get_archive_info().format == outer_format
+            outer_has_member = False
+            for member, stream in outer.iter_members_with_streams():
+                assert member.filename.endswith(os.path.basename(inner_path))
+                assert stream is not None
+                outer_has_member = True
 
-        outer_has_member = False
-        for member, stream in outer.iter_members_with_streams():
-            assert member.filename.endswith(os.path.basename(inner_path))
-            assert stream is not None
-            outer_has_member = True
+                if open_outer_streaming_only:
+                    assert not stream.seekable()
 
-            if open_outer_streaming_only:
-                assert not stream.seekable()
+                with expect_raise_if(
+                    not stream.seekable() and expect_non_seekable_failure,
+                    ArchiveStreamNotSeekableError,
+                ):
+                    with open_archive(
+                        stream, config=config, streaming_only=True
+                    ) as archive:
+                        assert archive.format == sample_archive.creation_info.format
+                        check_archive_iter_members(archive)
 
-            with expect_raise_if(
-                not stream.seekable() and expect_non_seekable_failure,
-                ArchiveStreamNotSeekableError,
-            ):
-                with open_archive(
-                    stream, config=config, streaming_only=True
-                ) as archive:
-                    assert archive.format == inner_archive.creation_info.format
-                    check_archive_iter_members(archive)
-
-        assert outer_has_member
+            assert outer_has_member

--- a/tests/archivey/test_open_compressed_stream.py
+++ b/tests/archivey/test_open_compressed_stream.py
@@ -22,29 +22,17 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_open_compressed_stream_from_file(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open_compressed_stream(sample_archive_path, config=config) as f:
+            data = f.read()
 
-    with open_compressed_stream(sample_archive_path, config=config) as f:
-        data = f.read()
-
-    expected = sample_archive.contents.files[0].contents
-    assert data == expected
+        expected = sample_archive.contents.files[0].contents
+        assert data == expected
 
 
 def test_open_compressed_stream_unsupported_format(tmp_path):
@@ -58,95 +46,60 @@ def test_open_compressed_stream_unsupported_format(tmp_path):
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_open_compressed_stream_from_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        compressed_data = open(sample_archive_path, "rb").read()
+        compressed_stream = io.BytesIO(compressed_data)
 
-    compressed_data = open(sample_archive_path, "rb").read()
-    compressed_stream = io.BytesIO(compressed_data)
+        with open_compressed_stream(compressed_stream, config=config) as f:
+            data = f.read()
 
-    with open_compressed_stream(compressed_stream, config=config) as f:
-        data = f.read()
-
-    expected = sample_archive.contents.files[0].contents
-    assert data == expected
+        expected = sample_archive.contents.files[0].contents
+        assert data == expected
 
 
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_open_compressed_stream_from_stream_with_prefix(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        # Add some bad data to the beginning of the stream, to test that the reading is
+        # done from the initial position.
+        bad_data = b"bad data " * 1000
+        compressed_data = bad_data + open(sample_archive_path, "rb").read()
+        compressed_stream = io.BytesIO(compressed_data)
+        compressed_stream.seek(len(bad_data))
 
-    # Add some bad data to the beginning of the stream, to test that the reading is
-    # done from the initial position.
-    bad_data = b"bad data " * 1000
-    compressed_data = bad_data + open(sample_archive_path, "rb").read()
-    compressed_stream = io.BytesIO(compressed_data)
-    compressed_stream.seek(len(bad_data))
+        with open_compressed_stream(compressed_stream, config=config) as f:
+            data = f.read()
 
-    with open_compressed_stream(compressed_stream, config=config) as f:
-        data = f.read()
-
-    expected = sample_archive.contents.files[0].contents
-    assert data == expected
+        expected = sample_archive.contents.files[0].contents
+        assert data == expected
 
 
 @pytest.mark.parametrize("sample_archive", BASIC_ARCHIVES, ids=lambda a: a.filename)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
 def test_open_compressed_stream_from_archive(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive, sample_archive_path, archive_configs: list[ArchiveyConfig]
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    if (
-        sample_archive.creation_info.format.container == ContainerFormat.TAR
-        and sample_archive.creation_info.format.stream != StreamFormat.UNCOMPRESSED
-    ):
-        with open_compressed_stream(sample_archive_path, config=config) as f:
-            data = f.read()
-            assert data[257 : 257 + 5] == b"ustar"
-    else:
-        with pytest.raises(ArchiveNotSupportedError):
-            open_compressed_stream(sample_archive_path, config=config)
+        if (
+            sample_archive.creation_info.format.container == ContainerFormat.TAR
+            and sample_archive.creation_info.format.stream
+            != StreamFormat.UNCOMPRESSED
+        ):
+            with open_compressed_stream(sample_archive_path, config=config) as f:
+                data = f.read()
+                assert data[257 : 257 + 5] == b"ustar"
+        else:
+            with pytest.raises(ArchiveNotSupportedError):
+                open_compressed_stream(sample_archive_path, config=config)

--- a/tests/archivey/test_open_member.py
+++ b/tests/archivey/test_open_member.py
@@ -1,8 +1,8 @@
 import pytest
 
 from archivey.core import open_archive
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     HARDLINK_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -17,40 +17,38 @@ from tests.archivey.testing_utils import remove_duplicate_files, skip_if_package
     BASIC_ARCHIVES + SYMLINK_ARCHIVES + HARDLINK_ARCHIVES,
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_member(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    with open_archive(sample_archive_path, config=config) as archive:
-        # members = archive.get_members()
+        with open_archive(sample_archive_path, config=config) as archive:
+            # members = archive.get_members()
 
-        for sample_file in remove_duplicate_files(sample_archive.contents.files):
-            if sample_file.contents is not None:
-                stream = archive.open(sample_file.name)
-                data = stream.read()
-                assert data == sample_file.contents
+            for sample_file in remove_duplicate_files(sample_archive.contents.files):
+                if sample_file.contents is not None:
+                    stream = archive.open(sample_file.name)
+                    data = stream.read()
+                    assert data == sample_file.contents
 
 
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_member_single_file_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    with open_archive(sample_archive_path, config=config) as archive:
-        member = archive.get_members()[0]
+        with open_archive(sample_archive_path, config=config) as archive:
+            member = archive.get_members()[0]
 
-        stream = archive.open(member)
-        data = stream.read()
-        assert data == sample_archive.contents.files[0].contents
+            stream = archive.open(member)
+            data = stream.read()
+            assert data == sample_archive.contents.files[0].contents

--- a/tests/archivey/test_open_nonseekable.py
+++ b/tests/archivey/test_open_nonseekable.py
@@ -7,8 +7,8 @@ from archivey.core import open_archive, open_compressed_stream
 from archivey.exceptions import ArchiveStreamNotSeekableError
 from archivey.internal.io_helpers import ensure_binaryio
 from archivey.types import ArchiveFormat
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SampleArchive,
@@ -67,87 +67,95 @@ class NonSeekableBytesIO(io.BytesIO):
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_archive_nonseekable(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Ensure open_archive can read from non-seekable streams in streaming mode."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        stream = NonSeekableBytesIO(data)
 
-    stream = NonSeekableBytesIO(data)
+        try:
+            with open_archive(stream, streaming_only=True, config=config) as archive:
+                members = []
+                for member, member_stream in archive.iter_members_with_streams():
+                    members.append(member)
+                    if member_stream is not None:
+                        member_stream.read()
+                # The file names may not match in case of single-file archives, as we take
+                # the name from the compressed file name which is not available when reading
+                # from a stream. But checking the number of members should ensure that
+                # we read all the members.
+                assert len(members) == len(
+                    [f.name for f in sample_archive.contents.files]
+                )
 
-    try:
-        with open_archive(stream, streaming_only=True, config=config) as archive:
-            members = []
-            for member, member_stream in archive.iter_members_with_streams():
-                members.append(member)
-                if member_stream is not None:
-                    member_stream.read()
-            # The file names may not match in case of single-file archives, as we take
-            # the name from the compressed file name which is not available when reading
-            # from a stream. But checking the number of members should ensure that
-            # we read all the members.
-            assert len(members) == len([f.name for f in sample_archive.contents.files])
-
-    except (
-        ArchiveStreamNotSeekableError
-    ) as exc:  # pragma: no cover - environment dependent
-        key = (sample_archive.creation_info.format, alternative_packages)
-        if key in EXPECTED_NON_SEEKABLE_FAILURES:
-            pytest.xfail(
-                f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+        except (
+            ArchiveStreamNotSeekableError
+        ) as exc:  # pragma: no cover - environment dependent
+            alternative_packages = any(
+                v
+                for k, v in config.__dict__.items()
+                if k != "use_single_file_stored_metadata"
             )
-        else:
-            assert False, (
-                f"Expected format {key} to work with non-seekable streams, but it failed with {exc!r}"
-            )
+            key = (sample_archive.creation_info.format, alternative_packages)
+            if key in EXPECTED_NON_SEEKABLE_FAILURES:
+                pytest.xfail(
+                    f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+                )
+            else:
+                assert False, (
+                    f"Expected format {key} to work with non-seekable streams, but it failed with {exc!r}"
+                )
 
 
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_compressed_stream_nonseekable(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        stream = ensure_binaryio(NonSeekableBytesIO(data))
 
-    stream = ensure_binaryio(NonSeekableBytesIO(data))
+        try:
+            with open_compressed_stream(stream, config=config) as f:
+                assert not f.seekable()
 
-    try:
-        with open_compressed_stream(stream, config=config) as f:
-            assert not f.seekable()
+                out = f.read()
 
-            out = f.read()
-
-    except (
-        ArchiveStreamNotSeekableError
-    ) as exc:  # pragma: no cover - environment dependent
-        key = (sample_archive.creation_info.format, alternative_packages)
-        logger.error(f"key: {key}")
-        logger.error(f"EXPECTED_FAILURES: {EXPECTED_NON_SEEKABLE_FAILURES}")
-        if key in EXPECTED_NON_SEEKABLE_FAILURES:
-            pytest.xfail(
-                f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+        except (
+            ArchiveStreamNotSeekableError
+        ) as exc:  # pragma: no cover - environment dependent
+            alternative_packages = any(
+                v
+                for k, v in config.__dict__.items()
+                if k != "use_single_file_stored_metadata"
             )
-        else:
-            assert False, (
-                f"Expected format {key} to work with non-seekable streams, but it failed with {exc!r}"
-            )
+            key = (sample_archive.creation_info.format, alternative_packages)
+            logger.error(f"key: {key}")
+            logger.error(f"EXPECTED_FAILURES: {EXPECTED_NON_SEEKABLE_FAILURES}")
+            if key in EXPECTED_NON_SEEKABLE_FAILURES:
+                pytest.xfail(
+                    f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+                )
+            else:
+                assert False, (
+                    f"Expected format {key} to work with non-seekable streams, but it failed with {exc!r}"
+                )
 
-    expected = sample_archive.contents.files[0].contents
-    assert out == expected
+        expected = sample_archive.contents.files[0].contents
+        assert out == expected

--- a/tests/archivey/test_open_stream.py
+++ b/tests/archivey/test_open_stream.py
@@ -2,9 +2,10 @@ import io
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat
-from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SAMPLE_ARCHIVES
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES
 from tests.archivey.testing_utils import skip_if_package_missing
 
 # Select one sample archive for each format (except FOLDER and ISO)
@@ -19,21 +20,18 @@ for a in SAMPLE_ARCHIVES:
 @pytest.mark.parametrize(
     "sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
-def test_open_stream(sample_archive, alternative_packages):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+def test_open_stream(sample_archive, archive_configs: list[ArchiveyConfig]):
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    path = sample_archive.get_archive_path()
-    with open(path, "rb") as f:
-        data = f.read()
+        path = sample_archive.get_archive_path()
+        with open(path, "rb") as f:
+            data = f.read()
 
-    with open_archive(io.BytesIO(data), config=config) as archive:
-        has_member = False
-        for member, stream in archive.iter_members_with_streams():
-            has_member = True
-            if stream is not None:
-                stream.read()
-        assert has_member
+        with open_archive(io.BytesIO(data), config=config) as archive:
+            has_member = False
+            for member, stream in archive.iter_members_with_streams():
+                has_member = True
+                if stream is not None:
+                    stream.read()
+            assert has_member

--- a/tests/archivey/test_open_url.py
+++ b/tests/archivey/test_open_url.py
@@ -12,8 +12,8 @@ import pytest
 from archivey.core import open_archive
 from archivey.exceptions import ArchiveStreamNotSeekableError
 from archivey.types import ArchiveFormat
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
     filter_archives,
@@ -75,37 +75,39 @@ def serve_dir(path: str):
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
-def test_open_archive_via_http(sample_archive, alternative_packages):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+def test_open_archive_via_http(sample_archive, archive_configs: list[ArchiveyConfig]):
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    path = sample_archive.get_archive_path()
-    with serve_dir(os.path.dirname(path)) as base_url:
-        url = f"{base_url}/{os.path.basename(path)}"
-        logger.info(f"Opening URL: {url}")
-        with urlopen(url, timeout=2) as response:
-            try:
-                with open_archive(
-                    response, streaming_only=True, config=config
-                ) as archive:
-                    has_member = False
-                    for member, stream in archive.iter_members_with_streams():
-                        has_member = True
-                        if stream is not None:
-                            stream.read()
-                    assert has_member
-            except (
-                ArchiveStreamNotSeekableError
-            ) as exc:  # pragma: no cover - env dependent
-                key = (sample_archive.creation_info.format, alternative_packages)
-                if key in EXPECTED_NON_SEEKABLE_FAILURES:
-                    pytest.xfail(
-                        f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+        path = sample_archive.get_archive_path()
+        with serve_dir(os.path.dirname(path)) as base_url:
+            url = f"{base_url}/{os.path.basename(path)}"
+            logger.info(f"Opening URL: {url}")
+            with urlopen(url, timeout=2) as response:
+                try:
+                    with open_archive(
+                        response, streaming_only=True, config=config
+                    ) as archive:
+                        has_member = False
+                        for member, stream in archive.iter_members_with_streams():
+                            has_member = True
+                            if stream is not None:
+                                stream.read()
+                        assert has_member
+                except (
+                    ArchiveStreamNotSeekableError
+                ) as exc:  # pragma: no cover - env dependent
+                    alternative_packages = any(
+                        v
+                        for k, v in config.__dict__.items()
+                        if k != "use_single_file_stored_metadata"
                     )
-                else:
-                    assert False, (
-                        f"Expected format {key} to work with HTTP streams, but it failed with {exc!r}"
-                    )
+                    key = (sample_archive.creation_info.format, alternative_packages)
+                    if key in EXPECTED_NON_SEEKABLE_FAILURES:
+                        pytest.xfail(
+                            f"Non-seekable {sample_archive.creation_info.format} are not supported with {alternative_packages=}: {exc}"
+                        )
+                    else:
+                        assert False, (
+                            f"Expected format {key} to work with HTTP streams, but it failed with {exc!r}"
+                        )

--- a/tests/archivey/test_read_archives.py
+++ b/tests/archivey/test_read_archives.py
@@ -20,7 +20,6 @@ from archivey.types import (
     MemberType,
 )
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     MARKER_MTIME_BASED_ON_ARCHIVE_NAME,
     SAMPLE_ARCHIVES,
     FileInfo,
@@ -391,28 +390,25 @@ logger = logging.getLogger(__name__)
     ),
     ids=lambda x: x.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_tar_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     logger.info(f"Testing {sample_archive.filename}; files at {sample_archive_path}")
 
     logger.info(
         f"Testing {sample_archive.filename} with format {sample_archive.creation_info.format}"
     )
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    check_iter_members(
-        sample_archive,
-        archive_path=sample_archive_path,
-        skip_member_contents=True,
-        config=config,
-    )
+        check_iter_members(
+            sample_archive,
+            archive_path=sample_archive_path,
+            skip_member_contents=True,
+            config=config,
+        )
 
 
 @pytest.mark.parametrize(
@@ -420,9 +416,10 @@ def test_read_tar_archives(
     filter_archives(SAMPLE_ARCHIVES, extensions=["rar"]),
     ids=lambda x: x.filename,
 )
-@pytest.mark.parametrize("use_rar_stream", [True, False])
 def test_read_rar_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, use_rar_stream: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     deps = get_dependency_versions()
     if (
@@ -431,38 +428,39 @@ def test_read_rar_archives(
     ):
         pytest.skip("Cryptography is not installed, skipping RAR encrypted-header test")
 
-    if use_rar_stream and deps.unrar_version is None:
-        pytest.skip("unrar not installed, skipping RarStreamReader test")
+    for config in archive_configs:
+        if config.use_rar_stream and deps.unrar_version is None:
+            pytest.skip("unrar not installed, skipping RarStreamReader test")
 
-    config = ArchiveyConfig(use_rar_stream=use_rar_stream)
-
-    has_password = sample_archive.contents.has_password()
-    has_multiple_passwords = sample_archive.contents.has_multiple_passwords()
-    first_file_has_password = sample_archive.contents.files[0].password is not None
-
-    expect_failure = use_rar_stream and (
-        has_multiple_passwords
-        or (
-            has_password
-            and not first_file_has_password
-            and not sample_archive.contents.header_password
+        has_password = sample_archive.contents.has_password()
+        has_multiple_passwords = sample_archive.contents.has_multiple_passwords()
+        first_file_has_password = (
+            sample_archive.contents.files[0].password is not None
         )
-    )
 
-    if expect_failure:
-        with pytest.raises(ValueError):
+        expect_failure = config.use_rar_stream and (
+            has_multiple_passwords
+            or (
+                has_password
+                and not first_file_has_password
+                and not sample_archive.contents.header_password
+            )
+        )
+
+        if expect_failure:
+            with pytest.raises(ValueError):
+                check_iter_members(
+                    sample_archive,
+                    archive_path=sample_archive_path,
+                    config=config,
+                )
+        else:
             check_iter_members(
                 sample_archive,
                 archive_path=sample_archive_path,
                 config=config,
+                skip_member_contents=deps.unrar_version is None,
             )
-    else:
-        check_iter_members(
-            sample_archive,
-            archive_path=sample_archive_path,
-            config=config,
-            skip_member_contents=deps.unrar_version is None,
-        )
 
 
 @pytest.mark.parametrize(
@@ -476,22 +474,23 @@ def test_read_rar_archives(
     ),
     ids=lambda x: x.filename,
 )
-@pytest.mark.parametrize("use_rar_stream", [True, False])
 def test_read_rar_archives_with_password_in_constructor(
-    sample_archive: SampleArchive, sample_archive_path: str, use_rar_stream: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     deps = get_dependency_versions()
-    if use_rar_stream and deps.unrar_version is None:
-        pytest.skip("unrar not installed, skipping RarStreamReader test")
+    for config in archive_configs:
+        if config.use_rar_stream and deps.unrar_version is None:
+            pytest.skip("unrar not installed, skipping RarStreamReader test")
 
-    config = ArchiveyConfig(use_rar_stream=use_rar_stream)
-    check_iter_members(
-        sample_archive,
-        archive_path=sample_archive_path,
-        config=config,
-        set_file_password_in_constructor=True,
-        skip_member_contents=deps.unrar_version is None,
-    )
+        check_iter_members(
+            sample_archive,
+            archive_path=sample_archive_path,
+            config=config,
+            set_file_password_in_constructor=True,
+            skip_member_contents=deps.unrar_version is None,
+        )
 
 
 @pytest.mark.parametrize(
@@ -532,24 +531,16 @@ def test_read_7z_archives(sample_archive: SampleArchive, sample_archive_path: st
     ),
     ids=lambda x: x.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_single_file_compressed_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-            use_single_file_stored_metadata=True,
+    for config in archive_configs:
+        config = replace(config, use_single_file_stored_metadata=True)
+        check_iter_members(
+            sample_archive, archive_path=sample_archive_path, config=config
         )
-    else:
-        config = ArchiveyConfig(use_single_file_stored_metadata=True)
-
-    check_iter_members(sample_archive, archive_path=sample_archive_path, config=config)
 
 
 @pytest.mark.parametrize(

--- a/tests/archivey/test_small_reads.py
+++ b/tests/archivey/test_small_reads.py
@@ -6,8 +6,8 @@ import pytest
 from archivey.core import open_archive
 from archivey.internal.utils import ensure_not_none
 from archivey.types import ArchiveFormat
+from archivey.config import ArchiveyConfig
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -59,31 +59,30 @@ class SizeLimitedReader(io.RawIOBase):
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "alternative"]
-)
 @pytest.mark.parametrize("streaming_only", [False, True], ids=["random", "stream"])
 def test_open_archive_small_reads(
     sample_archive: SampleArchive,
     sample_archive_path: str,
-    alternative_packages: bool,
     streaming_only: bool,
+    archive_configs: list[ArchiveyConfig],
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    # It's too slow to test single-byte reads for large archives. This chunk size
-    # should be enough to test incomplete reads while reading the member contents.
-    max_bytes = 250 if "large" in sample_archive_path else 1
-    stream = SizeLimitedReader(data, max_bytes=max_bytes)
+        # It's too slow to test single-byte reads for large archives. This chunk size
+        # should be enough to test incomplete reads while reading the member contents.
+        max_bytes = 250 if "large" in sample_archive_path else 1
+        stream = SizeLimitedReader(data, max_bytes=max_bytes)
 
-    with open_archive(stream, streaming_only=streaming_only, config=config) as archive:
-        has_member = False
-        for member, member_stream in archive.iter_members_with_streams():
-            has_member = True
-            if member_stream is not None:
-                member_stream.read()
-        assert has_member
+        with open_archive(
+            stream, streaming_only=streaming_only, config=config
+        ) as archive:
+            has_member = False
+            for member, member_stream in archive.iter_members_with_streams():
+                has_member = True
+                if member_stream is not None:
+                    member_stream.read()
+            assert has_member

--- a/tests/archivey/test_statsio.py
+++ b/tests/archivey/test_statsio.py
@@ -8,7 +8,6 @@ from archivey.core import open_archive, open_compressed_stream
 from archivey.internal.io_helpers import IOStats, StatsIO, ensure_binaryio
 from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SampleArchive,
@@ -28,55 +27,49 @@ logger = logging.getLogger(__name__)
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_archive_statsio(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Ensure open_archive can read from StatsIO-wrapped streams and tracks statistics correctly."""
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
+
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
+
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = StatsIO(io.BytesIO(data), stats)
+
+        # Track initial stats
+        initial_bytes_read = stats.bytes_read
+        initial_seek_calls = stats.seek_calls
+        initial_read_ranges = len(stats.read_ranges)
+
+        with open_archive(stream, config=config) as archive:
+            has_member = False
+            total_member_bytes = 0
+
+            for member, member_stream in archive.iter_members_with_streams():
+                has_member = True
+                if member_stream is not None:
+                    member_data = member_stream.read()
+                    total_member_bytes += len(member_data)
+
+            assert has_member
+
+        # Verify that statistics were tracked
+        assert stats.bytes_read > initial_bytes_read, (
+            "No bytes were read according to stats"
         )
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
-
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = StatsIO(io.BytesIO(data), stats)
-
-    # Track initial stats
-    initial_bytes_read = stats.bytes_read
-    initial_seek_calls = stats.seek_calls
-    initial_read_ranges = len(stats.read_ranges)
-
-    with open_archive(stream, config=config) as archive:
-        has_member = False
-        total_member_bytes = 0
-
-        for member, member_stream in archive.iter_members_with_streams():
-            has_member = True
-            if member_stream is not None:
-                member_data = member_stream.read()
-                total_member_bytes += len(member_data)
-
-        assert has_member
-
-    # Verify that statistics were tracked
-    assert stats.bytes_read > initial_bytes_read, (
-        "No bytes were read according to stats"
-    )
-    assert stats.seek_calls >= initial_seek_calls, "No seek operations were tracked"
-    assert len(stats.read_ranges) > initial_read_ranges, "No read ranges were tracked"
+        assert (
+            stats.seek_calls >= initial_seek_calls
+        ), "No seek operations were tracked"
+        assert (
+            len(stats.read_ranges) > initial_read_ranges
+        ), "No read ranges were tracked"
 
 
 @pytest.mark.parametrize(
@@ -87,100 +80,100 @@ def test_open_archive_statsio(
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_archive_statsio_streaming_mode(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Ensure open_archive can read from StatsIO-wrapped streams in streaming mode."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = StatsIO(io.BytesIO(data), stats)
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = StatsIO(io.BytesIO(data), stats)
+        # Track initial stats
+        initial_bytes_read = stats.bytes_read
+        initial_seek_calls = stats.seek_calls
+        initial_read_ranges = len(stats.read_ranges)
 
-    # Track initial stats
-    initial_bytes_read = stats.bytes_read
-    initial_seek_calls = stats.seek_calls
-    initial_read_ranges = len(stats.read_ranges)
+        with open_archive(stream, streaming_only=True, config=config) as archive:
+            has_member = False
+            total_member_bytes = 0
 
-    with open_archive(stream, streaming_only=True, config=config) as archive:
-        has_member = False
-        total_member_bytes = 0
+            for member, member_stream in archive.iter_members_with_streams():
+                has_member = True
+                if member_stream is not None:
+                    member_data = member_stream.read()
+                    total_member_bytes += len(member_data)
 
-        for member, member_stream in archive.iter_members_with_streams():
-            has_member = True
-            if member_stream is not None:
-                member_data = member_stream.read()
-                total_member_bytes += len(member_data)
+            assert has_member
 
-        assert has_member
+        # Verify that statistics were tracked
+        assert stats.bytes_read > initial_bytes_read
+        assert stats.seek_calls >= initial_seek_calls
+        assert len(stats.read_ranges) > initial_read_ranges
 
-    # Verify that statistics were tracked
-    assert stats.bytes_read > initial_bytes_read
-    assert stats.seek_calls >= initial_seek_calls
-    assert len(stats.read_ranges) > initial_read_ranges
-
-    # Verify that a significant portion of the archive was read. Some metadata
-    # may be skipped by the underlying library, so we only require 70% of the
-    # archive bytes to be consumed.
-    assert stats.bytes_read > len(data) * 0.7, (
-        f"Expected more than 70% of {len(data)} bytes read, got {stats.bytes_read}"
-    )
+        # Verify that a significant portion of the archive was read. Some metadata
+        # may be skipped by the underlying library, so we only require 70% of the
+        # archive bytes to be consumed.
+        assert stats.bytes_read > len(data) * 0.7, (
+            f"Expected more than 70% of {len(data)} bytes read, got {stats.bytes_read}"
+        )
 
 
 @pytest.mark.parametrize(
     "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_compressed_stream_statsio(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Ensure open_compressed_stream can read from StatsIO-wrapped streams and tracks statistics correctly."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = ensure_binaryio(StatsIO(io.BytesIO(data), stats))
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = ensure_binaryio(StatsIO(io.BytesIO(data), stats))
+        # Track initial stats
+        initial_bytes_read = stats.bytes_read
+        initial_seek_calls = stats.seek_calls
+        initial_read_ranges = len(stats.read_ranges)
 
-    # Track initial stats
-    initial_bytes_read = stats.bytes_read
-    initial_seek_calls = stats.seek_calls
-    initial_read_ranges = len(stats.read_ranges)
+        with open_compressed_stream(stream, config=config) as f:
+            out = f.read()
 
-    with open_compressed_stream(stream, config=config) as f:
-        out = f.read()
+        # Verify that statistics were tracked
+        assert stats.bytes_read > initial_bytes_read, (
+            "No bytes were read according to stats"
+        )
+        assert (
+            stats.seek_calls >= initial_seek_calls
+        ), "No seek operations were tracked"
+        assert (
+            len(stats.read_ranges) > initial_read_ranges
+        ), "No read ranges were tracked"
 
-    # Verify that statistics were tracked
-    assert stats.bytes_read > initial_bytes_read, (
-        "No bytes were read according to stats"
-    )
-    assert stats.seek_calls >= initial_seek_calls, "No seek operations were tracked"
-    assert len(stats.read_ranges) > initial_read_ranges, "No read ranges were tracked"
+        # Verify that a significant portion of the archive was read. Some metadata
+        # may be skipped by the underlying library, so we only require 70% of the
+        # archive bytes to be consumed.
+        assert stats.bytes_read > len(data) * 0.7, (
+            f"Expected more than 70% of {len(data)} bytes read, got {stats.bytes_read}"
+        )
 
-    # Verify that a significant portion of the archive was read. Some metadata
-    # may be skipped by the underlying library, so we only require 70% of the
-    # archive bytes to be consumed.
-    assert stats.bytes_read > len(data) * 0.7, (
-        f"Expected more than 70% of {len(data)} bytes read, got {stats.bytes_read}"
-    )
-
-    # Verify the decompressed content is correct
-    expected = sample_archive.contents.files[0].contents
-    assert out == expected
+        # Verify the decompressed content is correct
+        expected = sample_archive.contents.files[0].contents
+        assert out == expected
 
 
 @pytest.mark.parametrize(
@@ -190,49 +183,47 @@ def test_open_compressed_stream_statsio(
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
     ),
     ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
 )
 def test_open_archive_statsio_seek_operations(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that seek operations are properly tracked by StatsIO when opening archives."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = StatsIO(io.BytesIO(data), stats)
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = StatsIO(io.BytesIO(data), stats)
+        # Track initial stats
+        initial_seek_calls = stats.seek_calls
+        initial_read_ranges = len(stats.read_ranges)
 
-    # Track initial stats
-    initial_seek_calls = stats.seek_calls
-    initial_read_ranges = len(stats.read_ranges)
+        with open_archive(stream, config=config) as archive:
+            # Get member list first (this may trigger seeks)
+            members = archive.get_members()
+            assert len(members) > 0
 
-    with open_archive(stream, config=config) as archive:
-        # Get member list first (this may trigger seeks)
-        members = archive.get_members()
-        assert len(members) > 0
+            # Read a few members to trigger more I/O operations
+            for i, member in enumerate(members[:3]):  # Read first 3 members
+                if member.type.value == "file":  # Only try to open file members
+                    with archive.open(member) as member_stream:
+                        member_stream.read()
 
-        # Read a few members to trigger more I/O operations
-        for i, member in enumerate(members[:3]):  # Read first 3 members
-            if member.type.value == "file":  # Only try to open file members
-                with archive.open(member) as member_stream:
-                    member_stream.read()
+        # Verify that seek operations were tracked
+        assert stats.seek_calls >= initial_seek_calls
+        assert len(stats.read_ranges) > initial_read_ranges
 
-    # Verify that seek operations were tracked
-    assert stats.seek_calls >= initial_seek_calls
-    assert len(stats.read_ranges) > initial_read_ranges
-
-    # Verify read ranges are properly formatted
-    for read_range in stats.read_ranges:
-        assert len(read_range) == 2
-        assert read_range[0] >= 0
-        assert read_range[1] >= 0
+        # Verify read ranges are properly formatted
+        for read_range in stats.read_ranges:
+            assert len(read_range) == 2
+            assert read_range[0] >= 0
+            assert read_range[1] >= 0
 
 
 @pytest.mark.parametrize(
@@ -242,46 +233,46 @@ def test_open_archive_statsio_seek_operations(
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
     ),
     ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
 )
 def test_open_archive_statsio_readinto_operations(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that readinto operations are properly tracked by StatsIO when opening archives."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = StatsIO(io.BytesIO(data), stats)
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = StatsIO(io.BytesIO(data), stats)
+        # Track initial stats
+        initial_bytes_read = stats.bytes_read
+        initial_read_ranges = len(stats.read_ranges)
 
-    # Track initial stats
-    initial_bytes_read = stats.bytes_read
-    initial_read_ranges = len(stats.read_ranges)
+        with open_archive(stream, config=config) as archive:
+            # Read members using readinto to test that operation
+            for member in archive.get_members():
+                if member.type.value == "file":  # Only try to open file members
+                    with archive.open(member) as member_stream:
+                        buffer = bytearray(1024)
+                        while True:
+                            logger.debug(f"readinto {member_stream}")
+                            bytes_read = member_stream.readinto(buffer)  # type: ignore
+                            if bytes_read == 0:
+                                break
 
-    with open_archive(stream, config=config) as archive:
-        # Read members using readinto to test that operation
-        for member in archive.get_members():
-            if member.type.value == "file":  # Only try to open file members
-                with archive.open(member) as member_stream:
-                    buffer = bytearray(1024)
-                    while True:
-                        logger.debug(f"readinto {member_stream}")
-                        bytes_read = member_stream.readinto(buffer)  # type: ignore
-                        if bytes_read == 0:
-                            break
-
-    # Verify that bytes were read
-    assert stats.bytes_read > initial_bytes_read, (
-        "No bytes were read according to stats"
-    )
-    assert len(stats.read_ranges) > initial_read_ranges, "No read ranges were tracked"
+        # Verify that bytes were read
+        assert stats.bytes_read > initial_bytes_read, (
+            "No bytes were read according to stats"
+        )
+        assert (
+            len(stats.read_ranges) > initial_read_ranges
+        ), "No read ranges were tracked"
 
 
 @pytest.mark.parametrize(
@@ -291,47 +282,47 @@ def test_open_archive_statsio_readinto_operations(
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
     ),
     ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
 )
 def test_open_archive_statsio_multiple_opens(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that StatsIO properly tracks statistics across multiple archive opens."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        stream = StatsIO(io.BytesIO(data), stats)
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    stream = StatsIO(io.BytesIO(data), stats)
+        # First open
+        with open_archive(stream, config=config) as archive:
+            members = archive.get_members()
+            assert len(members) > 0
 
-    # First open
-    with open_archive(stream, config=config) as archive:
-        members = archive.get_members()
-        assert len(members) > 0
+        first_open_bytes = stats.bytes_read
+        first_open_seeks = stats.seek_calls
+        first_open_ranges = len(stats.read_ranges)
 
-    first_open_bytes = stats.bytes_read
-    first_open_seeks = stats.seek_calls
-    first_open_ranges = len(stats.read_ranges)
+        # Second open (should accumulate stats)
+        with open_archive(stream, config=config) as archive:
+            members = archive.get_members()
+            assert len(members) > 0
 
-    # Second open (should accumulate stats)
-    with open_archive(stream, config=config) as archive:
-        members = archive.get_members()
-        assert len(members) > 0
-
-    # Verify that stats accumulated across opens
-    assert stats.bytes_read > first_open_bytes, "Stats should accumulate across opens"
-    assert stats.seek_calls >= first_open_seeks, (
-        "Seek stats should accumulate across opens"
-    )
-    assert len(stats.read_ranges) > first_open_ranges, (
-        "Read ranges should accumulate across opens"
-    )
+        # Verify that stats accumulated across opens
+        assert (
+            stats.bytes_read > first_open_bytes
+        ), "Stats should accumulate across opens"
+        assert (
+            stats.seek_calls >= first_open_seeks
+        ), "Seek stats should accumulate across opens"
+        assert (
+            len(stats.read_ranges) > first_open_ranges
+        ), "Read ranges should accumulate across opens"
 
 
 @pytest.mark.parametrize(
@@ -342,43 +333,33 @@ def test_open_archive_statsio_multiple_opens(
     ),
     ids=lambda a: a.filename,
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_open_archive_statsio_io_methods(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_configs: list[ArchiveyConfig],
 ):
     """Test that StatsIO properly delegates IO methods to the underlying stream."""
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = None
+    for config in archive_configs:
+        skip_if_package_missing(sample_archive.creation_info.format, config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+        with open(sample_archive_path, "rb") as f:
+            data = f.read()
 
-    with open(sample_archive_path, "rb") as f:
-        data = f.read()
+        # Create StatsIO wrapper around the data
+        stats = IOStats()
+        underlying_stream = io.BytesIO(data)
+        stream = StatsIO(underlying_stream, stats)
 
-    # Create StatsIO wrapper around the data
-    stats = IOStats()
-    underlying_stream = io.BytesIO(data)
-    stream = StatsIO(underlying_stream, stats)
+        # Test that IO methods are properly delegated
+        assert stream.readable() == underlying_stream.readable()
+        assert stream.writable() == underlying_stream.writable()
+        assert stream.seekable() == underlying_stream.seekable()
 
-    # Test that IO methods are properly delegated
-    assert stream.readable() == underlying_stream.readable()
-    assert stream.writable() == underlying_stream.writable()
-    assert stream.seekable() == underlying_stream.seekable()
+        # Test that we can still open the archive normally
+        with open_archive(stream, config=config) as archive:
+            members = archive.get_members()
+            assert len(members) > 0
 
-    # Test that we can still open the archive normally
-    with open_archive(stream, config=config) as archive:
-        members = archive.get_members()
-        assert len(members) > 0
-
-    # Verify that statistics were tracked
-    assert stats.bytes_read > 0, "No bytes were read according to stats"
-    assert len(stats.read_ranges) > 1, "No read ranges were tracked"
+        # Verify that statistics were tracked
+        assert stats.bytes_read > 0, "No bytes were read according to stats"
+        assert len(stats.read_ranges) > 1, "No read ranges were tracked"


### PR DESCRIPTION
This commit refactors the test suite to use a new pytest fixture called `archive_configs`. This fixture replaces the static `ALTERNATIVE_CONFIG` object and provides a list of all relevant `ArchiveyConfig` objects for a given archive's type.

The new `archive_configs` fixture, located in `tests/archivey/conftest.py`, inspects the `sample_archive` fixture to determine its stream and container formats. Based on these formats, it dynamically builds and returns a list of `ArchiveyConfig` objects, including the default config and any relevant alternative configurations.

All existing tests have been updated to use this new fixture, removing the `alternative_packages` parameterization and instead looping through the configs provided by the `archive_configs` fixture. This makes the tests more robust and easier to maintain.