### PR TITLE
Jules: Refactor test suite to use pytest_generate_tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ optional = [
     # Not currently compatible with Python 3.14. Fix on the way, see
     # https://github.com/python-lz4/python-lz4/pull/303
     "lz4>=4.4.4 ; python_full_version < '3.14'",
-    "lzip>=1.2.0",
     "pycdlib>=1.14.0",
     "uncompresspy>=0.4.0; python_full_version >= '3.11'",
     "brotli>=1.1.0",
@@ -53,7 +52,6 @@ optional-freethreaded = [
     "python-xz>=0.5.0",
     "pyzstd>=0.17.0",
     "lz4>=4.4.4 ; python_full_version < '3.14'",
-    "lzip>=1.2.0",
     "pycdlib>=1.14.0",
     "uncompresspy>=0.4.0",
     "brotli>=1.1.0",
@@ -92,6 +90,10 @@ timeout = 15
 timeout_method = "thread"
 log_format = "%(asctime)s %(levelname)s %(threadName)s %(name)s:%(filename)s:%(lineno)d %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "sample_archives(archives): mark test to run with a list of sample archives",
+]
 
 [tool.hatch.envs.default]
 python = "3.13"

--- a/tests/archivey/conftest.py
+++ b/tests/archivey/conftest.py
@@ -2,16 +2,83 @@ import logging
 import pathlib
 
 import pytest
+from _pytest.main import Session
+from _pytest.python import Metafunc
 
+from archivey.config import ArchiveyConfig
 from archivey.exceptions import PackageNotInstalledError
 from archivey.internal.dependency_checker import (
     format_dependency_versions,
     get_dependency_versions,
 )
+from archivey.types import StreamFormat
 from tests.archivey.create_archives import create_archive
 from tests.archivey.sample_archives import SampleArchive
 
 logger = logging.getLogger(__name__)
+
+
+def archive_configs_for(sample_archive: SampleArchive) -> list[ArchiveyConfig]:
+    cfgs = [ArchiveyConfig()]
+    stream_format = sample_archive.creation_info.format.stream
+    if stream_format == StreamFormat.GZIP:
+        cfgs.append(ArchiveyConfig(use_rapidgzip=True))
+    elif stream_format == StreamFormat.BZIP2:
+        cfgs.append(ArchiveyConfig(use_indexed_bzip2=True))
+    elif stream_format == StreamFormat.XZ:
+        cfgs.append(ArchiveyConfig(use_python_xz=True))
+    elif stream_format == StreamFormat.ZSTD:
+        cfgs.append(ArchiveyConfig(use_zstandard=True))
+
+    return cfgs
+
+
+def _cfg_id(cfg: ArchiveyConfig) -> str:
+    # Make a short, stable id for nice test names
+    bits = []
+    if getattr(cfg, "use_rapidgzip", False):
+        bits.append("rapidgzip")
+    if getattr(cfg, "use_indexed_bzip2", False):
+        bits.append("indexed_bzip2")
+    if getattr(cfg, "use_python_xz", False):
+        bits.append("python_xz")
+    if getattr(cfg, "use_zstandard", False):
+        bits.append("zstandard")
+    return ",".join(bits) or "default"
+
+
+def pytest_generate_tests(metafunc: Metafunc):
+    if "archive_config" in metafunc.fixturenames:
+        marker = metafunc.definition.get_closest_marker("sample_archives")
+        if not marker:
+            return
+
+        sample_archives_list = marker.args[0]
+        params = []
+        for sa in sample_archives_list:
+            if sa.skip_test:
+                params.append(
+                    pytest.param(
+                        sa,
+                        ArchiveyConfig(),
+                        id=f"{sa.filename}::skipped",
+                        marks=pytest.mark.skip,
+                    )
+                )
+                continue
+            for cfg in archive_configs_for(sa):
+                params.append(pytest.param(sa, cfg, id=f"{sa.filename}::{_cfg_id(cfg)}"))
+        metafunc.parametrize("sample_archive,archive_config", params)
+
+
+@pytest.fixture
+def sample_archive(request) -> SampleArchive:
+    return request.param
+
+
+@pytest.fixture
+def archive_config(request) -> ArchiveyConfig:
+    return request.param
 
 
 @pytest.fixture

--- a/tests/archivey/sample_archives.py
+++ b/tests/archivey/sample_archives.py
@@ -1215,24 +1215,6 @@ SANITIZE_ARCHIVES = (
     )
 )
 
-ALTERNATIVE_CONFIG = ArchiveyConfig(
-    use_rapidgzip=True,
-    use_indexed_bzip2=True,
-    use_python_xz=True,
-    use_zstandard=True,
-)
-
-ALTERNATIVE_PACKAGES_FORMATS = (
-    ArchiveFormat.GZIP,
-    ArchiveFormat.BZIP2,
-    ArchiveFormat.XZ,
-    ArchiveFormat.ZSTD,
-    ArchiveFormat.TAR_GZ,
-    ArchiveFormat.TAR_BZ2,
-    ArchiveFormat.TAR_XZ,
-    ArchiveFormat.TAR_ZSTD,
-)
-
 SAMPLE_ARCHIVES = (
     BASIC_ARCHIVES
     + COMMENT_ARCHIVES

--- a/tests/archivey/test_corrupted_archives.py
+++ b/tests/archivey/test_corrupted_archives.py
@@ -4,6 +4,7 @@ from venv import logger
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.exceptions import (
     ArchiveCorruptedError,
@@ -11,8 +12,6 @@ from archivey.exceptions import (
 )
 from archivey.types import ArchiveFormat, ContainerFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
-    ALTERNATIVE_PACKAGES_FORMATS,
     SAMPLE_ARCHIVES,
     SampleArchive,
     filter_archives,
@@ -49,25 +48,20 @@ def _prepare_corrupted_archive(
     return corrupted_archive_path
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid", "large_single_file"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 @pytest.mark.parametrize("corruption_type", ["random", "zeroes", "ffs"])
 @pytest.mark.parametrize("read_streams", [True, False], ids=["read", "noread"])
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_corrupted_archives(
     sample_archive: SampleArchive,
     sample_archive_path: str,
     tmp_path_factory: pytest.TempPathFactory,
     read_streams: bool,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
     corruption_type: str,
 ):
     """Test that reading generally corrupted archives raises ArchiveCorruptedError.
@@ -80,14 +74,7 @@ def test_read_corrupted_archives(
             - "zeroes": Byte range replaced with zeros
             - "ffs": Byte range replaced with 0xFF
     """
-    if alternative_packages:
-        if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
-            pytest.skip("No alternative package for this format, no need to test")
-        config = ALTERNATIVE_CONFIG
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     formats_without_redundancy_check = [
         ArchiveFormat.LZ4,
@@ -111,7 +98,7 @@ def test_read_corrupted_archives(
         found_member_data = {}
 
         with open_archive(
-            corrupted_archive_path, config=config, streaming_only=True
+            corrupted_archive_path, config=archive_config, streaming_only=True
         ) as archive:
             for member, stream in archive.iter_members_with_streams():
                 logger.info(f"Reading member {member.filename}")
@@ -186,39 +173,27 @@ def test_read_corrupted_archives(
 
 
 @pytest.mark.parametrize("corrupted_length", [16, 47, 0.1, 0.9])
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid", "large_single_file"],
         # Tar files don't have any kind of error detection, so we skip them.
         # custom_filter=lambda a: a.creation_info.format != ArchiveFormat.TAR,
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 @pytest.mark.parametrize("read_streams", [True, False], ids=["read", "noread"])
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
 def test_read_truncated_archives(
     sample_archive: SampleArchive,
     corrupted_length: int | float,
     tmp_path_factory: pytest.TempPathFactory,
     read_streams: bool,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
 ):
     """Test that reading truncated archives raises appropriate errors."""
     if sample_archive.creation_info.format == ArchiveFormat.FOLDER:
         pytest.skip("Folder archives cannot be truncated")
 
-    if alternative_packages:
-        if sample_archive.creation_info.format not in ALTERNATIVE_PACKAGES_FORMATS:
-            pytest.skip("No alternative package for this format, no need to test")
-        config = ALTERNATIVE_CONFIG
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     filename = sample_archive.get_archive_name(variant=f"truncated_{corrupted_length}")
     output_path = tmp_path_factory.mktemp("generated_archives") / filename
@@ -235,7 +210,9 @@ def test_read_truncated_archives(
         f.write(data[:corrupted_length])
 
     try:
-        with open_archive(output_path, config=config, streaming_only=True) as archive:
+        with open_archive(
+            output_path, config=archive_config, streaming_only=True
+        ) as archive:
             for member, stream in archive.iter_members_with_streams():
                 if stream is not None and read_streams:
                     stream.read()

--- a/tests/archivey/test_encrypted_archives.py
+++ b/tests/archivey/test_encrypted_archives.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.exceptions import ArchiveEncryptedError, ArchiveError
 from archivey.internal.utils import platform_is_windows
@@ -42,27 +43,31 @@ def _first_encrypted_file(sample: SampleArchive):
     raise ValueError("sample archive has no encrypted files")
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_password_in_open_archive(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     pwd = _archive_password(sample_archive)
-    with open_archive(sample_archive_path, pwd=pwd) as archive:
+    with open_archive(sample_archive_path, pwd=pwd, config=archive_config) as archive:
         encrypted = _first_encrypted_file(sample_archive)
         with archive.open(encrypted.name) as fh:
             assert fh.read() == encrypted.contents
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_password_in_iter_members(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     pwd = _archive_password(sample_archive)
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
             pytest.skip(
                 "py7zr does not support password parameter for iter_members_with_streams"
@@ -77,35 +82,45 @@ def test_password_in_iter_members(
                 assert contents[f.name] == f.contents
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
-def test_password_in_open(sample_archive: SampleArchive, sample_archive_path: str):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
+def test_password_in_open(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     pwd = _archive_password(sample_archive)
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for f in sample_archive.contents.files:
             if f.type == MemberType.FILE:
                 with archive.open(f.name, pwd=pwd) as fh:
                     assert fh.read() == f.contents
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
-def test_wrong_password_open(sample_archive: SampleArchive, sample_archive_path: str):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
+def test_wrong_password_open(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     wrong = "wrong_password"
     encrypted = _first_encrypted_file(sample_archive)
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         with pytest.raises((ArchiveEncryptedError, ArchiveError)):
             with archive.open(encrypted.name, pwd=wrong) as f:
                 f.read()
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_wrong_password_iter_members_read(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
         pytest.skip(
@@ -113,7 +128,7 @@ def test_wrong_password_iter_members_read(
         )
 
     wrong = "wrong_password"
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for m, stream in archive.iter_members_with_streams(pwd=wrong):
             assert stream is not None
             if m.is_file:
@@ -124,14 +139,16 @@ def test_wrong_password_iter_members_read(
                     stream.read()
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_wrong_password_iter_members_no_read(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     wrong = "wrong_password"
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
             pytest.skip(
                 "py7zr does not support password parameter for iter_members_with_streams"
@@ -140,18 +157,21 @@ def test_wrong_password_iter_members_no_read(
             pass
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_extract_with_password(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     pwd = _archive_password(sample_archive)
     dest = tmp_path / "out"
     dest.mkdir()
     encrypted = _first_encrypted_file(sample_archive)
     # config = get_default_config()
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
             pytest.skip("py7zr extract password support incomplete")
         # archive.config.overwrite_mode = OverwriteMode.OVERWRITE
@@ -161,11 +181,14 @@ def test_extract_with_password(
         assert f.read() == encrypted.contents
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_extractall_with_password(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     # if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
     #     pytest.skip("py7zr extractall password support incomplete")
@@ -173,7 +196,7 @@ def test_extractall_with_password(
     pwd = _archive_password(sample_archive)
     dest = tmp_path / "all"
     dest.mkdir()
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         archive.extractall(dest, pwd=pwd)
 
     for f in sample_archive.contents.files:
@@ -184,17 +207,20 @@ def test_extractall_with_password(
                 assert fh.read() == f.contents
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_extract_wrong_password(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     wrong = "wrong_password"
     dest = tmp_path / "out"
     dest.mkdir()
     encrypted = _first_encrypted_file(sample_archive)
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
             pytest.skip("py7zr extract password support incomplete")
         # archive.config.overwrite_mode = OverwriteMode.OVERWRITE
@@ -202,11 +228,14 @@ def test_extract_wrong_password(
             archive.extract(encrypted.name, dest, pwd=wrong)
 
 
-@pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
 def test_extractall_wrong_password(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     # if sample_archive.creation_info.format == ArchiveFormat.SEVENZIP:
     #     pytest.skip("py7zr extractall password support incomplete")
@@ -214,27 +243,27 @@ def test_extractall_wrong_password(
     wrong = "wrong_password"
     dest = tmp_path / "all"
     dest.mkdir()
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         with pytest.raises((ArchiveEncryptedError, ArchiveError)):
             archive.extractall(dest, pwd=wrong)
 
 
-# @pytest.mark.parametrize("sample_archive", ENCRYPTED_ARCHIVES, ids=lambda a: a.filename)
-@pytest.mark.parametrize(
-    "sample_archive",
+# @pytest.mark.sample_archives(ENCRYPTED_ARCHIVES)
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_iterator_encryption_with_symlinks_no_password(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     members_by_name = {}
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for member, stream in archive.iter_members_with_streams():
             members_by_name[member.filename] = stream
 
@@ -243,21 +272,21 @@ def test_iterator_encryption_with_symlinks_no_password(
     }
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_iterator_encryption_with_symlinks_password_in_open_archive(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     members_by_name = {}
-    with open_archive(sample_archive_path, pwd="pwd") as archive:
+    with open_archive(sample_archive_path, pwd="pwd", config=archive_config) as archive:
         for member, stream in archive.iter_members_with_streams():
             members_by_name[member.filename] = stream
 
@@ -266,21 +295,21 @@ def test_iterator_encryption_with_symlinks_password_in_open_archive(
     }
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_iterator_encryption_with_symlinks_password_in_iterator(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     members_by_name = {}
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for member, stream in archive.iter_members_with_streams(pwd="pwd"):
             members_by_name[member.filename] = stream
 
@@ -289,19 +318,19 @@ def test_iterator_encryption_with_symlinks_password_in_iterator(
     }
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
         extensions=["rar", "7z"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_open_encrypted_symlink(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     sample_files = {f.name: f for f in sample_archive.contents.files}
 
@@ -310,7 +339,7 @@ def test_open_encrypted_symlink(
         ("encrypted_link_to_not_secret.txt", "longpwd"),
         ("plain_link_to_secret.txt", "pwd"),
     ]
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for filename, pwd in files_to_test:
             try:
                 data = archive.open(filename, pwd=pwd).read()
@@ -333,45 +362,45 @@ def test_open_encrypted_symlink(
                     raise
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
         extensions=["rar", "7z"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_open_encrypted_symlink_wrong_password(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     symlink_name = "encrypted_link_to_secret.txt"
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         with pytest.raises((ArchiveEncryptedError, ArchiveError)):
             with archive.open(symlink_name, pwd="wrong") as fh:
                 fh.read()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["encryption_with_symlinks"],
         extensions=["rar", "7z"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_open_encrypted_symlink_target_wrong_password(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     symlink_name = "encrypted_link_to_very_secret.txt"
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         with pytest.raises((ArchiveEncryptedError, ArchiveError)):
             with archive.open(symlink_name, pwd="pwd") as fh:
                 fh.read()

--- a/tests/archivey/test_extractall.py
+++ b/tests/archivey/test_extractall.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.internal.utils import (
     ensure_not_none,
@@ -54,22 +55,23 @@ def _check_file_metadata(path: Path, info: FileInfo, sample: SampleArchive):
         assert actual == info.mtime, (path, info)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    BASIC_ARCHIVES + DUPLICATE_FILES_ARCHIVES + SYMLINK_ARCHIVES + HARDLINK_ARCHIVES,
-    ids=lambda x: x.filename,
+@pytest.mark.sample_archives(
+    BASIC_ARCHIVES + DUPLICATE_FILES_ARCHIVES + SYMLINK_ARCHIVES + HARDLINK_ARCHIVES
 )
 def test_extractall(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     dest = tmp_path / "out"
     dest.mkdir()
 
     logger.info(f"Extracting {sample_archive_path} to {dest}")
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         extractall_result = archive.extractall(dest)
         members_by_filename = {
             m.filename: m for m in ensure_not_none(archive.get_members_if_available())
@@ -132,20 +134,19 @@ def test_extractall(
     assert expected_extractall_result == extractall_result
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    BASIC_ARCHIVES,
-    ids=lambda x: x.filename,
-)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_extractall_filter(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     dest = tmp_path / "out"
     dest.mkdir()
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         archive.extractall(dest, members=lambda m: m.filename.endswith("file2.txt"))
 
     path = dest / "subdir" / "file2.txt"
@@ -161,20 +162,19 @@ def test_extractall_filter(
     assert not (dest / "implicit_subdir" / "file3.txt").exists()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    BASIC_ARCHIVES,
-    ids=lambda x: x.filename,
-)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_extractall_members(
-    tmp_path: Path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path: Path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     dest = tmp_path / "out"
     dest.mkdir()
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         member_obj = archive.get_member("file1.txt")
         archive.extractall(dest, members=[member_obj, "subdir/file2.txt"])
 

--- a/tests/archivey/test_io_helpers.py
+++ b/tests/archivey/test_io_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_compressed_stream
 from archivey.formats.compressed_streams import get_stream_open_fn
 from archivey.internal.archive_stream import ArchiveStream
@@ -18,7 +19,7 @@ from archivey.internal.io_helpers import (
     is_stream,
     read_exact,
 )
-from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SINGLE_FILE_ARCHIVES
+from tests.archivey.sample_archives import SINGLE_FILE_ARCHIVES, SampleArchive
 from tests.archivey.test_open_nonseekable import NonSeekableBytesIO
 from tests.archivey.testing_utils import skip_if_package_missing
 
@@ -466,25 +467,20 @@ def test_ensure_bufferedio():
     assert buffered.read() == b"hello"
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_ensure_bufferedio_with_compressed_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    with open_compressed_stream(sample_archive_path, config=config) as f:
+    with open_compressed_stream(sample_archive_path, config=archive_config) as f:
         buffered = ensure_bufferedio(f)
         assert buffered.read() == sample_archive.contents.files[0].contents
 
     buffer = bytearray(1024)
-    with open_compressed_stream(sample_archive_path, config=config) as f:
+    with open_compressed_stream(sample_archive_path, config=archive_config) as f:
         buffered = ensure_bufferedio(f)
         bytes_read = buffered.readinto(buffer)
         assert bytes_read == min(
@@ -496,20 +492,17 @@ def test_ensure_bufferedio_with_compressed_stream(
         )
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_ensure_bufferedio_with_raw_compressed_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    open_fn, _ = get_stream_open_fn(sample_archive.creation_info.format.stream, config)
+    open_fn, _ = get_stream_open_fn(
+        sample_archive.creation_info.format.stream, archive_config
+    )
     with open_fn(sample_archive_path) as f:
         buffered = ensure_bufferedio(f)
         assert buffered.read() == sample_archive.contents.files[0].contents

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.exceptions import (
     PackageNotInstalledError,
 )
 from archivey.internal.dependency_checker import get_dependency_versions
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     SAMPLE_ARCHIVES,
     SampleArchive,
     filter_archives,
@@ -69,26 +69,29 @@ BASIC_UNIX_COMPRESS_ARCHIVE = filter_archives(
 
 
 @pytest.mark.parametrize(
-    ["library_name", "sample_archive", "alternative_packages"],
+    ["library_name", "sample_archive", "config"],
     [
         # ("pycdlib", BASIC_ISO_ARCHIVE.get_archive_path(), None),
-        ("rarfile", BASIC_RAR_ARCHIVE, False),
-        ("py7zr", BASIC_7Z_ARCHIVE, False),
-        ("rapidgzip", BASIC_GZIP_ARCHIVE, True),
-        ("indexed_bzip2", BASIC_BZIP2_ARCHIVE, True),
-        ("python-xz", BASIC_XZ_ARCHIVE, True),
-        ("pyzstd", BASIC_ZSTD_ARCHIVE, False),
-        ("zstandard", BASIC_ZSTD_ARCHIVE, True),
-        ("lz4", BASIC_LZ4_ARCHIVE, False),
-        ("brotli", BASIC_BROTLI_ARCHIVE, False),
-        ("uncompresspy", BASIC_UNIX_COMPRESS_ARCHIVE, False),
+        ("rarfile", BASIC_RAR_ARCHIVE, ArchiveyConfig()),
+        ("py7zr", BASIC_7Z_ARCHIVE, ArchiveyConfig()),
+        ("rapidgzip", BASIC_GZIP_ARCHIVE, ArchiveyConfig(use_rapidgzip=True)),
+        (
+            "indexed_bzip2",
+            BASIC_BZIP2_ARCHIVE,
+            ArchiveyConfig(use_indexed_bzip2=True),
+        ),
+        ("python-xz", BASIC_XZ_ARCHIVE, ArchiveyConfig(use_python_xz=True)),
+        ("pyzstd", BASIC_ZSTD_ARCHIVE, ArchiveyConfig()),
+        ("zstandard", BASIC_ZSTD_ARCHIVE, ArchiveyConfig(use_zstandard=True)),
+        ("lz4", BASIC_LZ4_ARCHIVE, ArchiveyConfig()),
+        ("brotli", BASIC_BROTLI_ARCHIVE, ArchiveyConfig()),
+        ("uncompresspy", BASIC_UNIX_COMPRESS_ARCHIVE, ArchiveyConfig()),
     ],
-    ids=lambda x: os.path.basename(x) if isinstance(x, str) else x,
+    ids=lambda x: os.path.basename(x) if isinstance(x, str) else str(x),
 )
 def test_missing_package_raises_exception(
-    library_name: str, sample_archive: SampleArchive, alternative_packages: bool
+    library_name: str, sample_archive: SampleArchive, config: ArchiveyConfig | None
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
     archive_path = sample_archive.get_archive_path()
     dependencies = get_dependency_versions()
     library_version = getattr(dependencies, f"{library_name.replace('-', '_')}_version")

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 import pytest
 
 from archivey.archive_reader import ArchiveReader
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive, open_compressed_stream
 from archivey.exceptions import ArchiveStreamNotSeekableError, PackageNotInstalledError
 from archivey.types import ArchiveFormat, ContainerFormat, StreamFormat
@@ -19,7 +20,6 @@ from tests.archivey.create_archives import (
     create_zip_archive_with_zipfile,
 )
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
     ArchiveContents,
@@ -93,16 +93,11 @@ def check_archive_iter_members(archive: ArchiveReader):
     "outer_stream_format",
     set(StreamFormat) - {StreamFormat.UNCOMPRESSED},
 )
-@pytest.mark.parametrize(
-    "inner_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
+    )
 )
 @pytest.mark.parametrize(
     "open_inner_streaming_only",
@@ -110,40 +105,39 @@ def check_archive_iter_members(archive: ArchiveReader):
 )
 def test_open_archive_from_compressed_stream(
     outer_stream_format: StreamFormat,
-    inner_archive: SampleArchive,
+    sample_archive: SampleArchive,
     tmp_path,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
     open_inner_streaming_only: bool,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
     outer_format = ArchiveFormat(ContainerFormat.RAW_STREAM, outer_stream_format)
 
-    skip_if_package_missing(outer_format, config)
-    skip_if_package_missing(inner_archive.creation_info.format, config)
+    skip_if_package_missing(outer_format, archive_config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     if (
-        alternative_packages
+        archive_config.use_indexed_bzip2
         and outer_stream_format == StreamFormat.BZIP2
-        and inner_archive.filename.endswith(".bz2")
+        and sample_archive.filename.endswith(".bz2")
     ):
         pytest.xfail("prevent segfault")
 
     logger.info(
-        f"alternative_packages: {alternative_packages}, outer_format: {outer_stream_format}, inner_archive.filename: {inner_archive.filename}"
+        f"archive_config: {archive_config}, outer_format: {outer_stream_format}, inner_archive.filename: {sample_archive.filename}"
     )
 
-    inner_path = inner_archive.get_archive_path()
+    inner_path = sample_archive.get_archive_path()
     compressed_path = os.path.join(
         tmp_path,
         os.path.basename(inner_path) + "." + outer_format.file_extension(),
     )
     compress_stream(inner_path, compressed_path, outer_stream_format)
 
-    with open_compressed_stream(compressed_path, config=config) as stream:
+    with open_compressed_stream(compressed_path, config=archive_config) as stream:
         with open_archive(
-            stream, config=config, streaming_only=open_inner_streaming_only
+            stream, config=archive_config, streaming_only=open_inner_streaming_only
         ) as archive:
-            assert archive.format == inner_archive.creation_info.format
+            assert archive.format == sample_archive.creation_info.format
             check_archive_iter_members(archive)
 
 
@@ -169,16 +163,11 @@ def expect_raise_if(condition: bool, exc_type: type[Exception]):
     + ALL_TAR_FORMATS,
     ids=lambda a: a.file_extension(),
 )
-@pytest.mark.parametrize(
-    "inner_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
+    )
 )
 @pytest.mark.parametrize(
     "open_outer_streaming_only",
@@ -187,32 +176,36 @@ def expect_raise_if(condition: bool, exc_type: type[Exception]):
 )
 def test_open_archive_from_member(
     outer_format: ArchiveFormat,
-    inner_archive: SampleArchive,
+    sample_archive: SampleArchive,
     tmp_path,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
     open_outer_streaming_only: bool,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
+    skip_if_package_missing(outer_format, archive_config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    skip_if_package_missing(outer_format, config)
-    skip_if_package_missing(inner_archive.creation_info.format, config)
-
-    inner_path = inner_archive.get_archive_path()
+    inner_path = sample_archive.get_archive_path()
     outer_path = os.path.join(tmp_path, "outer." + outer_format.file_extension())
     try:
         create_archive_with_member(outer_format, inner_path, outer_path)
     except PackageNotInstalledError as exc:
         pytest.skip(str(exc))
 
+    alternative_packages = (
+        archive_config.use_rapidgzip
+        or archive_config.use_indexed_bzip2
+        or archive_config.use_python_xz
+        or archive_config.use_zstandard
+    )
     expect_non_seekable_failure = (
-        inner_archive.creation_info.format,
+        sample_archive.creation_info.format,
         alternative_packages,
     ) in EXPECTED_NON_SEEKABLE_FAILURES
 
     # Try opening the inner archive in random mode. It should work if the outer
     # archive is seekable and it provides seekable streams (only 7z doesn't).
     with open_archive(
-        outer_path, config=config, streaming_only=open_outer_streaming_only
+        outer_path, config=archive_config, streaming_only=open_outer_streaming_only
     ) as outer:
         assert outer.get_archive_info().format == outer_format
 
@@ -230,9 +223,9 @@ def test_open_archive_from_member(
                 ArchiveStreamNotSeekableError,
             ):
                 with open_archive(
-                    stream, config=config, streaming_only=False
+                    stream, config=archive_config, streaming_only=False
                 ) as archive:
-                    assert archive.format == inner_archive.creation_info.format
+                    assert archive.format == sample_archive.creation_info.format
                     assert archive.get_members() is not None
                     check_archive_iter_members(archive)
 
@@ -242,7 +235,7 @@ def test_open_archive_from_member(
     # seekable or if the inner library support opening non-seekable streams in
     # streaming mode.
     with open_archive(
-        outer_path, config=config, streaming_only=open_outer_streaming_only
+        outer_path, config=archive_config, streaming_only=open_outer_streaming_only
     ) as outer:
         assert outer.get_archive_info().format == outer_format
 
@@ -260,9 +253,9 @@ def test_open_archive_from_member(
                 ArchiveStreamNotSeekableError,
             ):
                 with open_archive(
-                    stream, config=config, streaming_only=True
+                    stream, config=archive_config, streaming_only=True
                 ) as archive:
-                    assert archive.format == inner_archive.creation_info.format
+                    assert archive.format == sample_archive.creation_info.format
                     check_archive_iter_members(archive)
 
         assert outer_has_member

--- a/tests/archivey/test_open_compressed_stream.py
+++ b/tests/archivey/test_open_compressed_stream.py
@@ -10,6 +10,7 @@ from archivey.types import ContainerFormat, StreamFormat
 from tests.archivey.sample_archives import (
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
+    SampleArchive,
     filter_archives,
 )
 from tests.archivey.testing_utils import skip_if_package_missing
@@ -19,28 +20,15 @@ BASIC_ZIP_ARCHIVE = filter_archives(BASIC_ARCHIVES, extensions=["zip"])[0]
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_compressed_stream_from_file(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    skip_if_package_missing(sample_archive.creation_info.format, config)
-
-    with open_compressed_stream(sample_archive_path, config=config) as f:
+    with open_compressed_stream(sample_archive_path, config=archive_config) as f:
         data = f.read()
 
     expected = sample_archive.contents.files[0].contents
@@ -55,57 +43,31 @@ def test_open_compressed_stream_unsupported_format(tmp_path):
         open_compressed_stream(path)
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_compressed_stream_from_stream(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     compressed_data = open(sample_archive_path, "rb").read()
     compressed_stream = io.BytesIO(compressed_data)
 
-    with open_compressed_stream(compressed_stream, config=config) as f:
+    with open_compressed_stream(compressed_stream, config=archive_config) as f:
         data = f.read()
 
     expected = sample_archive.contents.files[0].contents
     assert data == expected
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_compressed_stream_from_stream_with_prefix(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     # Add some bad data to the beginning of the stream, to test that the reading is
     # done from the initial position.
@@ -114,39 +76,28 @@ def test_open_compressed_stream_from_stream_with_prefix(
     compressed_stream = io.BytesIO(compressed_data)
     compressed_stream.seek(len(bad_data))
 
-    with open_compressed_stream(compressed_stream, config=config) as f:
+    with open_compressed_stream(compressed_stream, config=archive_config) as f:
         data = f.read()
 
     expected = sample_archive.contents.files[0].contents
     assert data == expected
 
 
-@pytest.mark.parametrize("sample_archive", BASIC_ARCHIVES, ids=lambda a: a.filename)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "altlibs"]
-)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_open_compressed_stream_from_archive(
-    sample_archive, sample_archive_path, alternative_packages
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     if (
         sample_archive.creation_info.format.container == ContainerFormat.TAR
         and sample_archive.creation_info.format.stream != StreamFormat.UNCOMPRESSED
     ):
-        with open_compressed_stream(sample_archive_path, config=config) as f:
+        with open_compressed_stream(sample_archive_path, config=archive_config) as f:
             data = f.read()
             assert data[257 : 257 + 5] == b"ustar"
     else:
         with pytest.raises(ArchiveNotSupportedError):
-            open_compressed_stream(sample_archive_path, config=config)
+            open_compressed_stream(sample_archive_path, config=archive_config)

--- a/tests/archivey/test_open_member.py
+++ b/tests/archivey/test_open_member.py
@@ -1,8 +1,8 @@
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     HARDLINK_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -12,21 +12,17 @@ from tests.archivey.sample_archives import (
 from tests.archivey.testing_utils import remove_duplicate_files, skip_if_package_missing
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    BASIC_ARCHIVES + SYMLINK_ARCHIVES + HARDLINK_ARCHIVES,
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+@pytest.mark.sample_archives(
+    BASIC_ARCHIVES + SYMLINK_ARCHIVES + HARDLINK_ARCHIVES
 )
 def test_open_member(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path, config=config) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         # members = archive.get_members()
 
         for sample_file in remove_duplicate_files(sample_archive.contents.files):
@@ -36,19 +32,15 @@ def test_open_member(
                 assert data == sample_file.contents
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_member_single_file_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path, config=config) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         member = archive.get_members()[0]
 
         stream = archive.open(member)

--- a/tests/archivey/test_open_nonseekable.py
+++ b/tests/archivey/test_open_nonseekable.py
@@ -3,12 +3,12 @@ import logging
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive, open_compressed_stream
 from archivey.exceptions import ArchiveStreamNotSeekableError
 from archivey.internal.io_helpers import ensure_binaryio
 from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SampleArchive,
@@ -59,32 +59,34 @@ class NonSeekableBytesIO(io.BytesIO):
         raise io.UnsupportedOperation("tell")
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + LARGE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_nonseekable(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure open_archive can read from non-seekable streams in streaming mode."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
 
     stream = NonSeekableBytesIO(data)
 
+    alternative_packages = (
+        archive_config.use_rapidgzip
+        or archive_config.use_indexed_bzip2
+        or archive_config.use_python_xz
+        or archive_config.use_zstandard
+    )
+
     try:
-        with open_archive(stream, streaming_only=True, config=config) as archive:
+        with open_archive(stream, streaming_only=True, config=archive_config) as archive:
             members = []
             for member, member_stream in archive.iter_members_with_streams():
                 members.append(member)
@@ -110,26 +112,28 @@ def test_open_archive_nonseekable(
             )
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_compressed_stream_nonseekable(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
 
     stream = ensure_binaryio(NonSeekableBytesIO(data))
 
+    alternative_packages = (
+        archive_config.use_rapidgzip
+        or archive_config.use_indexed_bzip2
+        or archive_config.use_python_xz
+        or archive_config.use_zstandard
+    )
+
     try:
-        with open_compressed_stream(stream, config=config) as f:
+        with open_compressed_stream(stream, config=archive_config) as f:
             assert not f.seekable()
 
             out = f.read()

--- a/tests/archivey/test_open_stream.py
+++ b/tests/archivey/test_open_stream.py
@@ -2,9 +2,10 @@ import io
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.types import ArchiveFormat
-from tests.archivey.sample_archives import ALTERNATIVE_CONFIG, SAMPLE_ARCHIVES
+from tests.archivey.sample_archives import SAMPLE_ARCHIVES, SampleArchive
 from tests.archivey.testing_utils import skip_if_package_missing
 
 # Select one sample archive for each format (except FOLDER and ISO)
@@ -16,21 +17,18 @@ for a in SAMPLE_ARCHIVES:
     archives_by_format.setdefault(fmt, a)
 
 
-@pytest.mark.parametrize(
-    "sample_archive", list(archives_by_format.values()), ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
-def test_open_stream(sample_archive, alternative_packages):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+@pytest.mark.sample_archives(list(archives_by_format.values()))
+def test_open_stream(
+    sample_archive: SampleArchive,
+    archive_config: ArchiveyConfig,
+):
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     path = sample_archive.get_archive_path()
     with open(path, "rb") as f:
         data = f.read()
 
-    with open_archive(io.BytesIO(data), config=config) as archive:
+    with open_archive(io.BytesIO(data), config=archive_config) as archive:
         has_member = False
         for member, stream in archive.iter_members_with_streams():
             has_member = True

--- a/tests/archivey/test_open_url.py
+++ b/tests/archivey/test_open_url.py
@@ -9,13 +9,14 @@ from urllib.request import urlopen
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.exceptions import ArchiveStreamNotSeekableError
 from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
+    SampleArchive,
     filter_archives,
 )
 from tests.archivey.test_open_nonseekable import EXPECTED_NON_SEEKABLE_FAILURES
@@ -67,29 +68,31 @@ def serve_dir(path: str):
         t.join()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format != ArchiveFormat.FOLDER,
-    ),
-    ids=lambda a: a.filename,
+    )
 )
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
-def test_open_archive_via_http(sample_archive, alternative_packages):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+def test_open_archive_via_http(
+    sample_archive: SampleArchive, archive_config: ArchiveyConfig
+):
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     path = sample_archive.get_archive_path()
     with serve_dir(os.path.dirname(path)) as base_url:
         url = f"{base_url}/{os.path.basename(path)}"
         logger.info(f"Opening URL: {url}")
         with urlopen(url, timeout=2) as response:
+            alternative_packages = (
+                archive_config.use_rapidgzip
+                or archive_config.use_indexed_bzip2
+                or archive_config.use_python_xz
+                or archive_config.use_zstandard
+            )
             try:
                 with open_archive(
-                    response, streaming_only=True, config=config
+                    response, streaming_only=True, config=archive_config
                 ) as archive:
                     has_member = False
                     for member, stream in archive.iter_members_with_streams():

--- a/tests/archivey/test_path_traversal.py
+++ b/tests/archivey/test_path_traversal.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from archivey import open_archive
+from archivey.config import ArchiveyConfig
 from archivey.exceptions import (
     ArchiveMemberCannotBeOpenedError,
     ArchiveMemberNotFoundError,
@@ -18,12 +19,14 @@ from tests.archivey.testing_utils import skip_if_package_missing
 SANITIZE_ALL_ARCHIVES = filter_archives(SAMPLE_ARCHIVES, prefixes=["sanitize"])
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SANITIZE_ALL_ARCHIVES, ids=lambda a: a.filename
-)
-def test_open_symlink_outside(sample_archive: SampleArchive, sample_archive_path: str):
+@pytest.mark.sample_archives(SANITIZE_ALL_ARCHIVES)
+def test_open_symlink_outside(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
     """Opening a symlink that points outside the archive should fail."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     # For folder archives ensure the link target exists so failures are due to
     # the path check, not a missing file.
@@ -31,7 +34,7 @@ def test_open_symlink_outside(sample_archive: SampleArchive, sample_archive_path
         folder_root = Path(sample_archive_path)
         (folder_root.parent / "escape.txt").write_text("outside")
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         members = {m.filename: m for m in archive.get_members()}
         member = members.get("link_outside")
         assert member is not None, "test archive missing link_outside"

--- a/tests/archivey/test_read_archives.py
+++ b/tests/archivey/test_read_archives.py
@@ -20,7 +20,6 @@ from archivey.types import (
     MemberType,
 )
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     MARKER_MTIME_BASED_ON_ARCHIVE_NAME,
     SAMPLE_ARCHIVES,
     FileInfo,
@@ -177,9 +176,9 @@ def check_member_metadata(
 def check_iter_members(
     sample_archive: SampleArchive,
     archive_path: str,
+    config: ArchiveyConfig,
     set_file_password_in_constructor: bool = True,
     skip_member_contents: bool = False,
-    config: Optional[ArchiveyConfig] = None,
 ):
     skip_if_package_missing(sample_archive.creation_info.format, config)
 
@@ -237,7 +236,7 @@ def check_iter_members(
         )
 
     archive_path_resolved = archive_path or sample_archive.get_archive_path()
-    config = replace(config or ArchiveyConfig(), extraction_filter=TESTING_FILTER)
+    config = replace(config, extraction_filter=TESTING_FILTER)
 
     with open_archive(
         archive_path_resolved,
@@ -368,34 +367,30 @@ def check_iter_members(
                     archive.open(filename)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(
-        SAMPLE_ARCHIVES,
-        extensions=["zip"],
-    ),
-    ids=lambda x: x.filename,
-)
-def test_read_zip_archives(sample_archive: SampleArchive, sample_archive_path: str):
-    check_iter_members(sample_archive, archive_path=sample_archive_path)
+@pytest.mark.sample_archives(filter_archives(SAMPLE_ARCHIVES, extensions=["zip"]))
+def test_read_zip_archives(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
+    check_iter_members(
+        sample_archive, archive_path=sample_archive_path, config=archive_config
+    )
 
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         custom_filter=lambda x: x.creation_info.format.container == ContainerFormat.TAR,
-    ),
-    ids=lambda x: x.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_read_tar_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     logger.info(f"Testing {sample_archive.filename}; files at {sample_archive_path}")
 
@@ -403,26 +398,21 @@ def test_read_tar_archives(
         f"Testing {sample_archive.filename} with format {sample_archive.creation_info.format}"
     )
 
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     check_iter_members(
         sample_archive,
         archive_path=sample_archive_path,
         skip_member_contents=True,
-        config=config,
+        config=archive_config,
     )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(SAMPLE_ARCHIVES, extensions=["rar"]),
-    ids=lambda x: x.filename,
-)
-@pytest.mark.parametrize("use_rar_stream", [True, False])
+@pytest.mark.sample_archives(filter_archives(SAMPLE_ARCHIVES, extensions=["rar"]))
 def test_read_rar_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, use_rar_stream: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     deps = get_dependency_versions()
     if (
@@ -431,10 +421,9 @@ def test_read_rar_archives(
     ):
         pytest.skip("Cryptography is not installed, skipping RAR encrypted-header test")
 
+    use_rar_stream = archive_config.use_rar_stream
     if use_rar_stream and deps.unrar_version is None:
         pytest.skip("unrar not installed, skipping RarStreamReader test")
-
-    config = ArchiveyConfig(use_rar_stream=use_rar_stream)
 
     has_password = sample_archive.contents.has_password()
     has_multiple_passwords = sample_archive.contents.has_multiple_passwords()
@@ -454,123 +443,112 @@ def test_read_rar_archives(
             check_iter_members(
                 sample_archive,
                 archive_path=sample_archive_path,
-                config=config,
+                config=archive_config,
             )
     else:
         check_iter_members(
             sample_archive,
             archive_path=sample_archive_path,
-            config=config,
+            config=archive_config,
             skip_member_contents=deps.unrar_version is None,
         )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         extensions=["rar"],
         custom_filter=lambda x: x.contents.has_password()
         and not x.contents.has_multiple_passwords()
         and x.contents.header_password is None,
-    ),
-    ids=lambda x: x.filename,
+    )
 )
-@pytest.mark.parametrize("use_rar_stream", [True, False])
 def test_read_rar_archives_with_password_in_constructor(
-    sample_archive: SampleArchive, sample_archive_path: str, use_rar_stream: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     deps = get_dependency_versions()
-    if use_rar_stream and deps.unrar_version is None:
+    if archive_config.use_rar_stream and deps.unrar_version is None:
         pytest.skip("unrar not installed, skipping RarStreamReader test")
 
-    config = ArchiveyConfig(use_rar_stream=use_rar_stream)
     check_iter_members(
         sample_archive,
         archive_path=sample_archive_path,
-        config=config,
+        config=archive_config,
         set_file_password_in_constructor=True,
         skip_member_contents=deps.unrar_version is None,
     )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         extensions=["zip", "7z"],
         custom_filter=lambda x: x.contents.has_password()
         and not x.contents.has_multiple_passwords()
         and x.contents.header_password is None,
-    ),
-    ids=lambda x: x.filename,
+    )
 )
 def test_read_zip_and_7z_archives_with_password_in_constructor(
     sample_archive: SampleArchive,
     sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     check_iter_members(
         sample_archive,
         archive_path=sample_archive_path,
+        config=archive_config,
         set_file_password_in_constructor=True,
     )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(SAMPLE_ARCHIVES, extensions=["7z"]),
-    ids=lambda x: x.filename,
-)
-def test_read_7z_archives(sample_archive: SampleArchive, sample_archive_path: str):
-    check_iter_members(sample_archive, archive_path=sample_archive_path)
+@pytest.mark.sample_archives(filter_archives(SAMPLE_ARCHIVES, extensions=["7z"]))
+def test_read_7z_archives(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
+    check_iter_members(
+        sample_archive, archive_path=sample_archive_path, config=archive_config
+    )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES, prefixes=["single_file", "single_file_with_metadata"]
-    ),
-    ids=lambda x: x.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_read_single_file_compressed_archives(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-            use_single_file_stored_metadata=True,
-        )
-    else:
-        config = ArchiveyConfig(use_single_file_stored_metadata=True)
-
+    config = replace(archive_config, use_single_file_stored_metadata=True)
     check_iter_members(sample_archive, archive_path=sample_archive_path, config=config)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(SAMPLE_ARCHIVES, prefixes=["symlinks", "symlinks_solid"]),
-    ids=lambda x: x.filename,
+@pytest.mark.sample_archives(
+    filter_archives(SAMPLE_ARCHIVES, prefixes=["symlinks", "symlinks_solid"])
 )
 def test_read_symlinks_archives(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    check_iter_members(sample_archive, archive_path=sample_archive_path)
+    check_iter_members(
+        sample_archive, archive_path=sample_archive_path, config=archive_config
+    )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(SAMPLE_ARCHIVES, prefixes=["symlink_loop"]),
-    ids=lambda x: x.filename,
-)
-def test_symlink_loop_archives(sample_archive: SampleArchive, sample_archive_path: str):
+@pytest.mark.sample_archives(filter_archives(SAMPLE_ARCHIVES, prefixes=["symlink_loop"]))
+def test_symlink_loop_archives(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
     """Ensure that archives with symlink loops do not cause infinite loops."""
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for member in archive.get_members():
             if member.type == MemberType.SYMLINK:
                 if member.link_target == "file5.txt":
@@ -584,24 +562,28 @@ def test_symlink_loop_archives(sample_archive: SampleArchive, sample_archive_pat
                     fh.read()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES, prefixes=["hardlinks_nonsolid", "hardlinks_solid"]
-    ),
-    ids=lambda x: x.filename,
+    )
 )
 def test_read_hardlinks_archives(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
-    check_iter_members(sample_archive, archive_path=sample_archive_path)
+    check_iter_members(
+        sample_archive, archive_path=sample_archive_path, config=archive_config
+    )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
-    filter_archives(SAMPLE_ARCHIVES, extensions=["_folder/"]),
-    ids=lambda x: x.filename,
-)
-def test_read_folder_archives(sample_archive: SampleArchive, sample_archive_path: str):
+@pytest.mark.sample_archives(filter_archives(SAMPLE_ARCHIVES, extensions=["_folder/"]))
+def test_read_folder_archives(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
     logger.info(f"Testing {sample_archive.filename}; files at {sample_archive_path}")
-    check_iter_members(sample_archive, archive_path=sample_archive_path)
+    check_iter_members(
+        sample_archive, archive_path=sample_archive_path, config=archive_config
+    )

--- a/tests/archivey/test_small_reads.py
+++ b/tests/archivey/test_small_reads.py
@@ -3,11 +3,11 @@ import logging
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.internal.utils import ensure_not_none
 from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SINGLE_FILE_ARCHIVES,
@@ -51,26 +51,20 @@ class SizeLimitedReader(io.RawIOBase):
         super().close()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + SINGLE_FILE_ARCHIVES + LARGE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "alternative"]
+    )
 )
 @pytest.mark.parametrize("streaming_only", [False, True], ids=["random", "stream"])
 def test_open_archive_small_reads(
     sample_archive: SampleArchive,
     sample_archive_path: str,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
     streaming_only: bool,
 ):
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -80,7 +74,9 @@ def test_open_archive_small_reads(
     max_bytes = 250 if "large" in sample_archive_path else 1
     stream = SizeLimitedReader(data, max_bytes=max_bytes)
 
-    with open_archive(stream, streaming_only=streaming_only, config=config) as archive:
+    with open_archive(
+        stream, streaming_only=streaming_only, config=archive_config
+    ) as archive:
         has_member = False
         for member, member_stream in archive.iter_members_with_streams():
             has_member = True

--- a/tests/archivey/test_statsio.py
+++ b/tests/archivey/test_statsio.py
@@ -8,7 +8,6 @@ from archivey.core import open_archive, open_compressed_stream
 from archivey.internal.io_helpers import IOStats, StatsIO, ensure_binaryio
 from archivey.types import ArchiveFormat
 from tests.archivey.sample_archives import (
-    ALTERNATIVE_CONFIG,
     BASIC_ARCHIVES,
     LARGE_ARCHIVES,
     SampleArchive,
@@ -20,32 +19,19 @@ from tests.archivey.testing_utils import skip_if_package_missing
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + LARGE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure open_archive can read from StatsIO-wrapped streams and tracks statistics correctly."""
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -59,7 +45,7 @@ def test_open_archive_statsio(
     initial_seek_calls = stats.seek_calls
     initial_read_ranges = len(stats.read_ranges)
 
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         has_member = False
         total_member_bytes = 0
 
@@ -79,24 +65,19 @@ def test_open_archive_statsio(
     assert len(stats.read_ranges) > initial_read_ranges, "No read ranges were tracked"
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES + LARGE_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio_streaming_mode(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure open_archive can read from StatsIO-wrapped streams in streaming mode."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -110,7 +91,7 @@ def test_open_archive_statsio_streaming_mode(
     initial_seek_calls = stats.seek_calls
     initial_read_ranges = len(stats.read_ranges)
 
-    with open_archive(stream, streaming_only=True, config=config) as archive:
+    with open_archive(stream, streaming_only=True, config=archive_config) as archive:
         has_member = False
         total_member_bytes = 0
 
@@ -135,19 +116,14 @@ def test_open_archive_statsio_streaming_mode(
     )
 
 
-@pytest.mark.parametrize(
-    "sample_archive", SINGLE_FILE_ARCHIVES, ids=lambda a: a.filename
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
-)
+@pytest.mark.sample_archives(SINGLE_FILE_ARCHIVES)
 def test_open_compressed_stream_statsio(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure open_compressed_stream can read from StatsIO-wrapped streams and tracks statistics correctly."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -161,7 +137,7 @@ def test_open_compressed_stream_statsio(
     initial_seek_calls = stats.seek_calls
     initial_read_ranges = len(stats.read_ranges)
 
-    with open_compressed_stream(stream, config=config) as f:
+    with open_compressed_stream(stream, config=archive_config) as f:
         out = f.read()
 
     # Verify that statistics were tracked
@@ -183,24 +159,19 @@ def test_open_compressed_stream_statsio(
     assert out == expected
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio_seek_operations(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Test that seek operations are properly tracked by StatsIO when opening archives."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -213,7 +184,7 @@ def test_open_archive_statsio_seek_operations(
     initial_seek_calls = stats.seek_calls
     initial_read_ranges = len(stats.read_ranges)
 
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         # Get member list first (this may trigger seeks)
         members = archive.get_members()
         assert len(members) > 0
@@ -235,24 +206,19 @@ def test_open_archive_statsio_seek_operations(
         assert read_range[1] >= 0
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio_readinto_operations(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Test that readinto operations are properly tracked by StatsIO when opening archives."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -265,7 +231,7 @@ def test_open_archive_statsio_readinto_operations(
     initial_bytes_read = stats.bytes_read
     initial_read_ranges = len(stats.read_ranges)
 
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         # Read members using readinto to test that operation
         for member in archive.get_members():
             if member.type.value == "file":  # Only try to open file members
@@ -284,24 +250,19 @@ def test_open_archive_statsio_readinto_operations(
     assert len(stats.read_ranges) > initial_read_ranges, "No read ranges were tracked"
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio_multiple_opens(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Test that StatsIO properly tracks statistics across multiple archive opens."""
-    config = ALTERNATIVE_CONFIG if alternative_packages else None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -311,7 +272,7 @@ def test_open_archive_statsio_multiple_opens(
     stream = StatsIO(io.BytesIO(data), stats)
 
     # First open
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         members = archive.get_members()
         assert len(members) > 0
 
@@ -320,7 +281,7 @@ def test_open_archive_statsio_multiple_opens(
     first_open_ranges = len(stats.read_ranges)
 
     # Second open (should accumulate stats)
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         members = archive.get_members()
         assert len(members) > 0
 
@@ -334,32 +295,19 @@ def test_open_archive_statsio_multiple_opens(
     )
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         BASIC_ARCHIVES,
         custom_filter=lambda a: a.creation_info.format not in (ArchiveFormat.FOLDER,),
-    ),
-    ids=lambda a: a.filename,
-)
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["defaultlibs", "altlibs"]
+    )
 )
 def test_open_archive_statsio_io_methods(
-    sample_archive: SampleArchive, sample_archive_path: str, alternative_packages: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Test that StatsIO properly delegates IO methods to the underlying stream."""
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = None
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     with open(sample_archive_path, "rb") as f:
         data = f.read()
@@ -375,7 +323,7 @@ def test_open_archive_statsio_io_methods(
     assert stream.seekable() == underlying_stream.seekable()
 
     # Test that we can still open the archive normally
-    with open_archive(stream, config=config) as archive:
+    with open_archive(stream, config=archive_config) as archive:
         members = archive.get_members()
         assert len(members) > 0
 

--- a/tests/archivey/test_streaming_modes.py
+++ b/tests/archivey/test_streaming_modes.py
@@ -25,18 +25,20 @@ def _first_regular_file(sample: SampleArchive):
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
-def test_random_access_mode(sample_archive: SampleArchive, sample_archive_path: str):
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+def test_random_access_mode(
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
+):
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         assert archive.has_random_access()
         members_if_available = archive.get_members_if_available()
         members = archive.get_members()
@@ -84,40 +86,24 @@ def test_random_access_mode(sample_archive: SampleArchive, sample_archive_path: 
             f.read()
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 @pytest.mark.parametrize("close_streams", [False, True], ids=["noclose", "close"])
-@pytest.mark.parametrize(
-    "alternative_packages", [False, True], ids=["default", "alternative"]
-)
 def test_streaming_only_mode(
     sample_archive: SampleArchive,
     sample_archive_path: str,
     close_streams: bool,
-    alternative_packages: bool,
+    archive_config: ArchiveyConfig,
 ):
-    if alternative_packages:
-        config = ArchiveyConfig(
-            use_rar_stream=True,
-            use_rapidgzip=True,
-            use_indexed_bzip2=True,
-            use_python_xz=True,
-            use_zstandard=True,
-        )
-    else:
-        config = ArchiveyConfig()
-
-    skip_if_package_missing(sample_archive.creation_info.format, config)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     first_file = _first_regular_file(sample_archive)
     with open_archive(
-        sample_archive_path, streaming_only=True, config=config
+        sample_archive_path, streaming_only=True, config=archive_config
     ) as archive:
         assert not archive.has_random_access()
 
@@ -170,25 +156,28 @@ def test_streaming_only_mode(
                 stream.close()  # Should be a no-op, not raise anything
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 @pytest.mark.parametrize("streaming_only", [False, True], ids=["random", "stream"])
 def test_iter_members_partial_reads(
-    sample_archive: SampleArchive, sample_archive_path: str, streaming_only: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    streaming_only: bool,
+    archive_config: ArchiveyConfig,
 ):
     """Reading some members fully, partially or not at all should not break iteration."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     files = [f for f in sample_archive.contents.files if f.type == MemberType.FILE]
     assert len(files) == 5
 
-    with open_archive(sample_archive_path, streaming_only=streaming_only) as archive:
+    with open_archive(
+        sample_archive_path, streaming_only=streaming_only, config=archive_config
+    ) as archive:
         for i, (member, stream) in enumerate(
             archive.iter_members_with_streams(
                 members=lambda m: m.type == MemberType.FILE
@@ -210,8 +199,7 @@ def test_iter_members_partial_reads(
                 pass
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=[
@@ -219,15 +207,17 @@ def test_iter_members_partial_reads(
             "basic_solid",
             "duplicate_files",
         ],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 @pytest.mark.parametrize("streaming_only", [False, True], ids=["random", "stream"])
 def test_iter_members_list_filter(
-    sample_archive: SampleArchive, sample_archive_path: str, streaming_only: bool
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    streaming_only: bool,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure iter_members_with_streams honours the filter callable."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
     if (
         sample_archive.filename.startswith("duplicate_files")
         and not sample_archive.creation_info.features.duplicate_files
@@ -242,7 +232,9 @@ def test_iter_members_list_filter(
     ]
     read_contents = []
 
-    with open_archive(sample_archive_path, streaming_only=streaming_only) as archive:
+    with open_archive(
+        sample_archive_path, streaming_only=streaming_only, config=archive_config
+    ) as archive:
         for member, stream in archive.iter_members_with_streams(members=file_names):
             assert member.filename in file_names
             read_contents.append(
@@ -252,21 +244,24 @@ def test_iter_members_list_filter(
     assert sorted(file_contents) == sorted(read_contents), file_names
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_streaming_only_allows_single_iteration(
-    tmp_path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Ensure streaming-only archives can be consumed only once."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path, streaming_only=True) as archive:
+    with open_archive(
+        sample_archive_path, streaming_only=True, config=archive_config
+    ) as archive:
         next(archive.iter_members_with_streams())
 
         with pytest.raises(ValueError):
@@ -276,33 +271,36 @@ def test_streaming_only_allows_single_iteration(
             archive.extractall(tmp_path)
 
 
-@pytest.mark.parametrize(
-    "sample_archive",
+@pytest.mark.sample_archives(
     filter_archives(
         SAMPLE_ARCHIVES,
         prefixes=["large_files_nonsolid", "large_files_solid"],
-    ),
-    ids=lambda a: a.filename,
+    )
 )
 def test_random_access_allows_multiple_iterations(
-    tmp_path, sample_archive: SampleArchive, sample_archive_path: str
+    tmp_path,
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ):
     """Random access readers should allow multiple iterations."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         next(archive.iter_members_with_streams())
         list(archive.iter_members_with_streams())
         list(archive.iter_members_with_streams())
 
 
-@pytest.mark.parametrize("sample_archive", SYMLINK_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(SYMLINK_ARCHIVES)
 def test_resolve_link_symlink_without_target(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ) -> None:
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         for sample_file in sample_archive.contents.files:
             member = archive.get_member(sample_file.name)
             resolved = archive.resolve_link(member)

--- a/tests/archivey/test_usage_errors.py
+++ b/tests/archivey/test_usage_errors.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from archivey.config import ArchiveyConfig
 from archivey.core import open_archive
 from archivey.exceptions import ArchiveMemberCannotBeOpenedError
 from archivey.types import ArchiveMember, MemberType
@@ -15,14 +16,16 @@ from tests.archivey.testing_utils import skip_if_package_missing
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("sample_archive", BASIC_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_get_operations_after_close(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ) -> None:
     """Calling get_archive_info after closing should raise an error."""
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    archive = open_archive(sample_archive_path)
+    archive = open_archive(sample_archive_path, config=archive_config)
     assert archive.get_archive_info() is not None
     archive.close()
 
@@ -39,16 +42,18 @@ def test_get_operations_after_close(
         list(archive.extractall(path="/tmp"))
 
 
-@pytest.mark.parametrize("sample_archive", BASIC_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_open_member_from_another_archive(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ) -> None:
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
     # Open the archive twice
     with (
-        open_archive(sample_archive_path) as archive1,
-        open_archive(sample_archive_path) as archive2,
+        open_archive(sample_archive_path, config=archive_config) as archive1,
+        open_archive(sample_archive_path, config=archive_config) as archive2,
     ):
         first_file = archive1.get_member("file1.txt")
         assert first_file.type == MemberType.FILE
@@ -57,13 +62,15 @@ def test_open_member_from_another_archive(
             archive2.open(first_file)
 
 
-@pytest.mark.parametrize("sample_archive", BASIC_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(BASIC_ARCHIVES)
 def test_open_dir_member(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ) -> None:
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         first_dir = archive.get_member("subdir/")
         assert first_dir.type == MemberType.DIR
 
@@ -71,13 +78,15 @@ def test_open_dir_member(
             archive.open(first_dir)
 
 
-@pytest.mark.parametrize("sample_archive", SYMLINK_ARCHIVES, ids=lambda a: a.filename)
+@pytest.mark.sample_archives(SYMLINK_ARCHIVES)
 def test_resolve_link_non_registered_member(
-    sample_archive: SampleArchive, sample_archive_path: str
+    sample_archive: SampleArchive,
+    sample_archive_path: str,
+    archive_config: ArchiveyConfig,
 ) -> None:
-    skip_if_package_missing(sample_archive.creation_info.format, None)
+    skip_if_package_missing(sample_archive.creation_info.format, archive_config)
 
-    with open_archive(sample_archive_path) as archive:
+    with open_archive(sample_archive_path, config=archive_config) as archive:
         member = ArchiveMember(
             filename="dangling",
             file_size=None,


### PR DESCRIPTION
This commit refactors the test suite to use a more flexible and powerful test generation mechanism.

Key changes:
- Implemented a `pytest_generate_tests` hook in `tests/archivey/conftest.py`.
- Introduced a new custom marker, `@pytest.mark.sample_archives`, to dynamically parametrize tests with sample archives and corresponding configurations.
- Created a helper function, `archive_configs_for`, to generate different `ArchiveyConfig` objects based on the stream format of a sample archive (e.g., enabling `use_rapidgzip` for Gzip files).
- Removed the hardcoded `ALTERNATIVE_CONFIG` and updated all relevant test files to use the new `archive_config` fixture.
- This new approach simplifies the test code, eliminates boilerplate `parametrize` decorators, and makes it easier to add new test configurations in the future.