### PR TITLE
spec: investigations, OpenSpec artifacts, and streaming design for major rewrite

### DIFF
--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -13,12 +13,12 @@ architecture should evolve.
 
 | Property | ZIP | TAR | RAR | 7z | ISO |
 |---|---|---|---|---|---|
-| `members_list_supported` | True | False | True | True | True |
-| `streaming_only` default | False | Configurable¹ | False | False | False |
-| Central directory | Yes (EOCD) | No | Yes | Yes | Yes (VDs) |
+| `members_list_supported` | True⁵ | False | True | True | True |
+| `streaming_only` default | False (not optional⁶) | Configurable¹ | False | False | False |
+| Central directory | Yes (EOCD at EOF) | No | Yes (at EOF) | Yes (at EOF) | Yes (VDs at sector 16) |
 | Compression granularity | Per-member | Whole-archive² | Per-member + groups (solid) | Per-folder (solid) | None (stored only) |
 | Encryption granularity | Per-member (ZipCrypto) | None | Per-member + header | Per-folder | None |
-| Solid support | No | Yes (compressed) | Optional | Almost always | No |
+| Solid support | No | Yes (compressed, but see §4) | Optional | Almost always | No |
 | Hardlinks | No | Yes (native) | No | No | No |
 | Symlinks | Yes (Unix `external_attr`) | Yes (native) | Rarely³ | Yes | Yes (Rock Ridge only) |
 | Duplicate filenames | No | Yes | No | Yes | No |
@@ -27,7 +27,8 @@ architecture should evolve.
 | Library used | `zipfile` (stdlib) | `tarfile` (stdlib) | `rarfile` (third-party) | `py7zr` (third-party) | `pycdlib` (third-party, test-only) |
 
 ¹ Forced streaming when TAR is inside a non-seekable compressed stream; always
-  streaming for piped stdin usage.
+  streaming for piped stdin usage.  With indexed backends the compressed stream
+  becomes seekable and streaming mode is unnecessary.
 
 ² "Whole-archive" because a compressed TAR is a single compression stream
   wrapping all members; individual members are not compressed independently.
@@ -37,6 +38,16 @@ architecture should evolve.
 
 ⁴ TAR format has no checksum for file data; only the header has a simple
   checksum (sum of header bytes mod 256).
+
+⁵ ZIP's central directory is at the **end** of the file.  `members_list_supported=True`
+  means the list can be obtained without reading file data — but only once the
+  **entire** archive is available and the stream is seekable.  Non-seekable ZIP
+  input is rejected at construction; ZIP cannot stream at all.
+
+⁶ ZIP does not support `streaming_only=True` because the central directory is
+  at EOF; there is no way to list or open members while the archive is still
+  arriving.  The `False` default is therefore a hard constraint, not a
+  preference.
 
 ---
 
@@ -49,27 +60,55 @@ members before reading any file data.
 
 | Format | Flag | Reason |
 |---|---|---|
-| ZIP | True | Central directory at EOF; all ZipInfo metadata parsed on `ZipFile()` open |
-| TAR | False | No central directory; entries interleaved with data; must scan sequentially |
-| RAR | True | End-of-archive block; rarfile reads all `RarInfo` objects at open time |
-| 7z | True | End-header + Streams Info; py7zr reads all metadata at open |
-| ISO | True | Volume Descriptor → root directory record; entire directory tree can be walked before reading data |
+| ZIP | True | Central directory at EOF; `zipfile` seeks to EOCD and reads all ZipInfo records at open time — but requires seekable + complete input (see below) |
+| TAR | False | No central directory; member headers are interleaved with data; can only scan sequentially |
+| RAR | True | End-of-archive block at EOF; rarfile reads all `RarInfo` objects at open time |
+| 7z | True | End-header + Streams Info at EOF; py7zr reads all metadata at open time |
+| ISO | True | Volume Descriptor at sector 16; entire directory tree can be walked from root before reading any file data |
 
-TAR is the outlier.  The base class handles this via the `_early_members_list_supported` path: when both `streaming_only=True` and `members_list_supported=False`, `get_members_if_available()` returns `None`.
+**ZIP vs TAR streaming asymmetry**: TAR and ZIP are on opposite ends of the
+streaming spectrum.  TAR has no index at all — but because each entry's header
+immediately precedes its data, a TAR can be read in one forward pass without
+buffering the whole file.  ZIP has a full central directory — but it is at the
+*end* of the file, so `zipfile` must seek to EOF before it can read any member
+metadata.  This makes ZIP completely hostile to streaming: non-seekable ZIP
+input is rejected at construction time in archivey.  For the other formats with
+end-of-file indices (RAR, 7z), streaming is similarly impossible — they require
+the full file to be available to read the index.
+
+The base class handles the TAR case via the `_early_members_list_supported`
+path: when both `streaming_only=True` and `members_list_supported=False`,
+`get_members_if_available()` returns `None`.
 
 ### 2.2 `streaming_only`
 
 This flag has two sources of truth that are currently conflated:
 
-- **Format capability**: Can the format support random access at all?  ZIP, RAR, 7z, ISO always can. TAR can only if the underlying stream is seekable (plain TAR on disk, or compressed with an indexed backend like rapidgzip).
-- **User preference**: The caller may pass `streaming_only=True` to `open_archive()` to force sequential mode even when the format supports random access, for efficiency.
+- **Format capability**: Can the format support random access at all?  ZIP,
+  RAR, 7z, ISO always can (given a seekable source).  Plain TAR can if the
+  source is seekable.  Compressed TAR depends on the decompressor backend: the
+  stdlib backends (gzip, bz2, lzma) expose forward-seekable-only streams;
+  rapidgzip and indexed_bzip2 expose fully seekable streams with index-based
+  random access (see §4.1).
+- **User preference**: The caller may pass `streaming_only=True` to
+  `open_archive()` to force sequential mode even when the format supports
+  random access, for efficiency.
 
 Currently both are encoded in the single `_streaming_only` boolean on
-`BaseArchiveReader`. The TarReader sets `streaming_only` based on the stream
-type at construction time:
+`BaseArchiveReader`.  `TarReader` sets it based on whether the decompressed
+stream is seekable:
+
 ```python
-streaming_only = streaming_only or (not is_seekable(archive_path) and ...)
+if not streaming_only and not is_seekable(self._fileobj):
+    raise ArchiveStreamNotSeekableError(...)
+open_mode = "r|" if streaming_only else "r:"
 ```
+
+When an indexed backend (rapidgzip, indexed_bzip2, python-xz) is configured,
+the decompressed stream reports `seekable() == True`, so `TarReader` opens in
+`"r:"` (random-access) mode automatically.  The compressed TAR behaves like a
+non-solid archive for practical purposes — individual member opens are
+efficient — even though the underlying data is still in one compression stream.
 
 The conflation means `get_members()` raises `ValueError` in streaming mode
 even for TAR-on-disk where random access *would* work but was not requested.
@@ -119,7 +158,9 @@ Returns a `BinaryIO` for a single member's uncompressed data.
 | Format | Random access | Notes |
 |---|---|---|
 | ZIP | O(1) seek | `ZipFile.open(name)` seeks to local file header |
-| TAR | O(N) or O(1) | `tarfile.extractfile(info)` works if stream is seekable; otherwise must re-scan from start |
+| TAR (stdlib backend) | O(N) per backward seek | `tarfile.extractfile(info)` re-decompresses from position 0 on backward seek |
+| TAR (rapidgzip) | O(checkpoint) ≈ O(1–4 MB) | rapidgzip checkpoint index limits rewind distance |
+| TAR (indexed_bzip2/python-xz) | O(1) per block | True index-based; no rewind needed after initial scan |
 | RAR non-solid | O(1) | rarfile's "extract-hack": temp `.rar` file with one member, run unrar |
 | RAR solid | O(N) | Without `use_rar_stream`: re-decompresses all preceding members each call |
 | 7z | O(N) | py7zr must extract all folder members to reach target; thread+queue approach |
@@ -149,14 +190,50 @@ A "solid" archive is one where extracting member N requires decompressing
 members 0..N-1.  Each format handles this differently; the workarounds
 expose the main limitation of the `_open_member()` per-call contract.
 
-### 4.1 Compressed TAR (always solid)
+### 4.1 Compressed TAR — default backends (always solid)
 
-The entire file is one decompressed stream.  `TarReader` stores the
-decompressed stream and lets `tarfile` position it at each member's data
-offset.  Random access means re-decompressing from the start (unless an
-indexed backend like rapidgzip is used).
+The entire file is one decompressed stream.  `TarReader` passes this stream
+to `tarfile.open(mode="r:")` (random-access) or `"r|"` (streaming only).
+Random access requires backward seeks; with stdlib backends these restarts
+are done by rewinding to position 0 and re-decompressing forward.
 
-Strategy: sequential iteration natural; random access by stream rewind.
+The `DecompressorStream` base class in `compressed_streams.py` implements
+seek-by-rewind for Lzip, Zlib, Brotli, and uncompresspy backends:
+- **Forward seek**: reads and discards bytes.
+- **Backward seek**: calls `_rewind()`, then reads forward.
+- **Cost**: O(target_offset) per backward seek.
+
+Strategy: sequential iteration is O(N); random member access is O(N·M) for
+M random opens on an N-byte decompressed stream.
+
+### 4.1a Compressed TAR — indexed backends (quasi-random access)
+
+Three optional backends rewrite the cost model:
+
+| Backend | Config flag | Compression | Mechanism | Seek cost after index |
+|---|---|---|---|---|
+| `rapidgzip` | `use_rapidgzip` | gzip | Builds gzip-block checkpoint index; each block is a restart point | O(block_size) ≈ O(1–4 MB) per backward seek |
+| `indexed_bzip2` | `use_indexed_bzip2` | bzip2 | Finds all bzip2 block boundaries (each block ~900 KB, independently decompressible) | O(1) once index is built |
+| `python-xz` | `use_python_xz` | xz | Uses XZ's native block index at end of file | O(1) per block seek |
+| `zstandard` | `use_zstandard` | zstd | `ZstandardReopenOnBackwardsSeekIO`: reopens from position 0 on backward seek | O(target_offset) — same as stdlib |
+
+With rapidgzip and indexed_bzip2, the decompressed stream is fully seekable;
+`is_seekable()` returns True; `TarReader` opens in `"r:"` (random-access)
+mode and `streaming_only` is False.  The archive is no longer effectively
+solid:
+
+- **members_list_supported** remains False (no central directory).
+- **streaming_only** becomes False — individual members can be opened directly.
+- **is_solid** in `ArchiveInfo` is still True (format has no per-member
+  compression), but practical random-access cost is sub-linear.
+
+The index is built lazily during the first sequential scan.  After the first
+`get_members()` call, any subsequent `open(member)` call costs only a seek to
+the nearest checkpoint, not a full re-decompression.
+
+Zstandard with the reopen wrapper does not benefit from this: every backward
+seek still restarts from byte 0.  A streaming-only `.tar.zst` is effectively
+as solid as one with any stdlib backend.
 
 ### 4.2 RAR solid archives
 
@@ -183,17 +260,29 @@ Strategy:
 
 ### 4.4 Comparison
 
-| Strategy | Cost model | Random access | Works with `open()` |
+| Strategy | Cost model | streaming_only | `open()` works |
 |---|---|---|---|
-| TAR rewind | O(N) per random open | Slow but correct | Yes |
-| TAR indexed (rapidgzip) | O(log N) | Fast | Yes |
-| RAR `use_rar_stream` | O(N) total streaming | No (streaming only) | No |
-| RAR default | O(N²) total | Yes (expensive) | Yes |
-| 7z thread+queue | O(folder_size) per folder | Only via `iter_members_with_streams` | Via queue drain |
+| TAR + stdlib gzip/bz2/lzma (rewind) | O(N) per backward seek | True (non-seekable) or False | Yes (expensive) |
+| TAR + rapidgzip | O(checkpoint_distance) ≈ O(1–4 MB) per seek | False | Yes |
+| TAR + indexed_bzip2 / python-xz | O(1) per block after initial scan | False | Yes |
+| TAR + zstandard (reopen wrapper) | O(target_offset) per backward seek | False (if file seekable) | Yes (expensive) |
+| RAR non-solid | O(1) per member | False | Yes |
+| RAR solid (default) | O(N²) total over all members | False | Yes (expensive) |
+| RAR solid (`use_rar_stream`) | O(N) total, sequential only | True (effectively) | No |
+| 7z thread+queue | O(folder_size) per folder | False | Via queue drain |
 
-The 7z approach (thread+queue) is the most sophisticated: it correctly handles
-solid extraction while fitting into the archivey iterator protocol.  The RAR
-stream approach is simpler but only works sequentially.
+Key observations:
+
+- **indexed_bzip2 and python-xz** effectively break compressed TAR out of the
+  "solid" cost class after the first scan.  A `.tar.bz2` with indexed_bzip2
+  behaves comparably to a non-solid format for random member access.
+- **rapidgzip** is nearly as good — checkpoint granularity is a few MB, not
+  the full file.  Parallel decompression also makes the initial scan faster.
+- **zstandard** with the reopen wrapper provides forward-only efficiency; it
+  is not better than the stdlib backends for random access.
+- The 7z thread+queue approach is the most sophisticated for truly solid
+  archives where sequential extraction is unavoidable.  The RAR stream approach
+  is simpler but only works when iterating all members in order.
 
 ---
 
@@ -308,13 +397,20 @@ As noted in §2.2, `streaming_only` combines two orthogonal facts:
 1. "This format/stream doesn't support random access" — a format invariant.
 2. "The user wants sequential processing" — a runtime preference.
 
-Currently TAR sets `streaming_only=True` when the underlying stream is
-non-seekable; the user cannot override this.  A user might want to force
-streaming mode on a ZIP file even though ZIP supports random access.
+Currently TarReader sets `streaming_only=True` when the decompressed stream is
+non-seekable.  The outcome depends on which backend is configured:
+
+- Stdlib gzip/bz2/lzma on a piped input → non-seekable → `streaming_only=True`
+- Stdlib gzip/bz2/lzma on a file → seekable (via rewind) → `streaming_only=False`
+- rapidgzip or indexed_bzip2 → always seekable → `streaming_only=False`
+
+ZIP cannot use streaming mode at all (central directory at EOF); passing
+`streaming_only=True` to `open_archive()` for a ZIP would fail or be
+meaningless.
 
 Proposal: split into `format_supports_random_access: bool` (class attribute)
-and `streaming_only: bool` (runtime flag that can be True only if the format
-supports both modes, or always True for non-seekable streams).
+and `streaming_only: bool` (runtime flag that can be True only when the format
+and backend both support sequential-only access).
 
 ### 7.3 Duplicate filenames (7z, TAR)
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -1,0 +1,508 @@
+# Archive Format Architecture Comparison
+
+This document compares all five formats archivey handles across the axes that
+matter for the `BaseArchiveReader` contract: metadata availability, streaming
+vs. random access, solid archives, encryption, and the impedance mismatches
+between each format and the current abstract interface.  Its goal is to
+identify where the current extension points are adequate and where the
+architecture should evolve.
+
+---
+
+## 1. Format properties at a glance
+
+| Property | ZIP | TAR | RAR | 7z | ISO |
+|---|---|---|---|---|---|
+| `members_list_supported` | True | False | True | True | True |
+| `streaming_only` default | False | Configurable¹ | False | False | False |
+| Central directory | Yes (EOCD) | No | Yes | Yes | Yes (VDs) |
+| Compression granularity | Per-member | Whole-archive² | Per-member + groups (solid) | Per-folder (solid) | None (stored only) |
+| Encryption granularity | Per-member (ZipCrypto) | None | Per-member + header | Per-folder | None |
+| Solid support | No | Yes (compressed) | Optional | Almost always | No |
+| Hardlinks | No | Yes (native) | No | No | No |
+| Symlinks | Yes (Unix `external_attr`) | Yes (native) | Rarely³ | Yes | Yes (Rock Ridge only) |
+| Duplicate filenames | No | Yes | No | Yes | No |
+| CRC stored per member | CRC32 | None⁴ | CRC32 | CRC32 | None |
+| Encryption detection | Per-member flag | N/A | Per-member + header flag | Per-folder flag | N/A |
+| Library used | `zipfile` (stdlib) | `tarfile` (stdlib) | `rarfile` (third-party) | `py7zr` (third-party) | `pycdlib` (third-party, test-only) |
+
+¹ Forced streaming when TAR is inside a non-seekable compressed stream; always
+  streaming for piped stdin usage.
+
+² "Whole-archive" because a compressed TAR is a single compression stream
+  wrapping all members; individual members are not compressed independently.
+
+³ Some RAR4 archives store symlinks; not part of the official spec and not
+  widely supported.
+
+⁴ TAR format has no checksum for file data; only the header has a simple
+  checksum (sum of header bytes mod 256).
+
+---
+
+## 2. `BaseArchiveReader` flags
+
+### 2.1 `members_list_supported`
+
+If True, the archive has a "directory" structure that allows listing all
+members before reading any file data.
+
+| Format | Flag | Reason |
+|---|---|---|
+| ZIP | True | Central directory at EOF; all ZipInfo metadata parsed on `ZipFile()` open |
+| TAR | False | No central directory; entries interleaved with data; must scan sequentially |
+| RAR | True | End-of-archive block; rarfile reads all `RarInfo` objects at open time |
+| 7z | True | End-header + Streams Info; py7zr reads all metadata at open |
+| ISO | True | Volume Descriptor → root directory record; entire directory tree can be walked before reading data |
+
+TAR is the outlier.  The base class handles this via the `_early_members_list_supported` path: when both `streaming_only=True` and `members_list_supported=False`, `get_members_if_available()` returns `None`.
+
+### 2.2 `streaming_only`
+
+This flag has two sources of truth that are currently conflated:
+
+- **Format capability**: Can the format support random access at all?  ZIP, RAR, 7z, ISO always can. TAR can only if the underlying stream is seekable (plain TAR on disk, or compressed with an indexed backend like rapidgzip).
+- **User preference**: The caller may pass `streaming_only=True` to `open_archive()` to force sequential mode even when the format supports random access, for efficiency.
+
+Currently both are encoded in the single `_streaming_only` boolean on
+`BaseArchiveReader`. The TarReader sets `streaming_only` based on the stream
+type at construction time:
+```python
+streaming_only = streaming_only or (not is_seekable(archive_path) and ...)
+```
+
+The conflation means `get_members()` raises `ValueError` in streaming mode
+even for TAR-on-disk where random access *would* work but was not requested.
+
+---
+
+## 3. The abstract method contract and how each format fits
+
+### 3.1 `iter_members_for_registration()`
+
+Yields `ArchiveMember` objects one by one.  All metadata except `link_target`
+for encrypted-header archives must be populated here.
+
+| Format | Naturalness | Notes |
+|---|---|---|
+| ZIP | Natural | `ZipFile.infolist()` → iterate ZipInfo objects |
+| TAR | Natural | `tarfile.next()` in a loop; stream position advances |
+| RAR | Natural | `rarfile.infolist()` → iterate RarInfo objects |
+| 7z | Natural | `SevenZipFile.list()` → iterate py7zr FileInfo |
+| ISO | Natural | `pycdlib.walk(rr_path="/")` + `get_record()` per file; or native DR walk |
+
+All formats fit naturally here.  The only wrinkle is that for compressed TAR
+the TarFile stream must remain open — `raw_info` stores the `TarInfo` and the
+underlying stream position is preserved for later `extractfile()` calls.
+
+### 3.2 `get_archive_info()`
+
+Returns an `ArchiveInfo` with `format`, `version`, `is_solid`, `comment`,
+`extra`.
+
+| Format | `version` | `is_solid` | `comment` |
+|---|---|---|---|
+| ZIP | None (version_made_by not surfaced) | False | `ZipFile.comment` (bytes → str) |
+| TAR | Format variant (ustar/GNU/pax) | True if compressed | None |
+| RAR | "4" or "5" | From main archive block flag | `rarfile.comment` |
+| 7z | None (could parse from signature header) | From folder structure | None |
+| ISO | Interchange level (1/2/3) | False | Volume Identifier from PVD |
+
+`is_solid` for 7z is determined by `_is_solid()` which checks whether any
+folder has `num_unpackstreams > 1` — nearly every 7z archive is solid because
+the default compressor packs all files into one folder.
+
+### 3.3 `_open_member(member, pwd, for_iteration)`
+
+Returns a `BinaryIO` for a single member's uncompressed data.
+
+| Format | Random access | Notes |
+|---|---|---|
+| ZIP | O(1) seek | `ZipFile.open(name)` seeks to local file header |
+| TAR | O(N) or O(1) | `tarfile.extractfile(info)` works if stream is seekable; otherwise must re-scan from start |
+| RAR non-solid | O(1) | rarfile's "extract-hack": temp `.rar` file with one member, run unrar |
+| RAR solid | O(N) | Without `use_rar_stream`: re-decompresses all preceding members each call |
+| 7z | O(N) | py7zr must extract all folder members to reach target; thread+queue approach |
+| ISO | O(1) | Seek to `extent_location * BLOCK_SIZE`; read `data_length` bytes |
+
+The impedance mismatch for solid archives (RAR solid, 7z) is the core
+architectural tension.  `_open_member()` is a pull-based, per-call interface
+but solid archives need push-based, ordered sequential extraction.
+
+### 3.4 `_translate_exception(e)`
+
+Maps library exceptions to `ArchiveError` subclasses.
+
+| Format | Exception types | Coverage |
+|---|---|---|
+| ZIP | `BadZipFile`, `NotImplementedError`, `RuntimeError` (wrong pwd) | Good |
+| TAR | `TarError` and subclasses | Good |
+| RAR | `rarfile.BadRarFile`, `rarfile.PasswordRequired`, `rarfile.NeedFirstVolume` | Good |
+| 7z | `py7zr.*Error`, `PasswordRequired` | Good |
+| ISO | N/A (reader not implemented) | — |
+
+---
+
+## 4. Solid archive strategies compared
+
+A "solid" archive is one where extracting member N requires decompressing
+members 0..N-1.  Each format handles this differently; the workarounds
+expose the main limitation of the `_open_member()` per-call contract.
+
+### 4.1 Compressed TAR (always solid)
+
+The entire file is one decompressed stream.  `TarReader` stores the
+decompressed stream and lets `tarfile` position it at each member's data
+offset.  Random access means re-decompressing from the start (unless an
+indexed backend like rapidgzip is used).
+
+Strategy: sequential iteration natural; random access by stream rewind.
+
+### 4.2 RAR solid archives
+
+rarfile calls `unrar p` once per member: O(N²) total decompression cost.
+
+Workaround (`use_rar_stream=True`): `RarStreamReader` spawns a single
+`unrar p -inul archive.rar` subprocess and reads one `RarStreamMemberFile`
+slice per member in order.  O(N) total cost.  Only works during
+`iter_members_with_streams()` — calling `open()` on an individual member
+still triggers the O(N) re-decompression.
+
+### 4.3 7z (almost always solid)
+
+py7zr extracts an entire folder into memory/disk when asked for any member
+in that folder.  The `_extract_members_iterator()` method uses a background
+thread and a `Queue` to bridge py7zr's push model (it calls
+`StreamingFactory.create()` per member) to archivey's pull model.
+
+Strategy:
+1. First pass: yield dirs/empty files/symlinks with no stream needed.
+2. Second pass: start background thread, extract all file members of a folder
+   via `py7zr.SevenZipFile.extract(targets=...)`, dequeue results as
+   `(member, StreamingFile)` tuples in archive order.
+
+### 4.4 Comparison
+
+| Strategy | Cost model | Random access | Works with `open()` |
+|---|---|---|---|
+| TAR rewind | O(N) per random open | Slow but correct | Yes |
+| TAR indexed (rapidgzip) | O(log N) | Fast | Yes |
+| RAR `use_rar_stream` | O(N) total streaming | No (streaming only) | No |
+| RAR default | O(N²) total | Yes (expensive) | Yes |
+| 7z thread+queue | O(folder_size) per folder | Only via `iter_members_with_streams` | Via queue drain |
+
+The 7z approach (thread+queue) is the most sophisticated: it correctly handles
+solid extraction while fitting into the archivey iterator protocol.  The RAR
+stream approach is simpler but only works sequentially.
+
+---
+
+## 5. Metadata richness comparison
+
+### 5.1 Timestamps
+
+| Format | Precision | Timezone | Source |
+|---|---|---|---|
+| ZIP (DOS only) | 2 seconds | None (local time) | `ZipInfo.date_time` |
+| ZIP (Extended, 0x5455) | 1 second | UTC | Archivey parses extra field manually |
+| TAR (ustar/GNU) | 1 second | UTC | `TarInfo.mtime` (Unix timestamp) |
+| TAR (PAX) | Nanosecond | UTC | `TarInfo.pax_headers["mtime"]` |
+| RAR4 | 100 ns | UTC | Windows FILETIME via rarfile |
+| RAR5 | 1 second or 100 ns | UTC | Windows FILETIME or UNIX time |
+| 7z | 100 ns | UTC | Windows FILETIME |
+| ISO (base) | 1 second | UTC offset (15-min intervals) | `DirectoryRecordDate.gmtoffset` |
+| ISO (Rock Ridge TF) | 1 second | UTC offset | Rock Ridge TF extension |
+
+ZIP is the weakest without the Extended Timestamp extra field, which archivey
+explicitly parses.  All others provide UTC timestamps natively.
+
+### 5.2 Unix permissions / ownership
+
+| Format | Mode | UID/GID | Notes |
+|---|---|---|---|
+| ZIP (Unix) | Yes (`external_attr >> 16`) | No (some extra fields) | Only when `create_system == UNIX` |
+| TAR | Yes (`TarInfo.mode`) | Yes (`TarInfo.uid/gid`) | Native; always present |
+| RAR | Yes (Unix extra block) | Yes | Only when created on Unix |
+| 7z | No | No | Not supported in format |
+| ISO base | No | No | No POSIX metadata |
+| ISO + Rock Ridge | Yes (`PX.posix_file_mode`) | Yes (`PX.posix_uid/gid`) | Only with Rock Ridge extension |
+
+7z is the weakest; TAR and Rock Ridge ISO are the strongest.
+
+### 5.3 Symlinks
+
+| Format | Supported | How stored |
+|---|---|---|
+| ZIP | Yes (Unix only) | `external_attr` mode bits + file content = target |
+| TAR | Yes (native) | `TarInfo.linkname` |
+| RAR | Rarely | Not in official spec; limited support |
+| 7z | Yes | Stored as regular file with special attribute |
+| ISO base | No | Not in ISO9660 |
+| ISO + Rock Ridge | Yes | `SL` System Use Entry |
+
+### 5.4 Hardlinks
+
+| Format | Supported | How stored |
+|---|---|---|
+| ZIP | No | — |
+| TAR | Yes (native) | `LNKTYPE`, `linkname` points to another member |
+| RAR | No | — |
+| 7z | No | — |
+| ISO | No (sort of) | Multiple DRs can point to same extent (not exposed) |
+
+TAR is the only format with native hardlink support.
+
+### 5.5 Archive-level metadata
+
+| Format | Comment | Password-protected header | Volume label |
+|---|---|---|---|
+| ZIP | Yes (archive + per-member) | No | No |
+| TAR | No | No | No |
+| RAR | Yes | Yes (RAR5 encrypted headers) | No |
+| 7z | No | No (per-folder encryption) | No |
+| ISO | No comment per se | No | Volume Identifier (32 bytes) in PVD |
+
+---
+
+## 6. Library dependency comparison
+
+| Format | Library | Role | Quality | Replaceability |
+|---|---|---|---|---|
+| ZIP | `zipfile` (stdlib) | Full in-process decompressor + parser | Excellent | Low benefit: stdlib works well |
+| TAR | `tarfile` (stdlib) | Full in-process decompressor + parser | Good | Low benefit: stdlib works well |
+| RAR | `rarfile` (third-party) | Metadata parsing; shells out to `unrar` for data | Medium | **High** — native reader target; eliminates dependency |
+| 7z | `py7zr` (third-party) | Metadata + in-process decompressor | Medium | **High** — native reader target for metadata; keep py7zr for decompression |
+| ISO | `pycdlib` (third-party) | Test-only (creation); no reader exists | N/A | Wrap pycdlib or write native (native is ~400 lines) |
+
+The RAR and 7z native reader designs are documented in
+`rar-native-reader-design.md` and `sevenzip-native-reader-design.md`.
+
+---
+
+## 7. Impedance mismatches with `BaseArchiveReader`
+
+### 7.1 The registration/open split doesn't fit solid archives
+
+`iter_members_for_registration()` yields metadata only; `_open_member()` is
+called later, independently, for data.  For solid archives, these two phases
+cannot be fully separated: you can list members without decompressing (metadata
+lives in the header), but opening member N requires having streamed members
+0..N-1 in order.
+
+Current solutions are all workarounds:
+- **7z**: overrides `iter_members_with_streams()` wholesale — the base class
+  dispatch is bypassed entirely for file members.
+- **RAR**: exposes `use_rar_stream` config that changes the behaviour of
+  `_open_member()` at call time.
+- **Compressed TAR**: the stream is seekable so backward seek-by-rewind is
+  possible (expensive).
+
+A cleaner design would introduce an optional `iter_members_with_open()`
+contract that solid-archive readers implement directly, with the base class
+calling it instead of the `iter_members_for_registration` + `_open_member`
+two-step.
+
+### 7.2 `streaming_only` conflates format capability and user preference
+
+As noted in §2.2, `streaming_only` combines two orthogonal facts:
+1. "This format/stream doesn't support random access" — a format invariant.
+2. "The user wants sequential processing" — a runtime preference.
+
+Currently TAR sets `streaming_only=True` when the underlying stream is
+non-seekable; the user cannot override this.  A user might want to force
+streaming mode on a ZIP file even though ZIP supports random access.
+
+Proposal: split into `format_supports_random_access: bool` (class attribute)
+and `streaming_only: bool` (runtime flag that can be True only if the format
+supports both modes, or always True for non-seekable streams).
+
+### 7.3 Duplicate filenames (7z, TAR)
+
+Both 7z and TAR can contain multiple members with the same filename.  The base
+class tracks members by `member_id` (sequential integer) but `get_member(str)`
+returns the first match.
+
+The 7z reader renames duplicates (`filename_2`, `filename_3`, …) at
+registration time.  TAR does not rename — if the same filename appears twice,
+the second `open("name")` call will return the first entry.
+
+A principled solution: a `dedup_policy` parameter (`KEEP_FIRST`, `KEEP_LAST`,
+`KEEP_ALL_RENAME`, `KEEP_ALL_BY_ID`).
+
+### 7.4 Per-member vs archive-level password
+
+The `open(member, pwd=...)` API allows per-call password override.  In 7z
+this requires the `_temporary_password` context-manager hack because py7zr
+binds the password to each `Folder` at archive-open time.
+
+For a native 7z reader this problem goes away entirely — the key derivation
+can be done per-call.  For other formats it is already natural (ZIP and RAR
+accept per-call passwords).
+
+### 7.5 ISO: no streaming concerns, but multi-namespace path system
+
+ISO is the simplest format for data access (sector-aligned reads, no
+compression) but pycdlib's API requires choosing a namespace before every
+path operation.  An archivey `IsoReader` must:
+1. At open time: detect which extensions are present (Rock Ridge, Joliet, UDF).
+2. Pick a priority chain: Rock Ridge → Joliet → ISO9660.
+3. Walk using `walk(rr_path="/")` / `walk(joliet_path="/")` / `walk(iso_path="/")`.
+4. On `_open_member()`: call `open_file_from_iso()` with the correct keyword.
+
+This namespace selection must be stored on the reader instance; `raw_info`
+on each `ArchiveMember` must store enough to reconstruct the correct keyword
+argument for `open_file_from_iso()`.
+
+Alternatively, a native ISO reader avoids pycdlib entirely and uses direct
+struct parsing.
+
+---
+
+## 8. Are the current extension points adequate?
+
+### What works well
+
+- **`iter_members_for_registration()` + `_open_member()`** is the right split
+  for non-solid formats (ZIP, RAR non-solid, ISO).  It maps cleanly to "parse
+  directory" + "seek and read".
+
+- **`raw_info`** on `ArchiveMember` is a useful escape hatch.  Each reader
+  stores format-specific data there (ZipInfo, TarInfo, RarInfo, py7zr
+  FileInfo) without polluting the public `ArchiveMember` API.
+
+- **`_prepare_member_for_open()`** hook elegantly handles the case where some
+  metadata (e.g., `link_target` for encrypted RAR members) is only known after
+  opening the stream.  The hook is called before `_open_member()` so the member
+  can be adjusted.
+
+- **`_translate_exception()`** cleanly isolates format-specific error handling
+  from the generic logic in `ArchiveStream`.
+
+- **`members_list_supported` flag** correctly captures the TAR/non-TAR
+  distinction and drives `get_members_if_available()` behaviour.
+
+### What needs extension
+
+#### A. Solid-archive co-iteration contract
+
+**Problem**: `iter_members_with_streams()` is fully overridden by 7z and
+partly by RAR, duplicating the registration and iteration logic.
+
+**Proposed addition**: a protected `_iter_members_and_streams()` hook that
+the base class calls from inside `iter_members_with_streams()`:
+
+```python
+def _iter_members_and_streams(
+    self,
+) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
+    """
+    Optional override for solid-archive readers.
+
+    Yield (member, stream) pairs in archive order.
+    stream=None means the member has no data (dir, symlink, empty file).
+    The base class default calls _open_member() for each file member.
+    """
+    for member in self.iter_members():
+        if member.is_file:
+            yield member, self._open_member(member, pwd=self._pwd, for_iteration=True)
+        else:
+            yield member, None
+```
+
+Solid readers override this to drive a single extraction pass.  The base
+class `iter_members_with_streams()` calls `_iter_members_and_streams()`
+instead of its current piecemeal approach.
+
+#### B. Separate format capability from user preference
+
+**Problem**: `streaming_only` is both a format fact and a user preference.
+
+**Proposed addition**: a class attribute:
+```python
+class BaseArchiveReader:
+    _format_supports_random_access: ClassVar[bool] = True
+```
+
+Set to `False` for non-seekable compressed TAR streams (not for all TAR — only
+when the underlying decompressor is non-seekable). The runtime `streaming_only`
+flag then means "user requested streaming OR format cannot random-access".
+
+#### C. `members_list_supported` should be a class attribute
+
+Currently passed to `__init__()` as a constructor argument.  But it's
+determined solely by the format type, not by any runtime condition.
+
+Exception: TAR sets it based on whether the stream has a seekable structure,
+but the flag actually doesn't matter for TAR since `streaming_only` already
+captures the relevant behaviour.
+
+Making it a `ClassVar` would clarify that it is a format-level property:
+```python
+class ZipReader(BaseArchiveReader):
+    members_list_supported = True
+```
+
+#### D. Typed compression method enum
+
+`ArchiveMember.compression_method` is an untyped string.  Adding a
+`CompressionMethod` enum (or `StrEnum`) with known values like `STORED`,
+`DEFLATE`, `LZMA`, `ZSTD`, `BZIP2`, `LZMA2`, `BCJ2`, `PPMD`, etc. and a
+fallback `UNKNOWN` would allow callers to make programmatic decisions without
+parsing strings.
+
+#### E. Capability introspection
+
+**Problem**: callers must try operations and catch `ValueError` to discover
+whether random access is available.
+
+**Proposed addition**:
+```python
+@property
+def supports_random_access(self) -> bool:
+    return not self._streaming_only
+
+@property
+def supports_member_list(self) -> bool:
+    return self._early_members_list_supported or not self._streaming_only
+```
+
+Both are derivable from existing state; making them properties prevents
+callers from relying on internal flags.
+
+---
+
+## 9. Recommended implementation order
+
+Given the analysis above, the natural sequencing for work is:
+
+1. **ISO reader** — simplest to add (no solid concerns, no external process,
+   library or ~400-line native parser).  Completes the format matrix.
+
+2. **RAR native metadata reader** — eliminates the `rarfile` dependency for
+   metadata.  `unrar` remains for decompression.  Documented in
+   `rar-native-reader-design.md`.
+
+3. **7z native metadata reader** — eliminates py7zr for metadata parsing.
+   py7zr remains for decompression.  Documented in
+   `sevenzip-native-reader-design.md`.
+
+4. **Solid archive co-iteration refactor** (§8.A) — once both native readers
+   are done, the thread+queue pattern in 7z and the stream-reader pattern in
+   RAR can be unified under a cleaner `_iter_members_and_streams()` hook.
+
+5. **`streaming_only` / capability refactor** (§8.B, §8.C, §8.E) — cosmetic
+   but improves the public API and clarifies the mental model for contributors.
+
+---
+
+## 10. References
+
+| Document | Covers |
+|---|---|
+| `docs/rar-native-reader-design.md` | RAR3/RAR5 native parser design, extract-hack, solid streaming |
+| `docs/sevenzip-native-reader-design.md` | 7z folder model, thread+queue streaming, AES key derivation |
+| `docs/zip-stdlib-limitations.md` | zipfile gaps, Extended Timestamp parsing, symlink detection |
+| `docs/tar-stdlib-limitations.md` | tarfile gaps, integrity check, compressed-stream backends |
+| `docs/iso-pycdlib-analysis.md` | ISO9660/pycdlib multi-namespace confusion, native reader option |
+| `src/archivey/internal/base_reader.py` | BaseArchiveReader implementation |
+| `src/archivey/archive_reader.py` | ArchiveReader public interface |

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -13,8 +13,8 @@ architecture should evolve.
 
 | Property | ZIP | TAR | RAR | 7z | ISO |
 |---|---|---|---|---|---|
-| `members_list_supported` | True⁵ | False | True | True | True |
-| `streaming_only` default | False (not optional⁶) | Configurable¹ | False | False | False |
+| `members_list_supported` | True (seekable) / False (streaming)⁵ | False | True | True | True |
+| `streaming_only` default | False (current impl)⁶ | Configurable¹ | False | False | False |
 | Central directory | Yes (EOCD at EOF) | No | Yes (at EOF) | Yes (at EOF) | Yes (VDs at sector 16) |
 | Compression granularity | Per-member | Whole-archive² | Per-member + groups (solid) | Per-folder (solid) | None (stored only) |
 | Encryption granularity | Per-member (ZipCrypto) | None | Per-member + header | Per-folder | None |
@@ -39,15 +39,15 @@ architecture should evolve.
 ⁴ TAR format has no checksum for file data; only the header has a simple
   checksum (sum of header bytes mod 256).
 
-⁵ ZIP's central directory is at the **end** of the file.  `members_list_supported=True`
-  means the list can be obtained without reading file data — but only once the
-  **entire** archive is available and the stream is seekable.  Non-seekable ZIP
-  input is rejected at construction; ZIP cannot stream at all.
+⁵ With seekable input, `zipfile` seeks to the EOCD and reads the full central
+  directory, giving `members_list_supported=True`.  With a streaming (non-seekable)
+  reader that uses local file headers directly, members are discovered
+  sequentially just like TAR and `members_list_supported=False`.  Some metadata
+  is only in the central directory and not available in streaming mode (see §2.1).
 
-⁶ ZIP does not support `streaming_only=True` because the central directory is
-  at EOF; there is no way to list or open members while the archive is still
-  arriving.  The `False` default is therefore a hard constraint, not a
-  preference.
+⁶ The current archivey `ZipReader` (backed by stdlib `zipfile`) rejects
+  non-seekable input at construction.  This is a library limitation, not a
+  format limitation — see §2.1 for what a streaming ZIP reader would look like.
 
 ---
 
@@ -58,27 +58,53 @@ architecture should evolve.
 If True, the archive has a "directory" structure that allows listing all
 members before reading any file data.
 
-| Format | Flag | Reason |
-|---|---|---|
-| ZIP | True | Central directory at EOF; `zipfile` seeks to EOCD and reads all ZipInfo records at open time — but requires seekable + complete input (see below) |
-| TAR | False | No central directory; member headers are interleaved with data; can only scan sequentially |
-| RAR | True | End-of-archive block at EOF; rarfile reads all `RarInfo` objects at open time |
-| 7z | True | End-header + Streams Info at EOF; py7zr reads all metadata at open time |
-| ISO | True | Volume Descriptor at sector 16; entire directory tree can be walked from root before reading any file data |
+| Format | Flag (seekable) | Flag (streaming) | Reason |
+|---|---|---|---|
+| ZIP | True | False (format supports; stdlib doesn't) | Central dir at EOF for seekable; local headers before data enable streaming |
+| TAR | False | False | No central directory; entries discovered sequentially |
+| RAR | True | N/A | End-of-archive block at EOF; rarfile reads all `RarInfo` objects at open time |
+| 7z | True | N/A | End-header + Streams Info at EOF; py7zr reads all metadata at open time |
+| ISO | True | N/A | VD at sector 16; full directory tree walkable before any file data |
 
-**ZIP vs TAR streaming asymmetry**: TAR and ZIP are on opposite ends of the
-streaming spectrum.  TAR has no index at all — but because each entry's header
-immediately precedes its data, a TAR can be read in one forward pass without
-buffering the whole file.  ZIP has a full central directory — but it is at the
-*end* of the file, so `zipfile` must seek to EOF before it can read any member
-metadata.  This makes ZIP completely hostile to streaming: non-seekable ZIP
-input is rejected at construction time in archivey.  For the other formats with
-end-of-file indices (RAR, 7z), streaming is similarly impossible — they require
-the full file to be available to read the index.
+**ZIP can be streamed at the format level**: each ZIP entry has a local file
+header immediately before its compressed data, identical in concept to a TAR
+entry header.  A streaming ZIP reader processes these local headers in order —
+filename, compression method, and flags are all present — without ever needing
+the central directory.
 
-The base class handles the TAR case via the `_early_members_list_supported`
-path: when both `streaming_only=True` and `members_list_supported=False`,
-`get_members_if_available()` returns `None`.
+The **data descriptor** (flag bit 3) complicates sizing for streaming writes:
+when a ZIP is written to a pipe the writer doesn't know the CRC or sizes at the
+time the local header is written, so it puts them in a trailing data descriptor
+record after the compressed data.  For compressed methods (deflate, bzip2,
+lzma) this is handled naturally — each decompressor has an end-of-stream
+marker so the reader knows when the data ends without needing the size.  For
+stored (uncompressed) entries with bit 3 set, the end must be found by scanning
+for the data-descriptor signature `PK\x07\x08`, which is ambiguous if that
+byte sequence appears in the payload.
+
+What streaming mode **cannot** provide (central-directory-only fields):
+
+| Field | Notes |
+|---|---|
+| `external_attr` | Unix mode bits (permissions) and symlink detection — not in local header |
+| `create_system` | Needed to interpret `external_attr` — not in local header |
+| Per-file comment | Only in central directory |
+
+Everything else — filename (with UTF-8 detection via bit 11), compression
+method, DOS timestamp, and the Extended Timestamp extra field (0x5455) — is
+present in the local header and available in streaming mode.
+
+The current archivey `ZipReader` (stdlib `zipfile`) cannot stream: it seeks
+to EOCD at open time and rejects non-seekable input.  This is a **stdlib
+limitation**, not a format one.  Implementing a streaming ZIP reader would
+require parsing local headers directly.
+
+For RAR and 7z, streaming is not possible at all: the end-of-file index is the
+only place member metadata lives.
+
+The base class handles the TAR (and streaming ZIP) case via the
+`_early_members_list_supported` path: when both `streaming_only=True` and
+`members_list_supported=False`, `get_members_if_available()` returns `None`.
 
 ### 2.2 `streaming_only`
 
@@ -404,9 +430,12 @@ non-seekable.  The outcome depends on which backend is configured:
 - Stdlib gzip/bz2/lzma on a file → seekable (via rewind) → `streaming_only=False`
 - rapidgzip or indexed_bzip2 → always seekable → `streaming_only=False`
 
-ZIP cannot use streaming mode at all (central directory at EOF); passing
-`streaming_only=True` to `open_archive()` for a ZIP would fail or be
-meaningless.
+The current archivey `ZipReader` (stdlib `zipfile`) cannot use streaming mode;
+passing `streaming_only=True` to `open_archive()` for a ZIP raises an error at
+construction.  The ZIP format itself does support streaming via local file
+headers (see §2.1); a future streaming `ZipReader` would expose
+`streaming_only=True` just like `TarReader`, at the cost of losing
+`external_attr` (permissions, symlinks) and per-file comments.
 
 Proposal: split into `format_supports_random_access: bool` (class attribute)
 and `streaming_only: bool` (runtime flag that can be True only when the format

--- a/docs/iso-pycdlib-analysis.md
+++ b/docs/iso-pycdlib-analysis.md
@@ -1,0 +1,484 @@
+# ISO Reader — pycdlib Analysis and Implementation Guide
+
+This document analyses the ISO9660 format, what pycdlib provides, where it falls
+short, and what an `IsoReader` implementation must handle itself.  Unlike the ZIP
+and TAR docs — which address limitations of a library already in use — this
+document also covers the implementation decision (pycdlib vs native) because no
+reader exists yet.  The goal is to give a developer enough context to write an
+`IsoReader` from scratch.
+
+---
+
+## 1. Current state of ISO support in archivey
+
+| Item | Status |
+|---|---|
+| `ContainerFormat.ISO` / `ArchiveFormat.ISO` | Defined in `src/archivey/types.py` |
+| Magic-byte detection (offset `0x8001`) | Implemented in `src/archivey/formats/format_detection.py` |
+| Extension mapping | Only `.iso`; see section 9 for others |
+| `_FORMAT_TO_READER` entry in `src/archivey/core.py` | **Missing** — opening an ISO raises `ArchiveNotSupportedError` |
+| `IsoReader` class | **Does not exist** |
+| pycdlib in dependency checker | Declared in `src/archivey/internal/dependency_checker.py` (`pycdlib_version`), not used at runtime |
+| Test archive creation | `create_iso_archive_with_pycdlib` and `create_iso_archive_with_genisoimage` in `tests/archivey/create_archives.py` — both working, ISO filenames commented out of `SKIP_TEST_FILENAMES` |
+
+---
+
+## 2. BaseArchiveReader flags for ISO
+
+| Flag | Value | Reason |
+|---|---|---|
+| `members_list_supported` | `True` | ISO9660 has a root directory record; a full recursive walk produces the complete member list before any file data is read.  Unlike TAR there is no need to scan data blocks to discover members. |
+| `streaming_only` | `False` | ISO is sector-addressed; every file has a fixed `extent_location` (LBA).  Random access to any file requires only a `seek()` to `LBA * 2048`.  There is no sequential dependency between members. |
+
+---
+
+## 3. ISO9660 format essentials
+
+### 3.1 On-disk layout
+
+An ISO image is a sequence of 2048-byte sectors (logical blocks).  The first 16
+sectors (bytes 0–32767) are the **System Area** — reserved for bootloaders and
+left undefined by ISO9660.
+
+The Volume Descriptor chain begins at **sector 16** (offset `0x8000`):
+
+| Type | Name | Notes |
+|---|---|---|
+| 1 | Primary Volume Descriptor (PVD) | Always present; defines root directory record, volume name, dates |
+| 2 | Supplementary Volume Descriptor (SVD) | Joliet uses this; same structure as PVD but with UTF-16 BE names |
+| 3 | Volume Partition Descriptor | Rarely used |
+| 255 | Volume Descriptor Set Terminator | End of VD chain |
+
+UDF has a separate recognition area at sector 16+, parallel to the ISO9660 chain.
+
+Archivey's magic-byte check reads 5 bytes at offset `0x8001` (one byte past the
+start of sector 16) and checks for `CD001`, `CDW02`, `BEA01`, `NSR02`, `NSR03`,
+`TEA01`, or `BOOT2` — the same list pycdlib uses internally.
+
+### 3.2 Directory Record (DR) structure
+
+Each file or directory in an ISO9660 directory extent is described by a Directory
+Record.  pycdlib exposes these as `dr.DirectoryRecord` objects.
+
+| Field | Type | Notes |
+|---|---|---|
+| `dr_len` | uint8 | Length of this DR including System Use area |
+| `xattr_len` | uint8 | Extended attribute record length (usually 0) |
+| `orig_extent_loc` | uint32 LE + BE | LBA of file data start |
+| `data_length` | uint32 LE + BE | File size in bytes |
+| `date` | `DirectoryRecordDate` | 7-byte compact date; see section 3.3 |
+| `file_flags` | uint8 | Bit 1 = directory; bit 7 = multi-extent |
+| `file_unit_size` | uint8 | Interleaved files only (usually 0) |
+| `interleave_gap_size` | uint8 | Interleaved files only (usually 0) |
+| `seqnum` | uint16 | Volume sequence number |
+| `len_fi` | uint8 | Length of the file identifier |
+| `file_ident` | bytes | Filename; even-padded |
+
+Key methods: `is_dir()`, `is_file()`, `is_symlink()` (requires Rock Ridge),
+`is_dot()`, `is_dotdot()`, `file_identifier()`.
+
+### 3.3 DirectoryRecordDate (7 bytes)
+
+Defined in `pycdlib/dates.py`:
+
+```python
+class DirectoryRecordDate:
+    __slots__ = ('_initialized', 'years_since_1900', 'month', 'day_of_month',
+                 'hour', 'minute', 'second', 'gmtoffset')
+    # gmtoffset: signed int8, units of 15 minutes
+```
+
+This is **not** a Python `datetime`.  To convert to a UTC-aware `datetime`:
+
+```python
+from datetime import datetime, timezone, timedelta
+
+def dr_date_to_datetime(d):
+    year = 1900 + d.years_since_1900
+    tz = timezone(timedelta(minutes=d.gmtoffset * 15))
+    return datetime(year, d.month, d.day_of_month,
+                    d.hour, d.minute, d.second, tzinfo=tz)
+```
+
+The `gmtoffset` field is present in every Directory Record date, so timestamps
+are always timezone-aware.  This is better than DOS ZIP timestamps (which are
+naive local time) and comparable to PAX TAR timestamps.
+
+The Volume Descriptor uses a different, longer date format (`VolumeDescriptorDate`
+in pycdlib) with hundredths-of-a-second precision and a separate `gmtoffset`
+byte.
+
+---
+
+## 4. Extension namespaces — the core pycdlib complexity
+
+pycdlib has **four separate namespace systems**.  Every key API call (`walk()`,
+`list_children()`, `get_record()`, `open_file_from_iso()`) accepts `**kwargs`
+and requires **exactly one** of:
+
+| Kwarg | Namespace | Filename rules |
+|---|---|---|
+| `iso_path=` | Plain ISO9660 | Uppercase A–Z 0–9 `_`; files have `;1` version suffix (`README.TXT;1`); interchange level 3 relaxes charset but `;1` still applies |
+| `rr_path=` | Rock Ridge (POSIX extension) | Case-sensitive, arbitrary filenames, full UTF-8 |
+| `joliet_path=` | Joliet (Microsoft Unicode) | UTF-16 BE; max 64 characters per component; no `;1` suffix |
+| `udf_path=` | UDF (DVD/Blu-ray) | Separate filesystem entirely |
+
+An ISO can have **none, one, two, or all three** of these extensions
+simultaneously.  The test-creation code in archivey demonstrates the authoring
+side:
+
+```python
+iso.new(interchange_level=3, rock_ridge="1.09", joliet=3)
+# ...
+iso.add_file(src_path,
+             iso_path=iso_path.upper(),   # plain ISO9660
+             rr_name=f_name,              # Rock Ridge
+             joliet_path=iso_path)        # Joliet
+```
+
+For reading, you pick **one preferred namespace** and walk with it.
+
+### 4.1 Detecting which namespaces are present
+
+```python
+iso = pycdlib.pycdlib.PyCdlib()
+iso.open(path)
+
+has_rr     = bool(iso.rock_ridge)     # non-empty string if RR present, e.g. "1.09"
+has_joliet = iso.joliet_vd is not None
+has_udf    = iso.udf_root is not None
+```
+
+Note: `iso.rock_ridge` is a string (the RR version), not a boolean.  An empty
+string means no Rock Ridge.
+
+### 4.2 Recommended namespace priority for reading
+
+```
+Rock Ridge  →  Joliet  →  plain ISO9660
+```
+
+- **Rock Ridge** is preferred because it preserves case, full POSIX metadata
+  (permissions, UID/GID, symlinks), and arbitrary filenames.
+- **Joliet** is preferred over plain ISO9660 because it preserves mixed-case
+  Unicode names.
+- **Plain ISO9660** is the fallback; filenames will be uppercase and `;1`-suffixed.
+- **UDF** is a separate, more complex filesystem (different record types, different
+  iteration pattern).  It can be deferred to a later implementation milestone.
+
+### 4.3 Stripping the `;1` version suffix
+
+When using `iso_path=` the filenames returned by `walk()` include the version
+suffix (`;1`).  These must be stripped before storing in `ArchiveMember.filename`:
+
+```python
+def strip_version(name: str) -> str:
+    if name.endswith(';1'):
+        return name[:-2]
+    return name
+```
+
+---
+
+## 5. pycdlib API walk patterns
+
+### 5.1 `walk()` — yields `(path, dirs, files)`
+
+```python
+# Rock Ridge walk (preferred)
+for dirpath, dirnames, filenames in iso.walk(rr_path="/"):
+    for fname in filenames:
+        full_path = dirpath.rstrip("/") + "/" + fname
+        record = iso.get_record(rr_path=full_path)
+        # record is a dr.DirectoryRecord
+```
+
+`walk()` yields only **names** (strings), not records.  To get metadata, call
+`iso.get_record()` with the full path for each entry.  This is a two-step
+process.
+
+For Joliet the path separator and namespace kwarg change but the pattern is
+identical.  For plain ISO9660, strip `;1` from filenames after the walk.
+
+### 5.2 `open_file_from_iso()` — returns a `PyCdlibIO`
+
+```python
+with iso.open_file_from_iso(rr_path="/path/to/file") as f:
+    data = f.read()
+```
+
+`PyCdlibIO` is defined in `pycdlib/pycdlibio.py` and inherits from
+`io.RawIOBase`.  It implements `read()`, `readinto()`, `seek()`, `tell()`,
+`readable()`, and `seekable()`.
+
+**Important**: `PyCdlibIO` is a context manager and a raw IO object, but it is
+**not** a `BufferedIOBase`.  `read(n)` may not return exactly `n` bytes in one
+call.  Wrap it in `io.BufferedReader` before passing to archivey callers:
+
+```python
+raw = iso.open_file_from_iso(rr_path=full_path)
+raw.__enter__()
+return io.BufferedReader(raw)
+```
+
+The `__enter__` call is required because `PyCdlibIO` uses a context manager to
+bind the internal `_fp` file pointer.  Without it, `read()` will fail with an
+`AttributeError`.
+
+### 5.3 `get_record()` — returns a `dr.DirectoryRecord` (or `udf.UDFFileEntry` for UDF)
+
+```python
+record = iso.get_record(rr_path="/path/to/file")
+# record.data_length      — file size
+# record.date             — DirectoryRecordDate
+# record.rock_ridge       — RockRidge object (or None if no RR)
+# record.is_dir()
+# record.is_file()
+# record.is_symlink()     — True only if RR is present and SL entry exists
+```
+
+---
+
+## 6. Rock Ridge extension details
+
+Rock Ridge stores POSIX metadata in System Use fields appended after the filename
+in each Directory Record.  pycdlib parses these automatically; the parsed object
+is accessible via `dr_record.rock_ridge`.
+
+Relevant System Use Entry types:
+
+| SU type | pycdlib accessor | Content |
+|---|---|---|
+| `PX` | `rock_ridge.posix_file_mode`, `.posix_file_links`, `.posix_uid`, `.posix_gid` | POSIX permissions, link count, UID, GID |
+| `TF` | `rock_ridge.access_time`, `.modify_time`, `.attribute_time`, `.creation_time` | Timestamps (each is a `DirectoryRecordDate`) |
+| `SL` | `rock_ridge.symlink_path()` | Symlink target as bytes |
+| `NM` | `rock_ridge.name()` | Alternate (case-preserving) filename as bytes |
+| `CL` / `PL` / `RE` | — | Deep directory relocation; handled internally by pycdlib, safe to ignore for reading |
+| `SF` | — | Sparse file descriptor; uncommon |
+
+Notes:
+
+- `rock_ridge.name()` returns `bytes`.  Decode as UTF-8 for most modern ISOs.
+- `rock_ridge.symlink_path()` also returns `bytes`.  Decode as UTF-8.
+- `rock_ridge.modify_time` is the best mtime source when RR is present.  It is a
+  `DirectoryRecordDate` and must be manually converted (see section 3.3).
+- If `rock_ridge` is `None` on a record despite the ISO having RR, fall back to
+  the DR's own `date` field.
+
+---
+
+## 7. Mapping ISO metadata to ArchiveMember
+
+| `ArchiveMember` field | ISO source | Notes |
+|---|---|---|
+| `filename` | RR `name()` → Joliet UTF-16 → ISO9660 (strip `;1`) | Priority in section 4.2; decode bytes with UTF-8 |
+| `file_size` | `DR.data_length` | Always available |
+| `compress_size` | Same as `file_size` | No compression in ISO9660 |
+| `mtime_with_tz` | RR `rock_ridge.modify_time` → `DR.date` | Both are `DirectoryRecordDate`; convert with `dr_date_to_datetime()` |
+| `type` | `DR.is_dir()` / `DR.is_symlink()` / `DR.is_file()` | Symlinks only with Rock Ridge |
+| `mode` | `rock_ridge.posix_file_mode` | `None` if no Rock Ridge; use `stat.S_IMODE()` to strip type bits |
+| `uid` | `rock_ridge.posix_uid` | `None` if no Rock Ridge |
+| `gid` | `rock_ridge.posix_gid` | `None` if no Rock Ridge |
+| `link_target` | `rock_ridge.symlink_path().decode("utf-8")` | `None` if no Rock Ridge or not a symlink |
+| `compression_method` | `"stored"` | ISO9660 has no per-file compression |
+| `crc32` | Not stored in ISO | `None` |
+| `encrypted` | `False` | ISO9660 has no encryption |
+| `comment` | None | No per-file comments in ISO9660 |
+| `raw_info` | the `dr.DirectoryRecord` | Store for use in `_open_member()` |
+
+Directory member filenames should have a trailing `/` appended (archivey
+convention for all formats).
+
+---
+
+## 8. Archive-level metadata (ArchiveInfo)
+
+From the Primary Volume Descriptor:
+
+| `ArchiveInfo` field | Source |
+|---|---|
+| `format` | `ArchiveFormat.ISO` |
+| `version` | `"ISO9660"` or the interchange level as a string (`"1"`, `"2"`, `"3"`) |
+| `is_solid` | `False` — each file is stored at an independent extent; random access is always O(1) |
+| `comment` | PVD `volume_identifier` (32-byte space-padded ASCII string), stripped |
+| `extra` | Dict with `system_identifier`, `volume_set_identifier`, `publisher_identifier`, `creation_date`, `modification_date`; also `rock_ridge` version if present, `joliet` bool, `udf` bool |
+
+The PVD is accessible via `iso.pvd` in pycdlib.  Volume identifier:
+```python
+pvd = iso.pvd
+comment = pvd.volume_identifier.decode("ascii", errors="replace").rstrip()
+```
+
+---
+
+## 9. Extension and filename detection
+
+`EXTENSION_TO_FORMAT` in `src/archivey/formats/format_detection.py` currently
+registers only `.iso`.  Other common ISO image extensions:
+
+| Extension | Notes | Safe to add? |
+|---|---|---|
+| `.img` | Genuinely ambiguous — could be raw floppy, hard disk partition image, or CD-ROM image | **No** — rely on magic bytes only |
+| `.bin` | Raw CD image, typically paired with `.cue`; the `.bin` file itself is usually ISO9660 | Risky without `.cue` context |
+| `.nrg` | Nero Burning ROM — proprietary wrapper with its own header around ISO9660 | **No** — different format |
+| `.mdf` | Alcohol 120% — another proprietary wrapper | **No** — different format |
+| `.dmg` | macOS disk image — typically HFS+/APFS, not ISO9660 | **No** |
+
+**Recommendation**: Do not add any of these to `EXTENSION_TO_FORMAT`.  The
+magic-byte check at offset `0x8001` is already implemented and handles true
+ISO9660 images regardless of extension.  Files that pass magic detection get
+`ArchiveFormat.ISO` regardless of filename.
+
+---
+
+## 10. pycdlib API awkwardness summary
+
+For each pain point, the implementation approach is noted.
+
+| Pain point | Mitigation |
+|---|---|
+| Namespace selection required before every API call | Detect `rock_ridge`/`joliet_vd`/`udf_root` on open; store as instance variable; use a single `_walk_kwarg` dict like `{"rr_path": "/"}` throughout |
+| `**kwargs` API, no typed path parameter | Helper: `def _rr(path)` returns `{"rr_path": path}`, then `iso.walk(**_rr("/"))` |
+| No "best name" helper | Implement `_best_name(dr_record, walk_name)` that checks `rock_ridge.name()`, falls back to `walk_name` |
+| ISO9660 `;1` suffix | `strip_version()` helper (see section 4.3) |
+| `PyCdlibIO` is `RawIOBase`, not `BufferedIOBase` | Wrap in `io.BufferedReader` in `_open_member()` |
+| Must call `__enter__` before reading | Call `raw.__enter__()` explicitly; call `raw.__exit__(None, None, None)` in the stream's `close()` |
+| Two-pass walk: `walk()` gives names, `get_record()` gives metadata | Unavoidable with pycdlib; the per-file overhead is small for most ISOs |
+| `DirectoryRecordDate` is not `datetime` | `dr_date_to_datetime()` helper (see section 3.3) |
+| UDF uses `udf.UDFFileEntry`, not `dr.DirectoryRecord` | Defer UDF to a separate implementation milestone |
+| pycdlib may report wrong RR if `ER` record absent | pycdlib resets `rock_ridge` to `""` if it doesn't see the RRIP `ER` system use entry (line 1257–1258 of `pycdlib.py`); no workaround needed — it handles this internally |
+
+---
+
+## 11. Native reader alternative
+
+ISO9660 is specified in Ecma-119 (freely available).  A native reader without
+pycdlib is feasible at roughly 350–450 lines:
+
+```
+1. Seek to sector 16 (offset 32768); read VDs until type 255
+2. Pick PVD; note Joliet SVD and UDF if present
+3. Recursively read directory records from pvd.root_directory_extent_location
+4. For each DR: if file, record (extent_loc, data_length) for later opening
+5. Open file: seek(extent_loc * 2048), read(data_length)
+```
+
+Rock Ridge parsing requires walking the System Use fields after the filename in
+each DR and interpreting `PX`, `TF`, `SL`, `NM` entries.  The main complication
+is **Continuation Areas** (`CE` entries): some DRs overflow into a separate
+sector, requiring an additional seek.  pycdlib handles this; a native reader must
+too.
+
+Multi-extent files (bit 7 of `file_flags`) store a single logical file across
+multiple non-contiguous extents.  These are uncommon but must be handled
+correctly; they require chaining multiple reads.
+
+**Comparison**:
+
+| Criterion | pycdlib | Native |
+|---|---|---|
+| Lines of implementation code | ~150 (wrapping) | ~400 (full) |
+| Rock Ridge / CE areas | Handled by pycdlib | Must implement |
+| Multi-extent files | Handled by pycdlib | Must implement |
+| UDF | Handled by pycdlib (could skip) | Not feasible without significant effort |
+| El Torito boot records | Handled by pycdlib | Can skip (no member data) |
+| New dependency | `pycdlib` | None |
+| pycdlib authoring complexity leaking into reader | Yes | No |
+
+**Recommendation**: Use pycdlib for the initial implementation.  It handles all
+edge cases out of the box, and archivey already declares it as a dependency.  A
+native reader can be considered later if pycdlib causes runtime issues (it has
+occasional bugs in its RR parser for unusual discs) or if the dependency weight
+becomes a concern.
+
+---
+
+## 12. Implementation checklist
+
+The following steps are required to add a working `IsoReader`:
+
+1. **Create `src/archivey/formats/iso_reader.py`** inheriting from
+   `BaseArchiveReader` with `members_list_supported=True`, `streaming_only=False`.
+
+2. **Constructor**: `pycdlib.pycdlib.PyCdlib().open(path)` or
+   `PyCdlib().open_fp(stream)`.  Detect `has_rr`, `has_joliet`, `has_udf`.
+   Choose the preferred namespace kwarg; store as `self._ns`.
+
+3. **`iter_members_for_registration()`**: Call `iso.walk(**{ns: "/"})`.  For each
+   `(dirpath, dirnames, filenames)`:
+   - Yield a directory member for `dirpath` (skip the root `/` itself).
+   - For each filename, call `iso.get_record(**{ns: full_path})` and convert to
+     `ArchiveMember`.
+
+4. **`_open_member(member)`**: Call
+   `iso.open_file_from_iso(**{ns: member.raw_info_path})`, call `__enter__()`,
+   wrap in `io.BufferedReader`, return.
+
+5. **`get_archive_info()`**: Read `iso.pvd`; build and return `ArchiveInfo` with
+   `is_solid=False`, `version="ISO9660"`, `comment=volume_identifier.strip()`.
+
+6. **`_translate_exception(e)`**: Map
+   `pycdlib.pycdlibexception.PyCdlibException` → `ArchiveCorruptedError`; return
+   `None` for others.
+
+7. **`_close_archive()`**: Call `iso.close()`.
+
+8. **Register the reader**: Add
+   `ContainerFormat.ISO: IsoReader` to `_FORMAT_TO_READER` in
+   `src/archivey/core.py`.
+
+9. **Enable tests**: Uncomment the ISO filenames in `SKIP_TEST_FILENAMES` in
+   `tests/archivey/sample_archives.py`.
+
+---
+
+## 13. Known pycdlib bugs and quirks
+
+- **Rock Ridge false-negative**: If an ISO was created without the RRIP `ER`
+  system use entry, pycdlib resets `rock_ridge` to `""` even if `PX`/`TF`/`NM`
+  entries are present.  This causes RR metadata to be silently ignored.  There is
+  no workaround short of patching pycdlib or falling back to raw DR parsing.
+- **`PyCdlibIO` requires `__enter__`**: Calling `read()` before `__enter__()` raises
+  `AttributeError: 'PyCdlibIO' object has no attribute '_fp'`.
+- **`open_file_from_iso` is not reentrant**: Each call creates a new `PyCdlibIO`
+  bound to its own file descriptor context.  Multiple concurrent opens of
+  different files should be safe, but the pycdlib `PyCdlib` object itself is not
+  thread-safe.
+- **Joliet and RR name disagreement**: When both are present, the same file may
+  have a 64-character-truncated Joliet name and a full RR name.  Always prefer RR
+  for filenames to avoid silent truncation.
+- **Multi-extent files**: pycdlib handles the chaining internally; `data_length`
+  on a multi-extent DR is the length of that extent only, not the full logical
+  file.  Use `iso.get_iso_file_length()` for the total size of multi-extent files
+  if needed.
+- **pycdlib is an authoring library**: Much of the library code handles writing
+  ISOs; the read path is a secondary concern.  Error reporting for corrupt inputs
+  is sometimes poor.
+
+---
+
+## 14. What pycdlib handles well (no workaround needed)
+
+| Feature | Status |
+|---|---|
+| Multi-extent files | Chained automatically |
+| El Torito boot records | Parsed but not exposed as members (correct behaviour) |
+| All three of RR / Joliet / UDF simultaneously | Handled; pick one namespace |
+| Interchange levels 1, 2, 3 | All supported |
+| Volume descriptor chain iteration | `iso.open()` reads it fully |
+| Directory record padding and even-byte alignment | Handled internally |
+| Rock Ridge continuation areas (CE entries) | Handled internally |
+| Large ISOs (> 4 GB via relaxed sector counts) | Handled |
+
+---
+
+## 15. Useful references
+
+- Ecma-119 (ISO9660 specification): https://www.ecma-international.org/publications-and-standards/standards/ecma-119/
+- Rock Ridge Interchange Protocol specification: IEEE P1282
+- Joliet specification: https://en.wikipedia.org/wiki/Joliet_(file_system) (Microsoft did not publish a formal spec)
+- pycdlib source: `/tmp/pycdlib_extracted/pycdlib/` (in this dev environment)
+- pycdlib documentation: https://clalancette.github.io/pycdlib/
+- Test archive creation: `tests/archivey/create_archives.py` (`create_iso_archive_with_pycdlib`, `create_iso_archive_with_genisoimage`)
+- Format detection: `src/archivey/formats/format_detection.py`
+- Reader registration: `src/archivey/core.py` (`_FORMAT_TO_READER`)

--- a/docs/rar-native-reader-design.md
+++ b/docs/rar-native-reader-design.md
@@ -1,0 +1,532 @@
+# RAR Native Reader — Architecture Design Notes
+
+This document captures the research needed to replace `rarfile`-based RAR handling
+with a built-in implementation that parses archive metadata itself but still calls
+an external decompressor (`unrar` or a compatible library) for actual decompression.
+
+---
+
+## 1. What the BaseArchiveReader contract requires
+
+Every format reader inherits from `BaseArchiveReader`
+(`src/archivey/internal/base_reader.py`).  The contract is defined by three
+abstract methods and one hook:
+
+| Method | Obligation |
+|---|---|
+| `iter_members_for_registration()` | Yield `ArchiveMember` objects one by one, metadata-only, with `raw_info` pointing at whatever format-specific object the reader keeps. Called once; the base class drives member ID assignment and the lookup indices. |
+| `get_archive_info()` → `ArchiveInfo` | Return archive-level metadata: `is_solid`, `version`, `comment`, `extra` (format-specific dict). Called lazily; may cache. |
+| `_open_member(member, pwd, for_iteration)` → `BinaryIO` | Open and return a readable byte stream for a single file member.  Guaranteed to be called only for `is_file` members after link resolution.  `for_iteration=True` is a hint that the call comes from sequential iteration; `for_iteration=False` means random access. |
+| `_translate_exception(e)` → `ArchiveError \| None` | Map format library exceptions to archivey exception types; return `None` for unrecognised exceptions. |
+
+Optional hooks:
+
+- `_prepare_member_for_open(member, pwd, for_iteration)` — called before link
+  resolution in `_open_internal`.  The current RAR reader uses this to fetch
+  encrypted symlink/hardlink targets lazily.
+- `_close_archive()` — format-specific teardown.
+
+Constructor parameters that control base-class behaviour:
+
+- `members_list_supported=True` — tells the base class it can call
+  `get_members_if_available()` to build the full member list up-front (RAR has a
+  central-directory-like structure, so this is safe).
+- `streaming_only=False` — RAR supports random access so this is always False.
+
+---
+
+## 2. What the current rarfile-based reader does
+
+`src/archivey/formats/rar_reader.py` wraps the `rarfile` third-party library
+(≥ 4.2).  Here is what each phase uses from `rarfile`:
+
+### 2.1 Metadata reading
+
+`rarfile` parses the entire block sequence on construction (`RarFile.__init__` →
+`_parse()`).  The result is a `CommonParser` subclass (`Rar3Parser` or
+`Rar5Parser`) that holds:
+
+- `_info_list` — ordered list of `Rar3Info` / `Rar5Info` objects
+- `_main` — the archive main header (solid flag, password flag, comment …)
+- `_file_parser.has_header_encryption()` — whether headers are encrypted
+- `is_solid()` / `needs_password()` — delegated to the parser
+
+`rar_reader.py:iter_members_for_registration()` (line 610) calls
+`self._archive.infolist()` and converts each `RarInfo` to an `ArchiveMember`.
+Fields extracted:
+
+| `RarInfo` field | Usage |
+|---|---|
+| `filename` / `orig_filename` | UTF-8/UTF-16 dual decode, corruption detection |
+| `file_size`, `compress_size` | sizes |
+| `mtime` / `date_time` | modification time (RAR5 UTC-aware, RAR3 naive) |
+| `is_dir()`, `is_file()`, `is_symlink()`, `file_redir` | member type |
+| `mode` | unix permissions |
+| `CRC` / `blake2sp_hash` | integrity |
+| `compress_type` (0x30–0x35) | compression method name |
+| `host_os` | create system |
+| `needs_password()`, `file_encryption` | encryption metadata |
+| `comment` | per-file comment (RAR3 only) |
+
+### 2.2 Decompression path
+
+`rarfile` never decompresses in Python.  When `RarFile.open(inf, pwd)` is
+called it picks a strategy (lines 1280–1303 of `rarfile.py`):
+
+1. **`_open_clear`** — file is stored uncompressed (M0) and not encrypted: read
+   the raw bytes directly from the archive file using `DirectReader` (a seekable
+   Python reader that skips over RAR block headers).
+
+2. **`_open_hack`** — enabled when `USE_EXTRACT_HACK=1` (default) and the file
+   is small (< `HACK_SIZE_LIMIT` = 20 MB) and the archive is *not* solid and
+   not encrypted:
+   - Constructs a minimal single-file RAR archive in a temp file containing
+     only the target entry's compressed data (with a synthetic main header and
+     end-of-archive marker).
+   - Runs `unrar p -inul` against that tiny temp file.
+   - This lets unrar decompress just the one member without scanning the whole
+     original archive — a significant speed win for large archives.
+   - For RAR3: prefix is `RAR_ID + BLK_HDR + 13 zero bytes`.
+   - For RAR5: prefix is `RAR5_ID + minimal main block + endarc block`.
+   - Disabled for: solid flag on archive or file, encrypted files/headers,
+     split volumes, file copies (`RAR5_XREDIR_FILE_COPY`), large files.
+
+3. **`_open_unrar_membuf`** — if the archive is a file-like object (in-memory):
+   write it to a temp file first, then call unrar normally.
+
+4. **`_open_unrar`** — full archive path, ask unrar to extract just the named
+   member:  `unrar p -inul [-pPASSWORD] archive.rar member_path`.
+   Result is `PipeReader`, which wraps the subprocess stdout and handles
+   CRC/Blake2sp verification on close.
+
+`rarfile` supports multiple backend tools (picked in priority order by
+`tool_setup()`):
+
+| Tool | Command | Known limitations |
+|---|---|---|
+| `unrar` | `unrar p -inul` | Full RAR3/RAR5 support, passwords, solid |
+| `unar` | `unar -q -o -` | No RAR2 locked files, no RAR5 Blake2sp |
+| `bsdtar` | `bsdtar -x --to-stdout -f` | No solid, no passwords, no RARVM filters |
+| `7z` / `7zz` | `7z e -so -bb0` | Mostly complete |
+
+### 2.3 Solid archive problem
+
+A **solid archive** is one where multiple files are compressed as a single
+stream, so each file's decompression depends on the full decompressor state
+from all preceding files.  The solid flag lives at two levels:
+
+- **Archive-level** (`RAR_MAIN_SOLID` flag in RAR3 main header;
+  `RAR5_MAIN_FLAG_SOLID` in RAR5 main block) — the whole archive is solid.
+- **File-level** (`RAR5_COMPR_SOLID` in file compress flags) — this specific
+  file continues the preceding solid stream.
+
+When an archive is solid, calling `rarfile.RarFile.open(member)` for the *k*-th
+member requires unrar to re-decompress members 1 through k−1 before it can
+produce member k.  If all N members are extracted one by one, the total work
+is O(N²).
+
+**Current workaround — `RarStreamReader`** (`rar_reader.py` lines 388–477,
+enabled with config `use_rar_stream=True`):
+
+1. Spawn one `unrar p -inul` subprocess that prints all file data
+   sequentially to stdout.
+2. For each member (in member-ID order), wrap a fixed-size slice of that
+   shared stdout into a `RarStreamMemberFile` that tracks remaining bytes and
+   validates the CRC on full read.
+3. Yield `(member, stream)` pairs from `rar_stream_iterator()`.
+
+This reduces total decompression work to O(N) at the cost of requiring
+sequential consumption of the stream.  Caveats:
+
+- Requires a file path (not in-memory stream).
+- Only safe when all members share the same password (solid archives
+  guarantee this).  Mixed encryption/no-encryption archives may mismatch if
+  unrar silently skips some files.
+- CRC validation handles the "tweaked checksum" case for RAR5 encrypted
+  files where the stored CRC is modified with the password via
+  HMAC-SHA-256 over PBKDF2 key material.
+
+### 2.4 Encrypted headers
+
+RAR archives can encrypt file headers (not just file data):
+
+- **RAR3**: `RAR_MAIN_PASSWORD` flag on the main block signals encrypted
+  headers.  The block content is AES-CBC encrypted; `rarfile` calls
+  `_decrypt_header()` with AES-256 derived from password + salt via SHA-1 (20
+  rounds of mixing).
+- **RAR5**: A separate `RAR5_BLOCK_ENCRYPTION` block holds the AES-256
+  parameters (KDF count, salt, IV).  If present, all subsequent blocks are
+  encrypted.
+
+`rar_reader.py:get_archive_info()` (line 688) reads this via the private
+`self._archive._file_parser.has_header_encryption()`.
+
+Without the password, header-encrypted archives report no members.
+
+### 2.5 Encryption per-member (RAR5)
+
+RAR5 stores per-file encryption in the `RAR5_XFILE_ENCRYPTION` extra record:
+
+```
+(algo, flags, kdf_count, salt[16], iv[16], check_value[12])
+```
+
+- `algo` = 0 → AES-256-CBC.
+- `flags & RAR5_ENC_FLAG_HAS_CHECKVAL` (0x01) → `check_value` present,
+  allows pre-flight password verification (avoids decompressing garbage).
+- `flags & RAR5_XENC_TWEAKED` (0x02) → checksums are "tweaked": the stored
+  `CRC` field is not the actual data CRC but `HMAC-SHA256(CRC, key)` where
+  `key = PBKDF2-SHA256(password, salt, 1<<kdf_count + 16)`.
+
+`rar_reader.py` implements this independently:
+
+- `verify_rar5_password()` (line 215) — pre-flight check using the 8+4 byte
+  check value; cached via `lru_cache`.
+- `convert_crc_to_encrypted()` (line 241) — re-derives the tweaked CRC from
+  a computed data CRC and the password.
+- `check_rarinfo_crc()` (line 270) — dispatches to either plain CRC compare
+  or tweaked compare.
+
+---
+
+## 3. RAR format essentials
+
+### 3.1 RAR3 (v2.0 – v4.x on-disk)
+
+**Signatures**:
+
+```
+RAR_ID  = b"Rar!\x1a\x07\x00"     (7 bytes)
+```
+
+SFX archives may have an arbitrary-length prefix; `is_rarfile_sfx` scans up
+to 2 MB.
+
+**Block layout** — every block starts with:
+
+```
+CRC16  (2 bytes)  — CRC of the block header
+TYPE   (1 byte)   — block type
+FLAGS  (2 bytes)
+SIZE   (2 bytes)  — header size (includes all fixed fields, excludes data area)
+[ADD_SIZE (4 bytes) if FLAGS & RAR_LONG_BLOCK]  — data area size
+```
+
+Block types and their solid/encryption relevance:
+
+| Type | Const | Notes |
+|---|---|---|
+| 0x72 | `RAR_BLOCK_MARK` | marker block (fixed) |
+| 0x73 | `RAR_BLOCK_MAIN` | archive header; `flags & RAR_MAIN_SOLID` = solid; `flags & RAR_MAIN_PASSWORD` = encrypted headers; `flags & RAR_MAIN_VOLUME` = multi-volume |
+| 0x74 | `RAR_BLOCK_FILE` | file entry; `flags & RAR_FILE_PASSWORD` = encrypted; `flags & RAR_FILE_SOLID` = continues solid stream |
+| 0x7a | `RAR_BLOCK_SUB` | service/sub-block (comments, NTFS streams, …) |
+| 0x7b | `RAR_BLOCK_ENDARC` | end of archive |
+
+File header additional fields (after the fixed 7-byte common part):
+
+```
+PACK_SIZE  (4 bytes)  — compressed size
+UNP_SIZE   (4 bytes)  — uncompressed size
+HOST_OS    (1 byte)
+FILE_CRC   (4 bytes)  — CRC32 of uncompressed data
+FTIME      (4 bytes)  — MS-DOS timestamp
+UNP_VER    (1 byte)   — minimum unrar version (e.g., 0x1d = 29)
+METHOD     (1 byte)   — 0x30..0x35
+NAME_SIZE  (2 bytes)
+ATTR       (4 bytes)
+[HIGH_PACK, HIGH_UNP  (4+4 bytes) if FLAGS & RAR_FILE_LARGE]
+[FILENAME  (NAME_SIZE bytes)]
+[SALT      (8 bytes) if FLAGS & RAR_FILE_SALT]
+[EXTTIME   if FLAGS & RAR_FILE_EXTTIME]  — sub-second timestamps
+```
+
+Unicode filenames: if `FLAGS & RAR_FILE_UNICODE`, the filename field starts
+with the 8-bit (OEM/windows-1252) name, followed by a compressed UTF-16
+encoding (the `UnicodeFilename` class in `rarfile.py` decodes it).  The
+non-BMP truncation bug (emoji stored as surrogates) occurs in some RAR 2.9–4
+archivers and is detected by `get_non_corrupted_filename()`.
+
+### 3.2 RAR5 (v5.x on-disk)
+
+**Signatures**:
+
+```
+RAR5_ID = b"Rar!\x1a\x07\x01\x00"  (8 bytes)
+```
+
+**Block layout** — variable-length integer encoding (vint: 7 bits per byte,
+MSB continuation flag):
+
+```
+HEADER_CRC32  (4 bytes)  — CRC of everything that follows in the header
+HEADER_SIZE   (vint)
+HEADER_TYPE   (vint)     — 1=MAIN, 2=FILE, 3=SERVICE, 4=ENCRYPTION, 5=ENDARC
+HEADER_FLAGS  (vint)
+[EXTRA_DATA_SIZE (vint) if flags & RAR5_BLOCK_FLAG_EXTRA_DATA]
+[DATA_AREA_SIZE  (vint) if flags & RAR5_BLOCK_FLAG_DATA_AREA]
+... type-specific fields ...
+[EXTRA_DATA  — array of typed extra records]
+```
+
+Important MAIN block flags:
+
+- `RAR5_MAIN_FLAG_SOLID` (0x04) — solid archive.
+- `RAR5_MAIN_FLAG_ISVOL` (0x01) — multi-volume.
+
+File block fields:
+
+```
+FILE_FLAGS  (vint)     — RAR5_FILE_FLAG_ISDIR, HAS_MTIME, HAS_CRC32, UNKNOWN_SIZE
+UNP_SIZE    (vint)
+ATTR        (vint)
+MTIME       (4 bytes)  — Unix timestamp if FILE_FLAG_HAS_MTIME
+DATA_CRC32  (4 bytes)  — if FILE_FLAG_HAS_CRC32
+COMPRESS_INFO  (vint)  — method(3b), solid(1b), algo version(6b), dict(4b)
+HOST_OS     (vint)     — 0=Windows, 1=Unix
+NAME_LEN    (vint)
+NAME        (bytes, UTF-8)
+[EXTRA_DATA records]
+```
+
+`compress_info & RAR5_COMPR_SOLID` (0x40) means this file depends on the
+previous compressed stream (per-file solid flag).
+
+Extra record types relevant to a reader:
+
+| Type | Content |
+|---|---|
+| `RAR5_XFILE_ENCRYPTION` (1) | AES-256 params: algo, flags, kdf_count, salt[16], iv[16], check_value[12] |
+| `RAR5_XFILE_HASH` (2) | Blake2SP hash (32 bytes) |
+| `RAR5_XFILE_TIME` (3) | Extended time: mtime/ctime/atime; optional nanosecond precision |
+| `RAR5_XFILE_REDIR` (5) | Symlink / hardlink / file copy target |
+| `RAR5_XFILE_OWNER` (6) | Unix uid/gid and name strings |
+
+The `RAR5_BLOCK_ENCRYPTION` block (type 4) precedes all file blocks when
+headers are encrypted.  It holds: `algo`, `flags`, `kdf_count`, `salt[16]`.
+The consumer must decrypt each subsequent header block (AES-256-CBC) before
+it can parse it.
+
+---
+
+## 4. What a native reader needs to implement
+
+### 4.1 Scope: metadata only
+
+The goal is to replace `rarfile` for **metadata parsing** while still
+delegating decompression to an external tool (`unrar`, or in future a native
+Python library such as `unrar-cffi`).
+
+This means the new reader must:
+
+1. Detect and skip the SFX prefix (scan up to 2 MB for `RAR_ID` / `RAR5_ID`).
+2. Parse the archive's block sequence to build the member list.
+3. Decode all member metadata fields listed in §2.1.
+4. Detect `is_solid`, `has_header_encryption`, `needs_password`.
+5. For header-encrypted archives, derive the AES-256 key from password and
+   decrypt headers before parsing.
+6. For `RAR5_XFILE_ENCRYPTION`, expose the per-file encryption record so
+   `verify_rar5_password()` and `convert_crc_to_encrypted()` can continue to
+   work as-is (they only need the `(algo, flags, kdf_count, salt, iv,
+   check_value)` tuple, which we already extract as `RarEncryptionInfo`).
+7. For RAR3 symlink/hardlink targets: the target is stored as the file's data
+   content, so we need to call the external tool once to read it (same as the
+   current `_get_link_target()` fallback path).
+8. Provide the `raw_info` object (our own dataclass replacing `RarInfo`) with
+   at minimum `filename`, `file_size`, `CRC`, `needs_password()`, and the
+   encryption record, since these are referenced by `RarStreamMemberFile` and
+   the CRC helpers.
+
+### 4.2 Decompression strategy
+
+Nothing changes conceptually from today:
+
+| Path | When | Mechanism |
+|---|---|---|
+| **Stored** (M0, no encryption) | `compress_type == 0x30` | Read raw bytes directly from archive at `data_offset`, no subprocess. |
+| **Random access** (non-solid, or solid but single member) | Default `_open_member` path | Spawn `unrar p -inul [-pPWD] archive.rar member_name`. |
+| **Extract-hack** (non-solid, file ≤ 20 MB) | When enabled | Build minimal temp archive containing only this member's compressed block, run unrar on it. Avoids unrar re-scanning whole archive. |
+| **Solid streaming** | `use_rar_stream=True` | One `unrar p -inul` subprocess, share stdout across all members via `RarStreamMemberFile`. Already implemented in `RarStreamReader`; no change needed. |
+
+The extract-hack currently lives inside `rarfile`.  A native reader should
+re-implement it:
+
+- For **RAR3**: prefix = `RAR_ID + BLK_HDR(crc=0x90CF, type=0x73, flags=0, size=13) + 6 zero bytes`, then verbatim copy of the file header + compressed data block, no suffix.
+- For **RAR5**: prefix = `RAR5_ID + crc32(main_hdr) + main_hdr + crc32(endarc_hdr) + endarc_hdr`, where `main_hdr = b"\x03\x01\x00\x00"` and `endarc_hdr = b"\x03\x05\x00\x00"`, then the file block verbatim.
+- This requires storing the on-disk byte offsets and sizes of each block (`header_offset`, `header_size`, `add_size`) in the native `RarMemberInfo` so they can be re-read when building the temp archive.
+
+Conditions to **disable** the extract-hack (same as rarfile):
+
+- Archive is solid (`RAR_MAIN_SOLID` or `RAR5_MAIN_FLAG_SOLID`).
+- File has `RAR_FILE_SOLID` / `RAR5_COMPR_SOLID` flag (depends on previous stream).
+- File is password-protected.
+- Headers are encrypted.
+- File is split across volumes.
+- File is a redirect / file copy (`file_redir` present).
+- `file_size > HACK_SIZE_LIMIT` (20 MB).
+
+### 4.3 Header decryption (encrypted headers)
+
+For RAR3:
+
+1. Each block's AES-256-CBC key is derived via 70,144 rounds of SHA-1 mixing
+   (`rarfile` does this in `_gen_rar3_key`, not shown here but documented in
+   WinRAR SDK).  The salt is 8 bytes stored right after the main header.
+2. The `cryptography` or `pycryptodome` package is required (same as today).
+
+For RAR5:
+
+1. Read the `RAR5_BLOCK_ENCRYPTION` block (type 4): `algo=0`, `kdf_count`,
+   `salt[16]`.
+2. Derive AES-256 key: `PBKDF2-HMAC-SHA256(password, salt, 1<<kdf_count + 32)` —
+   first 32 bytes are the key, next 16 bytes are the IV tweak XOR'd with the
+   block's stored IV field.
+3. Decrypt each subsequent block header with AES-256-CBC.
+
+### 4.4 Native `RarMemberInfo` dataclass
+
+Replace `Rar3Info` / `Rar5Info` as the `raw_info` payload.  Minimum fields
+needed by existing consumers:
+
+```python
+@dataclass
+class RarMemberInfo:
+    filename: str
+    orig_filename: bytes | None        # RAR3 8-bit name, for corruption detection
+    file_size: int | None
+    compress_size: int | None
+    compress_type: int | None          # 0x30..0x35
+    CRC: int | None
+    blake2sp_hash: bytes | None
+    flags: int                         # for RAR_FILE_PASSWORD, RAR_FILE_UNICODE, etc.
+    rar_version: int                   # 3 or 5
+    file_encryption: tuple | None      # RarEncryptionInfo namedtuple fields
+    file_redir: tuple | None           # (type, flags, target) for RAR5
+    host_os: int | None
+    mode: int | None
+    mtime: datetime | None
+    ctime: datetime | None
+    atime: datetime | None
+    comment: str | None
+    # for extract-hack:
+    header_offset: int
+    header_size: int
+    data_offset: int
+    volume_file: str
+    # for is_solid detection:
+    file_compress_flags: int           # RAR5 compress_info field
+
+    def needs_password(self) -> bool: ...
+    def is_dir(self) -> bool: ...
+    def is_file(self) -> bool: ...
+    def is_symlink(self) -> bool: ...
+```
+
+### 4.5 Parser classes
+
+Following rarfile's pattern, separate parsers for RAR3 and RAR5:
+
+```
+NativeRar3Parser
+    - read_blocks() → list[RarMemberInfo]
+    - _parse_block_header(fd) → header dict
+    - _decrypt_header(fd) → decrypted fd  (RAR3 header encryption)
+    - is_solid() → bool
+    - needs_password() → bool
+    - has_header_encryption() → bool
+    - comment: str | None
+
+NativeRar5Parser
+    - read_blocks() → list[RarMemberInfo]
+    - _parse_vint(fd) → int
+    - _parse_block(fd) → header dict
+    - _decrypt_header(fd, enc_block) → decrypted fd  (RAR5 header encryption)
+    - _parse_extra(data, h) → None  (populates extra fields on h)
+    - is_solid() → bool
+    - needs_password() → bool
+    - has_header_encryption() → bool
+```
+
+### 4.6 Unicode filename handling
+
+The `get_non_corrupted_filename()` function can remain unchanged — it only
+needs `rarinfo.filename` (decoded UTF-16) and `rarinfo.orig_filename` (8-bit
+bytes).  Both fields will be present on `RarMemberInfo`.
+
+The RAR3 `UnicodeFilename` decompressor logic (currently in `rarfile`) will
+need to be ported, or we can use the same UTF-16 compressed format description
+from the RAR Technical Note.
+
+---
+
+## 5. Things that can be dropped / simplified
+
+| Current complexity | Why it exists | Native reader stance |
+|---|---|---|
+| `rarfile.RarFile` constructor + `_parse()` | `rarfile` re-parses on `setpassword()` if headers were encrypted | Native reader just re-parses once when password is provided |
+| `_open_unrar_membuf` path (in-memory archive → temp file) | `rarfile` supports file-like objects | We can keep or drop; most use is file-path based |
+| Multiple backend tools (unar, bsdtar, 7z) | `rarfile` abstracts tool selection | Initially target `unrar` only; add others if needed |
+| `rarfile.FORCE_TOOL` and `CURRENT_SETUP` global | Tool selection caching | Not needed if we own the subprocess |
+| `rarfile.RarExtFile.seek()` | rarfile's open() claims to be seekable | Our `_open_member` is not expected to be seekable (base class sets `seekable=not streaming_only=True`) |
+
+---
+
+## 6. Files affected by the change
+
+| File | Change |
+|---|---|
+| `src/archivey/formats/rar_reader.py` | Replace `rarfile.RarFile` / `Rar3Info` / `Rar5Info` usage with native parser; keep `RarStreamReader`, `RarStreamMemberFile`, all CRC/encryption helpers |
+| New: `src/archivey/formats/rar_parser.py` | `NativeRar3Parser`, `NativeRar5Parser`, `RarMemberInfo` |
+| `src/archivey/internal/dependency_checker.py` | `rarfile` becomes optional; list `unrar` as required tool instead |
+| `pyproject.toml` | Remove `rarfile>=4.2` from `optional` dependencies |
+| Tests | Verify all existing RAR test archives still pass; add parser unit tests |
+
+---
+
+## 7. Open questions / risks
+
+1. **Multi-volume archives** — `rarfile` handles volume chaining
+   (`_next_volname`, `NeedFirstVolume`).  The native reader needs the same
+   logic.  Currently archivey does not advertise multi-volume support, but
+   it should at minimum raise `ArchiveError` cleanly.
+
+2. **RARVM filters** (RAR3) — Some RAR3 archives use bytecode filter programs
+   for preprocessing (e.g., the "delta" or "exe" filters).  `unrar` handles
+   these transparently.  The native parser does not need to implement RARVM;
+   the extract-hack will still work because unrar in the temp archive path runs
+   over the raw compressed block including any filter metadata.
+
+3. **RAR2 / very old formats** — RAR 2.0 (extract_version ≤ 20) archives have
+   a slightly different block layout.  `rarfile` handles them.  Decide whether
+   to support them or raise `ArchiveError("RAR2 not supported")`.
+
+4. **Blake2sp verification** — RAR5 files may have Blake2sp instead of CRC32.
+   `rarfile`'s `PipeReader` verifies this; our subprocess-based path does not
+   currently verify anything (verification is left to the subprocess exit code).
+   The `RarStreamMemberFile` only checks CRC32.  For a native reader, if
+   `blake2sp_hash` is present and `CRC` is None, streaming CRC checks become
+   no-ops.  Consider adding Blake2sp streaming verification.
+
+5. **Encrypted headers + in-memory stream** — current reader raises
+   `ArchiveStreamNotSeekableError` for non-seekable streams; seekable
+   in-memory streams work.  Header decryption requires reading a fixed number
+   of bytes at known offsets, which is compatible with seekable streams.
+   The native reader can preserve this behaviour.
+
+6. **`file_encryption` is a private rarfile attribute** — currently accessed
+   via `rarinfo.file_encryption`.  With a native reader this becomes a
+   first-class field on `RarMemberInfo` and the hack is gone.
+
+---
+
+## 8. Useful references
+
+- WinRAR Technical Note (included with WinRAR): `technote.txt`; defines the
+  complete RAR5 format.
+- RAR3 format: historically undocumented; `rarfile.py` source is the best
+  available description.
+- `rarfile.py` source (4.2): `/tmp/rarfile_src/rarfile.py` (extracted from
+  wheel during this research session).
+- Current implementation: `src/archivey/formats/rar_reader.py`.
+- Base class: `src/archivey/internal/base_reader.py`.
+- 7-zip reader (parallel for solid-archive streaming pattern):
+  `src/archivey/formats/sevenzip_reader.py`.

--- a/docs/sevenzip-native-reader-design.md
+++ b/docs/sevenzip-native-reader-design.md
@@ -1,0 +1,616 @@
+# 7-Zip Native Reader — Architecture Design Notes
+
+This document captures the research needed to replace `py7zr`-based 7-zip handling
+with a built-in implementation that parses archive metadata itself but still
+delegates decompression to py7zr (or a future alternative like the `lzma` stdlib
+module for LZMA2-only archives, or an external `7z` tool for other codecs).
+
+The structure mirrors [`rar-native-reader-design.md`](rar-native-reader-design.md).
+
+---
+
+## 1. What the BaseArchiveReader contract requires
+
+See the RAR design doc §1 for the full description.  The relevant flags for 7z:
+
+- `members_list_supported=True` — 7z has a central directory at the end of the
+  file (the "end header"), so a complete member list is always available before
+  any decompression.
+- `streaming_only=False` — random access is supported.
+- Non-seekable input streams are rejected at construction time
+  (`ArchiveStreamNotSeekableError`), because `SevenZipFile._real_get_contents()`
+  seeks back to the start of the payload after reading the header.
+
+---
+
+## 2. What the current py7zr-based reader does
+
+`src/archivey/formats/sevenzip_reader.py` wraps `py7zr` (≥ 1.0.0).  Unlike
+RAR, py7zr is a **pure-Python decompressor** — it never calls an external tool.
+
+### 2.1 Metadata reading
+
+`SevenZipFile.__init__` calls `_real_get_contents(password)` which:
+
+1. Reads the 32-byte **signature header** at the start of the file to get the
+   offset and size of the **end header** block.
+2. Seeks to the end header, reads it into a `BytesIO` buffer, and verifies its
+   CRC32.
+3. Passes the buffer to `Header.retrieve(fp, buffer, afterheader, password)`,
+   which parses `ENCODED_HEADER` (LZMA2-compressed header) or plain `HEADER`
+   blocks, potentially decrypting if header encryption is in use.
+4. Iterates over the parsed `files_info.files` list, associating each file
+   record with a `Folder` object and computing per-file sizes and CRCs from
+   `SubStreamsInfo`.
+5. Builds `self.files` as an `ArchiveFileList` of `ArchiveFile` objects.
+
+`sevenzip_reader.py:iter_members_for_registration()` (line 414) iterates
+`self._archive.files` and converts each `ArchiveFile` to an `ArchiveMember`.
+
+Fields extracted from `ArchiveFile`:
+
+| `ArchiveFile` field | Usage | Notes |
+|---|---|---|
+| `filename` | member path | UTF-16LE decoded by py7zr |
+| `is_directory` | `MemberType.DIR` | trailing `/` added if missing |
+| `is_symlink` | `MemberType.SYMLINK` | derived from POSIX mode bits |
+| `is_junction`, `is_socket` | `MemberType.OTHER` | Windows junction / socket |
+| `uncompressed` | `file_size` | typed as `list[int]` in py7zr docs but actually `int` |
+| `compressed` | `compress_size` | **folder's** total packed size, not per-file |
+| `crc32` | `crc32` | per-file CRC32; empty files get 0 explicitly |
+| `lastwritetime` | `mtime_with_tz` | Windows FILETIME; `py7zr.helpers.filetime_to_dt()` converts it |
+| `posix_mode` | `mode` | POSIX permissions from Unix extra field |
+| `folder` | used for `encrypted` detection | internal `Folder` object reference |
+
+Fields **not** exposed by py7zr (set to `None` in `ArchiveMember`):
+
+- `compression_method` — py7zr doesn't expose the codec per-file.
+- `comment` — 7z format supports comments but py7zr doesn't expose them.
+- `create_system` — not available.
+- Per-file `compressed` size in solid archives (all files in the same folder
+  share the folder's total `compressed` value).
+
+### 2.2 Decompression: how py7zr works
+
+py7zr implements all decompression in Python:
+
+| Codec | py7zr implementation | Method ID |
+|---|---|---|
+| LZMA / LZMA1 | `lzma` stdlib | `0x030101` |
+| LZMA2 | `lzma` stdlib | `0x21` |
+| Delta filter | Python | `0x03` |
+| BCJ (x86/ARM/…) | Python | `0x04`–`0x09`, `0x03030103` etc. |
+| Deflate | `zlib` stdlib | `0x040108` |
+| Deflate64 | `inflate64` optional | `0x040109` |
+| BZip2 | `bz2` stdlib | `0x040202` |
+| Zstd | `zstandard` optional | `0x04f71101` |
+| Brotli | `brotli` optional | `0x04f71102` |
+| AES-256/SHA-256 | `Cryptodome.Cipher.AES` | `0x06f10701` |
+| Copy (store) | identity | `0x00` |
+| PPMd | (limited) | `0x030401` |
+
+The `Folder.get_decompressor(packsize)` method builds a `SevenZipDecompressor`
+chain for the folder's coders list — filters are applied in pipeline order
+(e.g. LZMA2 → AES means: decrypt first, then decompress; in the coder list
+order that is AES → LZMA2 which is reversed for decompression).
+
+`extract(targets=[...], factory=factory)` iterates `self.files`, skips
+non-targeted files (registering a `NullIO` on the worker), then extracts
+targeted ones in a single forward pass through the archive, decompressing
+each folder once regardless of how many files in it are targeted.
+
+Key implication: **there is no O(N²) problem for solid archives** as long as
+all members from a given folder are extracted in a single `extract()` call.
+This is what `_extract_members_iterator()` does — it collects all pending files
+and passes them all to one `extract()` invocation.
+
+### 2.3 The solid archive concept in 7z
+
+Unlike RAR (where "solid" is an archive-wide flag), 7z uses a **folder-based**
+model:
+
+- A **Folder** is a compression unit: one packed bitstream that decompresses to
+  the concatenation of one or more files.
+- If a folder holds exactly 1 file, it is non-solid for that file.
+- If a folder holds N > 1 files, those N files form a solid group.
+- `SubStreamsInfo.num_unpackstreams_folders[i]` = number of files in folder i.
+- `SevenZipFile._is_solid()` (line 835) returns `True` if any
+  `num_unpackstreams_folders` value is > 1.
+
+`archiveinfo().solid` reports this same flag.
+
+The guard in `_is_solid()` (lines 795–800):
+
+```python
+if self._archive.header.main_streams is None:
+    # py7zr bug: archiveinfo() raises if archive is empty / no main streams
+    return False
+```
+
+### 2.4 The thread + queue streaming design
+
+py7zr's extraction model is push-based: you pass a `WriterFactory` and py7zr
+calls `factory.create(filename)` → writes chunks → calls `writer.close()`.
+There is no way to pull one file at a time from the outside.
+
+To expose the archivey `iter_members_with_streams()` pull-based iterator,
+the reader spawns a background thread:
+
+```
+Main thread                      Background thread
+──────────────────               ─────────────────────────────
+iter_members_with_streams()      extractor()
+  _extract_members_iterator()
+    Thread(target=extractor).start()
+                                   archive.reset()
+                                   archive.extract(targets, factory=factory)
+                                     factory.create("a.txt") → StreamingFile
+                                       StreamingFile.write(chunk)
+    q.get() ← ────────────────────────── q.put(("a.txt", reader))
+    yield member, reader
+    caller reads reader.read(n)
+      ← reader._data_queue.get() ← StreamingFile._data_queue.put(chunk)
+                                     StreamingFile.close()
+                                       _data_queue.put(None)  # EOF
+    stream.close()
+                                   factory.finish()
+                                     q.put(None)  # no more files
+    q.get() → None → break
+```
+
+Each `StreamingFile` has its own internal `_data_queue` (max 64 chunks) for
+backpressure.  The shared `q` carries `(filename, reader)` pairs as each new
+file starts (when py7zr first calls `writer.write()`).
+
+**Edge cases in the streaming path**:
+
+- **Empty files** (line 683): py7zr never calls `write()` for zero-size files,
+  so they never appear in the queue.  The first pass yields them with an empty
+  `BytesIO` immediately.
+- **Directories** (line 678): yielded from the first pass with `stream=None`.
+- **Unresolved links without target** (lines 665–668): collected into
+  `pending_links_by_id`, extracted alongside files in the second pass, their
+  content decoded as UTF-8 to set `link_target`.
+- **Exceptions in background thread** (lines 585–590): caught and put into the
+  queue as `Exception` objects; the main thread detects these and re-raises
+  (after joining the thread).
+
+### 2.5 Password handling — the `_temporary_password` hack
+
+py7zr stores the AES password on each `Folder` object (`folder.password`).
+The password is set when the archive is opened:
+
+```python
+# in _real_get_contents():
+for folder in folders:
+    folder.password = password   # string or None
+```
+
+There is **no parameter on `extract()`** to pass a different password.  To
+support per-call passwords, the reader temporarily mutates the folder objects:
+
+```python
+@contextmanager
+def _temporary_password(self, pwd):
+    SevenZipReader._password_lock.acquire()   # class-level lock
+    folders = archive.header.main_streams.unpackinfo.folders
+    previous = [f.password for f in folders]
+    for f in folders:
+        f.password = bytes_to_str(pwd)
+    yield
+    for f, p in zip(folders, previous):
+        f.password = p
+    SevenZipReader._password_lock.release()
+```
+
+The **class-level `_password_lock`** (line 286) prevents two threads from
+concurrently mutating the same archive's folder passwords.  A single `SevenZipFile`
+object is shared across all calls to the reader; concurrent `open()` or
+`iter_members_with_streams()` calls with different passwords would race without
+this lock.
+
+**Known limitation** (tests are skipped for it): `iter_members_with_streams(pwd=...)`
+does not work correctly when different members need different passwords
+(e.g. `encryption_several_passwords__7zcmd.7z`).  The lock sets the password
+globally for all folders, so files in folders that should have a different
+password (or no password) will fail or produce garbage.  The password must be
+set at `open_archive()` construction time for reliable behaviour.
+
+### 2.6 Duplicate filename handling
+
+py7zr renames duplicate filenames during extraction by appending `_<n-1>` to
+later occurrences.  The `extract_filename` mapping in `raw_info.extra` mirrors
+this logic (lines 427–433) so that `StreamingFactory.create(filename)` returns
+the correct member when py7zr passes the sanitised name.
+
+### 2.7 `reset()` requirement
+
+`archive.reset()` (called before every `extract()`) recreates the internal
+`Worker` object.  Without it, a second extraction call on the same
+`SevenZipFile` fails because the worker's state has been consumed.
+
+### 2.8 Archive info and `password_protected`
+
+`SevenZipFile.password_protected` is set to:
+- `True` if a password was passed to the constructor **or** if any folder's
+  coders include the AES method (detected after parsing, lines 555–558).
+- This is what `get_archive_info()` exposes as `extra["is_encrypted"]`.
+
+There is no explicit "header encryption" flag exposed in py7zr's public API;
+it is implicit — if `header_encryption=True` was set during writing, the
+`ENCODED_HEADER` block is wrapped in AES, and `_real_get_contents` decrypts it
+using the provided password before parsing.
+
+---
+
+## 3. 7z format essentials
+
+### 3.1 Signature
+
+```
+37 7a bc af 27 1c     (6 bytes)  —  MAGIC_7Z = b"7z\xbc\xaf\x27\x1c"
+```
+
+Unlike ZIP or RAR, there is **no SFX support** in the signature — 7z files
+always start at byte 0.
+
+### 3.2 Signature header (first 32 bytes)
+
+```
+Signature[6]          = 37 7a bc af 27 1c
+MajorVersion[1]       = 00
+MinorVersion[1]       = 04
+StartHeaderCRC[4]     — CRC32 of the next 20 bytes
+NextHeaderOffset[8]   — offset of end header from byte 32 (after sig header)
+NextHeaderSize[8]     — size of end header
+NextHeaderCRC[4]      — CRC32 of end header
+```
+
+The end header immediately follows the payload data:
+`end_header_pos = 32 + NextHeaderOffset`.
+
+After parsing the signature header, py7zr seeks to `afterheader +
+sig_header.nextheaderofs` to read the header block.
+
+### 3.3 End header / archive header
+
+The end header is either:
+
+- A plain `HEADER` block (property tag `0x01`), or
+- An `ENCODED_HEADER` block (property tag `0x17`) — the actual header is
+  stored compressed (LZMA2 by default) as another packed stream; the
+  `ENCODED_HEADER` contains a `StreamsInfo` describing how to decompress it.
+- If **header encryption** is active, the `ENCODED_HEADER`'s packed stream is
+  encrypted with AES-256.
+
+A plain `HEADER` block contains:
+
+```
+HEADER (0x01)
+  [ARCHIVE_PROPERTIES (0x02)]          — optional
+  [ADDITIONAL_STREAMS_INFO (0x03)]     — optional
+  [MAIN_STREAMS_INFO (0x04)]
+    PACK_INFO (0x06)
+      PackPos (uint64)
+      NumPackStreams (uint64)
+      SIZE (0x09): N × uint64 pack sizes
+      [CRC (0x0a): optional folder CRCs]
+    UNPACK_INFO (0x07)
+      FOLDER (0x0b)
+        NumFolders (uint64)
+        [External flag]
+        Folder[NumFolders]:
+          NumCoders (uint64)
+          Coder[NumCoders]:
+            CodecIdSize (1 byte)
+            CodecId[CodecIdSize]
+            [NumInStreams/NumOutStreams if complex coder]
+            [PropertiesSize + Properties if has properties]
+          [BindPairsInfo]
+          [PackedStreamsForCoder: index of input pack stream]
+          UnpackSizes[NumCoders]
+          [CRC]
+      CODERS_UNPACK_SIZE (0x0c): per-coder unpack sizes
+      [CRC (0x0a)]
+    SUBSTREAMS_INFO (0x08)
+      [NUM_UNPACK_STREAM (0x0d): files-per-folder counts]
+      [SIZE (0x09): per-stream unpack sizes, omitted if 1 per folder]
+      [CRC (0x0a): per-file CRCs]
+  FILES_INFO (0x05)
+    NumFiles (uint64)
+    Property records until END (0x00):
+      0x0e  EMPTY_STREAM bitmask   — which files have no data stream
+      0x0f  EMPTY_FILE bitmask     — which empty-stream files are real files vs dirs
+      0x10  ANTI bitmask           — anti-items (delete on extraction)
+      0x11  NAME: UTF-16LE names with NUL separator
+      0x12  CREATION_TIME: optional Windows FILETIME values
+      0x13  LAST_ACCESS_TIME: optional
+      0x14  LAST_WRITE_TIME: optional
+      0x15  ATTRIBUTES: optional Windows file attributes
+      0x18  START_POS: optional per-file pack start positions
+END (0x00)
+```
+
+All integers are little-endian.  Sizes use a variable-length encoding
+(`read_uint64`): first byte's high bits indicate length; if `< 0x80` it's 1
+byte, otherwise up to 8 bytes.
+
+### 3.4 Folder and solid detection
+
+A `Folder` represents one compressed stream.  Its `coders` list describes the
+pipeline: each coder has a method ID (byte sequence) and optional properties.
+
+The **solid flag** for a folder is determined during `_real_get_contents`:
+
+```python
+folder.solid = subinfo.num_unpackstreams_folders[folder_idx] > 1
+```
+
+A folder is solid if it decompresses to more than one file.  The archive is
+solid overall if any folder is solid.
+
+**Implication for a native reader**: detecting `is_solid` only requires
+reading `SubStreamsInfo.num_unpackstreams_folders`, not decompressing anything.
+
+### 3.5 AES-256 encryption
+
+Method ID: `0x06f10701` (`CRYPT_AES256_SHA256`).
+
+Properties (stored as coder properties):
+
+```
+FirstByte[1]:
+  bits 5..0 = NumCyclesPower (key derivation iteration count = 1 << NumCyclesPower,
+              or 0x3f for max)
+  bit  6    = IV is present
+  bit  7    = Salt is present
+SaltSize[1] (if Salt present): upper nibble = salt byte count
+IVSize[1] (if IV present)
+Salt[SaltSize bytes]
+IV[IVSize bytes], zero-padded to 16 bytes
+```
+
+Key derivation (`calculate_key` in py7zr):
+
+```python
+password_bytes = password.encode("utf-16LE")
+iterations = 1 << NumCyclesPower   # (special case: if NumCyclesPower == 0x3f, use 0x7fffffff)
+sha = hashlib.sha256()
+for round in range(iterations):
+    sha.update(password_bytes)
+    sha.update(salt)
+    sha.update(struct.pack("<Q", round))   # round counter as little-endian uint64
+key = sha.digest()  # 32 bytes
+```
+
+Then AES-256-CBC decrypt with the derived key and the IV from properties.
+
+Note: **header encryption** uses the same AES-256 scheme but applied to the
+`ENCODED_HEADER`'s packed stream.  There is no separate "check value" for
+pre-flight password verification (unlike RAR5).  A wrong password simply
+produces garbage that fails CRC validation.
+
+---
+
+## 4. What a native reader needs to implement
+
+### 4.1 Scope
+
+The goal is to replace py7zr for **metadata parsing** while still using py7zr
+(or another backend) for decompression.  A native parser would:
+
+1. Detect the 7z signature and read the 32-byte signature header.
+2. Seek to the end header, read and verify its CRC32.
+3. If `ENCODED_HEADER`: read the inner `StreamsInfo` to locate the compressed
+   header payload, then decompress it (using `lzma.decompress` for LZMA2, or
+   delegating to py7zr/external tool), verify CRC.
+4. If header-encrypted: derive the AES key and decrypt before step 3.
+5. Parse `HEADER` → `FILES_INFO` to build the member list.
+6. Parse `MAIN_STREAMS_INFO` → `UNPACK_INFO` → folders + coders, and
+   `SUBSTREAMS_INFO` → per-file sizes and CRCs.
+7. Associate each file with its folder and compute per-file metadata.
+8. Detect `is_solid`, `is_encrypted`, folder-level encryption.
+
+### 4.2 Native `SevenZipMemberInfo` dataclass
+
+The `raw_info` payload currently stored is py7zr's `ArchiveFile` object.
+The only field used after registration is `ArchiveFile.filename` for building
+the `extract_targets` list (line 569).  An equivalent native dataclass:
+
+```python
+@dataclass
+class SevenZipMemberInfo:
+    filename: str              # original name as stored in archive (no trailing /)
+    is_directory: bool
+    is_symlink: bool
+    is_junction: bool
+    is_socket: bool
+    is_emptystream: bool       # has no data stream (dirs, some special files)
+    uncompressed: int          # file_size
+    compressed: int | None     # total folder packed size (not per-file in solid archives)
+    crc32: int | None          # per-file CRC32
+    lastwritetime: int | None  # Windows FILETIME (100ns since 1601)
+    posix_mode: int | None     # Unix mode bits from extra field
+    folder_index: int | None   # which folder holds this file; None for empty-stream files
+    file_in_folder: int        # 0-based index within the folder
+    # for extract_filename de-dup tracking (mirrors py7zr naming):
+    extract_filename: str      # may differ from filename if duplicate
+```
+
+### 4.3 Decompression strategy
+
+Nothing changes in the decompression path — we still use py7zr's `extract()`
+with the `StreamingFactory`/`WriterFactory` pattern.  The only change is that
+we no longer need py7zr for metadata (the `iter_members_for_registration` phase),
+so we build our own `SevenZipMemberInfo` objects and construct a minimal
+py7zr-compatible structure for the extraction call.
+
+**Alternative (future)**: if py7zr is removed entirely, decompression would need
+to fall back to an external `7z` tool (like `unrar` for RAR).  The streaming
+design would then mirror `RarStreamReader`: spawn `7z e -so`, share stdout.
+
+### 4.4 Solid-archive extraction: current strategy is already O(N)
+
+Unlike RAR (where each `rarfile.open()` re-decompresses from the start of the
+solid stream), py7zr's `extract(targets=[f1, f2, ..., fN], factory=factory)`
+decompresses each folder **once** regardless of how many of its files are
+targeted.  The archivey reader collects all pending members before calling
+`extract()`, which means:
+
+- Best case (all members extracted at once): O(N) total decompression work.
+- Worst case (single file from a large solid folder): O(folder_files)
+  decompression work per call (same as any decompressor).
+
+The `use_rar_stream` optimization has no 7z equivalent — the same result is
+achieved by the existing batch collection in `iter_members_with_streams()`.
+
+For `_open_member()` (random access), the current implementation calls
+`iter_members_with_streams()` with a single-member list (lines 528–539),
+which still goes through the full thread+queue machinery.  This means a single
+`open()` call is relatively expensive for members in large solid folders.
+
+### 4.5 Password handling: what would improve
+
+The `_temporary_password` pattern is a **workaround** for py7zr's lack of a
+per-call password parameter.  If the decompression backend changes:
+
+- A native Python decompressor would accept a password at decompression time
+  (pass to `AESDecompressor(aes_properties, password)`).
+- An external `7z` tool would accept `-p<password>` on the command line.
+
+Either approach eliminates the need for the global class-level lock.
+
+### 4.6 Header decryption in a native parser
+
+For header-encrypted archives, the parser needs to:
+
+1. Read the `ENCODED_HEADER` block.
+2. Find the `PACK_INFO` → pack stream position and size.
+3. Seek to the pack stream, read the encrypted bytes.
+4. Derive the AES-256 key from the password (same algorithm as §3.5).
+5. Decrypt (AES-256-CBC), strip padding.
+6. Decompress (usually LZMA2).
+7. Parse the resulting plain `HEADER` bytes as normal.
+
+This requires either:
+- `Cryptodome.Cipher.AES` (already listed as optional dependency for RAR), or
+- `cryptography` (already used for RAR encrypted headers).
+
+Without the password, header-encrypted archives report no members (same
+behaviour as today).
+
+### 4.7 Metadata fields gap analysis
+
+| Field | Source | Gap |
+|---|---|---|
+| `filename` | `FILES_INFO.NAME` property | None |
+| `file_size` | `SUBSTREAMS_INFO.SIZE` or folder unpack size | None |
+| `compress_size` | `PACK_INFO.packsizes` (folder total) | Not per-file in solid archives; same as now |
+| `crc32` | `SUBSTREAMS_INFO.CRC` | None |
+| `mtime` | `FILES_INFO.LAST_WRITE_TIME` | None |
+| `atime`, `ctime` | `FILES_INFO.LAST_ACCESS_TIME / CREATION_TIME` | Not currently exposed by archivey |
+| `mode` (POSIX) | Extra field in attributes (POSIX extension) | Currently from `posix_mode` |
+| `is_directory` | `EMPTY_STREAM` + `EMPTY_FILE` bitmasks | None |
+| `is_symlink` | `st_fmt` from POSIX mode bits | Same detection logic as py7zr |
+| `encrypted` | folder's coders include `0x06f10701` | Same as `SupportedMethods.needs_password()` |
+| `compression_method` | folder coder IDs | **New**: native parser can expose this |
+| `is_solid` | `num_unpackstreams_folders` | None |
+| `comment` | `FILES_INFO.COMMENT` (0x16) property | py7zr ignores this; native reader could expose it |
+
+The most significant improvement a native parser offers is exposing
+**`compression_method`** per member (currently `None`) and archive
+**comments** (currently discarded by py7zr).
+
+---
+
+## 5. Things that can be dropped / simplified
+
+| Current complexity | Why it exists | Native reader stance |
+|---|---|---|
+| `_temporary_password` context manager + class lock | py7zr has no per-call password | Keep until decompression backend also changes |
+| `reset()` before every `extract()` | py7zr's Worker is stateful | Keep if still using py7zr extraction |
+| `_build_extract_filename_to_member_map` with `get_sanitized_output_path` | py7zr renames duplicates | Keep if still using py7zr extraction |
+| `_is_member_encrypted` via `SupportedMethods.needs_password` | py7zr private API | Replace with direct coder-list check in native parser |
+| `archiveinfo()` crash guard (empty archive) | py7zr bug | Can implement `is_solid` directly from `num_unpackstreams_folders` |
+| `py7zr.helpers.filetime_to_dt` | py7zr utility | Trivial to inline: `datetime(1601,1,1) + timedelta(microseconds=ft//10)` |
+| Exception catch-all in extractor thread | py7zr exceptions not wrapped | Keep regardless of backend |
+
+---
+
+## 6. Files affected by the change
+
+| File | Change |
+|---|---|
+| `src/archivey/formats/sevenzip_reader.py` | Replace `py7zr.files` / `ArchiveFile` usage in `iter_members_for_registration` with native parser; keep streaming machinery |
+| New: `src/archivey/formats/sevenzip_parser.py` | `SevenZipParser`, `SevenZipMemberInfo`, raw header reading |
+| `src/archivey/internal/dependency_checker.py` | Mark `py7zr` as optional for metadata, still required for decompression |
+| Tests | Verify all existing 7z test archives still pass; add parser unit tests |
+
+If the decompression backend is also replaced (phase 2):
+
+| File | Change |
+|---|---|
+| `src/archivey/formats/sevenzip_reader.py` | Replace `_extract_members_iterator` thread+queue with direct decompressor calls or external-tool subprocess |
+| `pyproject.toml` | Remove `py7zr>=1.0.0` from `optional` dependencies |
+
+---
+
+## 7. Open questions / risks
+
+1. **LZMA1 vs LZMA2 detection** — most modern 7z archives use LZMA2, but older
+   ones use LZMA1.  Both are supported by Python's `lzma` module.  The native
+   parser needs to dispatch correctly based on the coder ID.
+
+2. **BCJ/Delta filter chain** — many 7z archives prepend a BCJ (Branch
+   Conversion Jump) filter or Delta filter before LZMA2.  These must be
+   inverted during decompression.  py7zr implements all of these in Python; a
+   native reader must either port them or continue to use py7zr for
+   decompression.
+
+3. **Multi-volume archives** — py7zr uses `multivolumefile.MultiVolume` for
+   split archives.  This is not currently supported in archivey (same as RAR);
+   a native parser should raise `ArchiveError` cleanly at the volume-detection
+   step rather than producing garbage output.
+
+4. **Anti-files** — 7z supports "anti-items" (files that should be deleted
+   during extraction from a delta-update archive).  py7zr handles them silently.
+   A native reader should either support them or warn.
+
+5. **Empty archive CRC edge case** — `_real_get_contents` skips `FILES_INFO` if
+   absent (line 478: `if getattr(self.header, "files_info", None) is None`).
+   The native parser must handle the same case.
+
+6. **Thread safety of the extractor thread** — py7zr (1.0+) itself is not
+   thread-safe, which is why the `_temporary_password` lock exists at the
+   reader level.  Any new decompression backend must document its own
+   thread-safety model.
+
+7. **`compressed` size inaccuracy for solid archives** — the current reader
+   stores the **folder's** total packed size as `compress_size` for every file
+   in a solid folder.  A native parser has the same structural limitation (per-
+   file compressed sizes are undefined in solid streams) but could at least
+   expose the folder-level size clearly via `extra`.
+
+8. **Compression method name mapping** — the coder ID `0x030101` = LZMA,
+   `0x21` = LZMA2, etc.  A native reader can produce human-readable method
+   names (e.g. `"LZMA2 + BCJ"`) by walking the folder's coder list.  Currently
+   archivey returns `None` for 7z.
+
+---
+
+## 8. Useful references
+
+- 7z format specification: included in the 7-Zip source tree as
+  `DOC/7zFormat.txt` (also at https://py7zr.readthedocs.io/en/latest/archive_format.html).
+- py7zr source (1.1.0): `/tmp/py7zr_dl/py7zr_src/py7zr/` (extracted from
+  wheel during this research session).
+  - `archiveinfo.py` — header parsing: `Header`, `SignatureHeader`, `Folder`,
+    `UnpackInfo`, `PackInfo`, `SubStreamsInfo`, `FilesInfo`.
+  - `compressor.py` — `AESDecompressor`, `SevenZipDecompressor`, `Folder.get_decompressor`.
+  - `py7zr.py` — `SevenZipFile._real_get_contents`, `_extract`, `_is_solid`,
+    `archiveinfo()`, `ArchiveFile`.
+  - `properties.py` — `MAGIC_7Z`, `PROPERTY.*` constants, `CompressionMethod.*`.
+- Current implementation: `src/archivey/formats/sevenzip_reader.py`.
+- Base class: `src/archivey/internal/base_reader.py`.
+- RAR reader (for comparison, especially `RarStreamReader` solid-stream
+  pattern): `src/archivey/formats/rar_reader.py`.

--- a/docs/tar-stdlib-limitations.md
+++ b/docs/tar-stdlib-limitations.md
@@ -1,0 +1,484 @@
+# TAR Reader — stdlib tarfile Limitations and Workarounds
+
+This document analyses what the Python stdlib `tarfile` module provides, where
+it falls short, and what archivey does to work around each gap.  Like ZIP, the
+goal is not to replace the library — `tarfile` handles the in-process reading.
+The analysis focuses on the boundary between library and archivey.
+
+---
+
+## 1. BaseArchiveReader flags for TAR
+
+| Flag | Value | Reason |
+|---|---|---|
+| `members_list_supported` | `False` | TAR has no central directory; members are found by sequential scan only. |
+| `streaming_only` | configurable | True for non-seekable compressed streams (e.g. piped gzip); False when the underlying stream supports `seek()`. |
+
+Unlike ZIP, TAR is an inherently sequential format: each member's header
+immediately precedes its data, and there is no end-of-file index.  This means:
+
+- `get_members_if_available()` overrides the base-class implementation to return
+  `None` when `streaming_only=True` (line 148–151), because the member list
+  cannot be built without scanning the entire archive.
+- For seekable archives, `get_members()` still works by iterating to completion.
+- `iter_members_for_registration()` is a true generator: each `yield` advances
+  the tarfile read position by one header + data block.
+
+---
+
+## 2. TAR format variants
+
+`tarfile` handles three on-disk format families, selected at write time and
+auto-detected at read time:
+
+### 2.1 POSIX ustar (`USTAR_FORMAT = 0`, magic `"ustar\x0000"`)
+
+The original POSIX.1-1988 format.  Each header is exactly 512 bytes:
+
+```
+name[100]         filename (null-terminated, ASCII)
+mode[8]           octal permissions
+uid[8]            octal UID
+gid[8]            octal GID
+size[12]          octal file size (max 8 GB via GNU extension)
+mtime[12]         octal Unix timestamp (seconds)
+checksum[8]       header checksum
+typeflag[1]       0=regular, 1=hardlink, 2=symlink, 3=char, 4=block, 5=dir, 6=fifo
+linkname[100]     link target (null-terminated)
+magic[6]          "ustar\0"
+version[2]        "00"
+uname[32]         owner name (ASCII)
+gname[32]         group name (ASCII)
+devmajor[8]       device major number
+devminor[8]       device minor number
+prefix[155]       prefix for long paths (joined with "/" to name)
+padding[12]
+```
+
+**Filename limit**: 100 bytes for `name` + 155 bytes for `prefix`, joined by
+`/`.  Filenames exceeding this cannot be stored in ustar without loss.
+
+**Size limit**: The `size` field is 12 octal ASCII digits → max `077777777777`
+octal = 8 GB.  Enforced in archiver; `tarfile` reads it without validation.
+
+**No sub-second timestamp**: `mtime` is integer seconds only.
+
+### 2.2 GNU tar (`GNU_FORMAT = 1`, magic `"ustar  \0"`)
+
+Extends ustar with:
+
+- **`GNUTYPE_LONGNAME` (`L`)**: A synthetic header entry whose content is the
+  full filename of the next entry (>100 bytes).
+- **`GNUTYPE_LONGLINK` (`K`)**: Same for symlink targets (>100 bytes).
+- **`GNUTYPE_SPARSE` (`S`)**: Sparse file descriptor with hole/data map.
+- **Numeric encoding for large UID/GID/size**: values > octal max are stored as
+  big-endian binary with a leading `0x80` byte.
+
+`tarfile` reads GNU long names/links transparently (`_proc_gnulong`): the
+content of the `L`/`K` entry replaces the truncated `name`/`linkname` field.
+
+### 2.3 PAX (POSIX.1-2001, `PAX_FORMAT = 2`)
+
+The modern standard.  Extends ustar with **extended header** entries:
+
+- **`XHDTYPE` (`x`)**: Per-file extended header.  Content is UTF-8 key=value
+  pairs (`%d %s=%s\n` format).
+- **`XGLTYPE` (`g`)**: Global extended header applying to all subsequent entries.
+
+PAX fields that override the base header (`PAX_FIELDS`):
+`path`, `linkpath`, `size`, `mtime`, `atime`, `ctime`, `uid`, `gid`, `uname`,
+`gname`, `hdrcharset`, `comment`, `charset`.
+
+Key improvements over ustar:
+- **Arbitrary length filenames and symlink targets** (via `path`/`linkpath`).
+- **Sub-second timestamps**: `mtime` stored as a decimal fraction (e.g.
+  `1234567890.123456789`).
+- **Large UIDs/GIDs** (> 2^21).
+- **Unicode filenames** (always UTF-8 in PAX headers).
+- **Arbitrary metadata** via non-standard `SCHILY.*` or `LIBARCHIVE.*` prefixes.
+
+`tarfile` reads PAX headers transparently via `_proc_paxheaders` and stores
+parsed key-value pairs in `TarInfo.pax_headers`.
+
+---
+
+## 3. What tarfile provides
+
+### 3.1 TarFile open modes
+
+`tarfile.open(name, fileobj, mode, errorlevel)`:
+
+| Mode | Meaning |
+|---|---|
+| `"r:"` | Read, no compression, seekable required |
+| `"r:\*"` | Read, auto-detect compression, seekable preferred |
+| `"r|"` | Read streaming (pipe), no compression |
+| `"r|gz"` | Read streaming, gzip compressed |
+| `"r|bz2"` | Read streaming, bzip2 compressed |
+| `"r|xz"` | Read streaming, xz compressed |
+
+**Key distinction**: `r:` mode calls `getmembers()` lazily (advances on each
+`next()` call); `r|` mode uses `_Stream` (an internal wrapper) which cannot
+seek backward.
+
+Archivey always uses:
+- `"r:"` for seekable streams (random access supported)
+- `"r|"` for streaming (one-pass only)
+
+`errorlevel=2` makes tarfile raise exceptions on any error instead of silently
+continuing.
+
+### 3.2 TarInfo metadata fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | str | filename; PAX overrides with Unicode version |
+| `size` | int | uncompressed size in bytes |
+| `mtime` | float | Unix timestamp (seconds); float for PAX sub-second |
+| `mode` | int | Unix mode bits (type + permissions) |
+| `type` | bytes | entry type: REGTYPE, LNKTYPE, SYMTYPE, DIRTYPE, etc. |
+| `linkname` | str | symlink target or hardlink target |
+| `uid`, `gid` | int | owner numeric IDs |
+| `uname`, `gname` | str | owner name strings |
+| `devmajor`, `devminor` | int | device numbers for CHRTYPE/BLKTYPE |
+| `pax_headers` | dict | PAX extended header key-value pairs |
+| `sparse` | list | sparse file segment list (GNU sparse) |
+| `offset` | int | byte offset of this header in the archive file |
+| `offset_data` | int | byte offset of the file data |
+
+Archivey uses all of these except `sparse`, `devmajor`/`devminor` (stored in
+`extra` dict only), and `pax_headers` (not exposed).
+
+### 3.3 `extractfile()` — opening a member
+
+`TarFile.extractfile(tarinfo)` returns:
+
+- A `tarfile.ExFileObject` (a `_FileInFile` wrapper) for regular files and
+  CONTTYPE entries.
+- `None` for directories, symlinks, hardlinks, device files, FIFOs.
+- `None` for any entry where `is_file()` is False.
+
+`ExFileObject` supports `read(size)`, `readline()`, `readlines()`, `tell()`,
+and `seek()`.  It reads the data section of the entry directly from the
+underlying archive file at `offset_data`.
+
+**Seeking in streaming mode**: In `r|` mode, the underlying stream is non-
+seekable.  `ExFileObject.seek()` will raise or silently produce wrong results.
+Archivey never calls `open()` (random access) in streaming mode; the base
+class's `_prepare_member_for_open` raises `ValueError` if `for_iteration=False`
+and `streaming_only=True` (lines 243–248 of `tar_reader.py`).
+
+### 3.4 Iteration
+
+`for tarinfo in TarFile` calls `TarFile.next()` on each iteration, which:
+
+1. Reads the next 512-byte block.
+2. Detects `GNUTYPE_LONGNAME`/`GNUTYPE_LONGLINK`/`XHDTYPE`/`XGLTYPE` and
+   processes them before returning the actual entry.
+3. Returns `None` at end-of-archive (two consecutive zero blocks).
+4. Skips unknown types with `errorlevel < 2`.
+
+With `errorlevel=2` (archivey's setting), unknown block types raise `ReadError`.
+
+---
+
+## 4. Limitations and workarounds
+
+### 4.1 No central directory → `members_list_supported=False`
+
+TAR has no index; to get a complete member list, the archive must be scanned
+from start to finish.
+
+`iter_members_for_registration()` is a plain generator over `for tarinfo in self._archive`.
+Members are registered one at a time as they are yielded.
+
+**Implication**: The first call to `get_members()` on an unseekable TAR reads
+and discards all data.  Subsequent calls reuse the cached `_members` list.  For
+large compressed TARs over a network pipe this is the only option.
+
+### 4.2 Silent corruption at end of archive — `tar_check_integrity` workaround
+
+**The problem**: When `tarfile` encounters a block it cannot parse as a valid
+header — e.g. a zero block in the middle of a corrupted archive — it raises a
+`HeaderError` subclass.  With `errorlevel=2` this becomes a `ReadError`, but
+**only if the bad block follows a valid header**.  If the archive is truncated
+partway through the final member's data, `tarfile` can silently stop iterating
+and return only the members read so far, treating the truncation as end-of-archive.
+
+The TAR end-of-archive marker is **two consecutive 512-byte zero blocks**.
+tarfile stops when it sees the first zero block (it may or may not check for the
+second one in different Python versions).
+
+**Archivey's workaround** (`_check_tar_integrity()`, lines 198–238): after
+`iter_members_for_registration()` finishes (all `TarInfo` objects yielded),
+archivey manually seeks to just after the last member's data, reads 1024 bytes,
+and verifies they are all zeros.  If not (short read, non-zero data), an
+`ArchiveCorruptedError` is raised.
+
+Controlled by `config.tar_check_integrity` (default `True`).  For non-seekable
+streams, the check uses `self._archive.fileobj.tell()` (the internal position
+tracked by tarfile's `_Stream` wrapper) to compute how far to skip forward
+before reading the terminal blocks.
+
+### 4.3 `tarfile.read()` short-read failure
+
+**The problem**: Inside `tarfile._FileInFile.read()`, the code calls
+`self.fileobj.read(size)` and assumes it gets exactly `size` bytes.  If the
+underlying file object's `read()` returns fewer bytes (a legal Python I/O
+behaviour), tarfile raises a confusing error or reads corrupt data.
+
+This can happen with `GzipFile`, `BZ2File`, and similar decompressor wrappers
+that are not `BufferedReader`-wrapped — they sometimes return partial chunks.
+
+**Archivey's workaround** (lines 90–94): `ensure_bufferedio()` wraps the
+decompressed stream in `io.BufferedReader` before passing it to `tarfile.open()`.
+`BufferedReader.read(n)` always returns exactly `n` bytes (or raises on EOF).
+
+### 4.4 `GzipFile.seekable()` lies
+
+**The problem**: `gzip.GzipFile.seekable()` returns `True` even when the
+underlying file object is a pipe (non-seekable), because it implements `seek()`
+by reading and discarding data.  tarfile's `"r:"` mode checks `seekable()` to
+decide whether random access is available.
+
+**Archivey's workaround** (`open_gzip_stream()`, lines 123–132 of
+`compressed_streams.py`): if the underlying stream is not seekable, the
+`seekable` attribute of the `GzipFile` is monkey-patched to a lambda returning
+`False`, and `seek` is replaced with a function that raises
+`io.UnsupportedOperation`.
+
+### 4.5 Compressed TAR is architecturally solid
+
+A compressed TAR (`.tar.gz`, `.tar.bz2`, `.tar.xz`, etc.) is a single-stream
+archive — all members are compressed together as one stream.
+
+In archivey, `is_solid` is set to `True` for compressed TARs (line 282–283):
+```python
+is_solid=format.stream is not None and format.stream != StreamFormat.UNCOMPRESSED,
+```
+
+**Implication**: Random access to individual members in a compressed TAR
+requires decompressing from the beginning up to the member's offset.  This is
+O(member_offset) per access.  For a 1 GB `.tar.gz`, accessing the last member
+requires reading the entire compressed stream.
+
+**Alternative backends for random access**: The `ArchiveyConfig` offers
+drop-in replacements for the stdlib decompressors that support random access:
+
+| Format | Default | Alternative (`config.use_X=True`) | Random access |
+|---|---|---|---|
+| `.tar.gz` | `gzip.GzipFile` | `rapidgzip` | Yes (index-based) |
+| `.tar.bz2` | `bz2.BZ2File` | `indexed_bzip2` | Yes (index-based) |
+| `.tar.xz` | `lzma.open` | `python-xz` | Yes |
+| `.tar.zst` | `pyzstd.open` | `zstandard` (via `ZstandardReopenOnBackwardsSeekIO`) | Reopen from start on backward seek |
+
+### 4.6 Zstandard backward seeking — `ZstandardReopenOnBackwardsSeekIO`
+
+**The problem**: `zstandard.open()` raises `OSError("cannot seek zstd
+decompression stream backwards")` on backward seeks.  For a seekable `.tar.zst`,
+tarfile needs to seek backward when re-opening a member (random access mode).
+
+**Archivey's workaround** (`ZstandardReopenOnBackwardsSeekIO`, lines 267–329 of
+`compressed_streams.py`): a wrapper that catches backward-seek `OSError`,
+re-opens the underlying `zstandard.open()` from position 0, and re-seeks forward
+to the target position.  For large archives this can be slow; it is essentially
+O(target_offset) per backward seek.
+
+### 4.7 Encoding issues
+
+**The problem**: TAR header names are fixed-width byte arrays.
+
+- **ustar**: ASCII-only; non-ASCII names are encoded with the `encoding` and
+  `errors` parameters.  Default encoding is `sys.getfilesystemencoding()` (often
+  UTF-8 on Linux, but not always).
+- **GNU format**: Same as ustar for the base header; long names via `L`/`K`
+  entries are raw bytes decoded with the configured encoding.
+- **PAX format**: `path` and `linkpath` in extended headers are always UTF-8;
+  non-name fields use the configured encoding.  `hdrcharset` field can override
+  encoding for the name fields within a PAX header.
+
+Archivey opens tarfile with the default encoding (UTF-8 on modern systems) and
+`errors="surrogateescape"` (tarfile's default).  Names that cannot be decoded in
+UTF-8 will contain surrogate escape characters, which Python will round-trip
+through most operations but cannot be written to some filesystems.
+
+**Exposed in `get_archive_info()`** (line 288):
+```python
+"encoding": self._archive.encoding
+```
+
+### 4.8 Hardlinks vs symlinks
+
+Both are natively represented in TAR:
+- `LNKTYPE = b"1"`: hardlink, `linkname` = target filename within the archive.
+- `SYMTYPE = b"2"`: symbolic link, `linkname` = symlink target path.
+
+`tarfile` exposes both via `TarInfo.islnk()` and `TarInfo.issym()`.
+
+Archivey maps:
+- `islnk()` → `MemberType.HARDLINK`, `link_target = info.linkname`
+- `issym()` → `MemberType.SYMLINK`, `link_target = info.linkname`
+
+The base class handles hardlink resolution via `resolve_link()` — it looks up
+the target filename in the registered member table by `member_id`.
+
+**Limitation in streaming mode**: When `streaming_only=True`, hardlink targets
+may not have been yielded yet (if the target appears later in the archive), so
+link resolution may fail.  Links that cannot be resolved return `None` from
+`resolve_link()`.
+
+### 4.9 Special file types
+
+TAR stores device files, FIFOs, and contiguous files:
+
+| Type byte | Name | `tarfile` exposes | Archivey maps to |
+|---|---|---|---|
+| `3` | Character device | `ischr()`, `devmajor`, `devminor` | `MemberType.OTHER` |
+| `4` | Block device | `isblk()`, `devmajor`, `devminor` | `MemberType.OTHER` |
+| `6` | FIFO | `isfifo()` | `MemberType.OTHER` |
+| `7` | Contiguous file | — (treated as regular) | `MemberType.FILE` |
+
+`devmajor` and `devminor` are stored in `ArchiveMember.extra` but not in a
+dedicated field.
+
+### 4.10 Sparse files
+
+GNU sparse files (`GNUTYPE_SPARSE`) store a list of `(offset, size)` pairs
+describing non-zero regions.  `tarfile` reads the sparse map into
+`TarInfo.sparse`, but `extractfile()` does not reconstruct the sparse layout —
+it returns the raw (packed) data without the holes.  The caller would need to
+use `TarInfo.sparse` to reconstruct the sparse file correctly.
+
+Archivey does not handle sparse files specially; they are treated as regular
+files and their `file_size` reflects the logical (sparse) size while the data
+stream contains only the non-hole data.  This may produce incorrect output for
+sparse files.
+
+### 4.11 The Python 3.12+ `filter` parameter — security implications
+
+Python 3.12 introduced `TarFile.extractall(filter=...)` and
+`TarFile.extract(filter=...)` with three built-in security filters:
+
+| Filter name | What it blocks |
+|---|---|
+| `"fully_trusted"` | Nothing; extracts everything |
+| `"tar"` | Absolute paths, `..` components |
+| `"data"` | All of above + special files, setuid bits, hardlinks outside dest |
+
+Python 3.12 emits a `DeprecationWarning` if no `filter` is specified (defaults
+to `"fully_trusted"`).  Python 3.14 will change the default to `"data"`.
+
+**Archivey's stance**: archivey uses `tarfile` only for reading member metadata
+and opening individual file streams via `extractfile()`, not for direct
+extraction to the filesystem via `extract()` or `extractall()`.  The `filter`
+parameter does not apply to `extractfile()`.
+
+However, the `ArchiveyConfig.extraction_filter` setting serves a similar
+purpose for archivey's own extraction path: `ExtractionFilter.DATA` (the default)
+applies tarfile-like security rules within archivey's extraction logic.
+
+### 4.12 No CRC or hash verification
+
+TAR files do not store a checksum per-member (only a header checksum for error
+detection, not data integrity).  `tarfile` verifies the header checksum on read
+but there is no equivalent for the member data.
+
+Archivey sets `crc32=None` for all TAR members.
+
+### 4.13 Timestamp timezone
+
+`TarInfo.mtime` is a Unix timestamp (float for PAX sub-second precision, int for
+ustar/GNU).  Unix timestamps are UTC by definition.
+
+Archivey converts correctly (line 166):
+```python
+mtime_with_tz=datetime.fromtimestamp(info.mtime, tz=timezone.utc)
+```
+
+This is simpler and more correct than ZIP (which needs the extended timestamp
+extra field).
+
+---
+
+## 5. Compressed stream handling
+
+For compressed TARs, the decompression is handled **outside** tarfile by
+`open_stream()` in `compressed_streams.py`.  The returned stream is passed to
+`tarfile.open(fileobj=stream, mode="r:")` (or `"r|"` for non-seekable).
+
+This separation means archivey can swap the decompressor (e.g. stdlib gzip vs
+rapidgzip) without touching any tarfile logic.
+
+### 5.1 Stream format table
+
+| Extension | Format | Default backend | Alternative |
+|---|---|---|---|
+| `.tar.gz` / `.tgz` | gzip | `gzip.GzipFile` | `rapidgzip.open` |
+| `.tar.bz2` / `.tbz2` | bzip2 | `bz2.open` | `indexed_bzip2.open` |
+| `.tar.xz` / `.txz` | xz/LZMA | `lzma.open` | `xz.open` (python-xz) |
+| `.tar.zst` | zstandard | `pyzstd.open` | `zstandard.open` + reopen-on-backward-seek |
+| `.tar.lz4` | LZ4 | `lz4.frame.open` | — |
+| `.tar.lz` | lzip | `LzipDecompressorStream` | — |
+| `.tar.zz` | zlib/deflate | `ZlibDecompressorStream` | — |
+| `.tar.br` | brotli | `BrotliDecompressorStream` | — |
+| `.tar.Z` | LZW (Unix compress) | `uncompresspy.LZWFile` | — |
+
+### 5.2 The `DecompressorStream` base class
+
+Many of the non-stdlib decompressors that don't support seeking are wrapped in
+`DecompressorStream` (`compressed_streams.py`, lines 420–565), which provides:
+
+- **Forward seeking**: reads and discards data up to the target position.
+- **Backward seeking**: calls `_rewind()` which seeks the underlying raw stream
+  to 0 and recreates the decompressor, then reads forward.
+- **SEEK_END**: reads to the end to find the size, then seeks backward.
+- **EOF detection**: raises `ArchiveEOFError` if the decompressor ends before
+  expected.
+
+This makes these streams usable as seekable `fileobj` for `tarfile.open(mode="r:")`.
+
+---
+
+## 6. Config options (TAR-specific)
+
+| Option | Default | Effect |
+|---|---|---|
+| `tar_check_integrity` | `True` | After iterating all members, verify the two-zero-block EOF marker. Raises `ArchiveCorruptedError` on truncated archives that tarfile would accept silently. |
+| `use_rapidgzip` | `False` | Use `rapidgzip` instead of `gzip.GzipFile` for `.tar.gz`. Enables parallel decompression and index-based random access. |
+| `use_indexed_bzip2` | `False` | Use `indexed_bzip2` instead of `bz2` for `.tar.bz2`. Enables parallel decompression and index-based random access. |
+| `use_python_xz` | `False` | Use `python-xz` instead of `lzma.open` for `.tar.xz`. Enables random access. |
+| `use_zstandard` | `False` | Use `zstandard` instead of `pyzstd` for `.tar.zst`. Uses `ZstandardReopenOnBackwardsSeekIO` wrapper; slightly worse error reporting. |
+
+---
+
+## 7. TarInfo fields: exposed vs not exposed in archivey
+
+| `TarInfo` field | Archivey field | Notes |
+|---|---|---|
+| `name` | `filename` | trailing `/` added for dirs |
+| `size` | `file_size` | logical size (may differ from data length for sparse) |
+| `mtime` | `mtime_with_tz` | UTC-aware datetime |
+| `mode` | `mode` | Unix permission bits via `stat.S_IMODE(info.mode)` |
+| `uid` | `uid` | 0 is stored as `None` (considered "unset") |
+| `gid` | `gid` | 0 is stored as `None` |
+| `uname` | `uname` | empty string stored as `None` |
+| `gname` | `gname` | empty string stored as `None` |
+| `linkname` | `link_target` | for SYMTYPE and LNKTYPE only |
+| `type` | `extra["type"]` | raw type byte |
+| `devmajor`, `devminor` | `extra["devmajor/devminor"]` | not a dedicated field |
+| `pax_headers` | not exposed | PAX key-value pairs discarded |
+| `sparse` | not exposed | sparse map discarded |
+| `offset`, `offset_data` | not exposed | internal tarfile fields |
+| `compress_size` | `None` | TAR doesn't store compressed size per-member |
+| `crc32` | `None` | TAR doesn't store data checksums |
+
+---
+
+## 8. Useful references
+
+- GNU tar format documentation: `info tar` → "Internals" chapter
+- POSIX.1-2001 pax interchange format: IEEE Std 1003.1-2001
+- Python stdlib tarfile source: `/usr/lib/python3.11/tarfile.py`
+- Current implementation: `src/archivey/formats/tar_reader.py`
+- Compressed stream wrappers: `src/archivey/formats/compressed_streams.py`
+- PEP 706 (tarfile extraction filters): https://peps.python.org/pep-0706/

--- a/docs/zip-stdlib-limitations.md
+++ b/docs/zip-stdlib-limitations.md
@@ -249,9 +249,42 @@ low bits could produce a spurious mode value (the DOS attribute byte in the low
 ```
 Scans all members for the encryption flag.
 
-### 3.9 Non-seekable streams
+### 3.9 Non-seekable streams (streaming mode)
 
-Architecturally impossible with `zipfile`; rejected at construction.
+`zipfile` requires a seekable stream and rejects non-seekable input at
+construction.  This is a **library limitation, not a format limitation**.
+
+The ZIP format was designed from the beginning to support streaming writes: each
+entry has a 30-byte local file header immediately before its compressed data,
+containing the filename, compression method, and flags.  A streaming reader can
+process these local headers in order, identical in concept to a TAR reader.
+
+When an archive is written to a pipe or network socket (the "streaming" writing
+case), the writer does not know the CRC32 or sizes at the time the local header
+is written.  It sets flag bit 3 (`_MASK_USE_DATA_DESCRIPTOR`) and writes the
+CRC32, compressed size, and uncompressed size in a trailing data descriptor
+record after the compressed data.  Compressed methods (deflate, bzip2, lzma)
+have end-of-stream markers so the decompressor knows when the data ends without
+needing the size field.  Stored (uncompressed) entries with bit 3 set require
+scanning for the `PK\x07\x08` data-descriptor signature, which is ambiguous if
+that byte sequence appears in the payload.
+
+**What a streaming ZIP reader would lose** (central-directory-only fields):
+
+| Field | Impact |
+|---|---|
+| `external_attr` | Unix mode bits lost; symlink detection unavailable |
+| `create_system` | Cannot determine if archive was created on Unix |
+| Per-file comment | Not available in streaming mode |
+
+Everything else — filename (UTF-8 via flag bit 11), compression method, DOS
+timestamp, and the Extended Timestamp extra field (`0x5455`) — is present in
+the local file header.
+
+Implementing a streaming `ZipReader` would require parsing local file headers
+directly rather than relying on `zipfile`.  The resulting reader would set
+`members_list_supported=False` and `streaming_only=True`, analogous to
+`TarReader` with a non-seekable compressed stream.
 
 ---
 

--- a/docs/zip-stdlib-limitations.md
+++ b/docs/zip-stdlib-limitations.md
@@ -1,0 +1,328 @@
+# ZIP Reader — stdlib zipfile Limitations and Workarounds
+
+This document analyses what the Python stdlib `zipfile` module provides, where
+it falls short, and what archivey does to work around each gap.  Unlike the RAR
+and 7z design docs, the goal here is not to replace the library — `zipfile` is
+a full in-process decompressor and there is no external tool in the loop.  The
+focus is on understanding the boundary between what the library does and what
+archivey must handle itself.
+
+---
+
+## 1. BaseArchiveReader flags for ZIP
+
+| Flag | Value | Reason |
+|---|---|---|
+| `members_list_supported` | `True` | ZIP has a central directory at end-of-file; all member metadata is available before any decompression. |
+| `streaming_only` | `False` | Random access is fully supported (and required). |
+
+Non-seekable input is rejected at construction (line 157–160 in `zip_reader.py`)
+because `zipfile` must seek to the End of Central Directory record at the tail
+of the file before it can read anything.  There is no workaround; the entire
+file must be buffered in memory or on disk first.
+
+---
+
+## 2. What zipfile provides
+
+### 2.1 Central directory parsing
+
+`ZipFile._RealGetContents()` seeks to the end of the file, finds the **End of
+Central Directory** record (magic `0x06054b50`, up to 64 KB from EOF to allow
+for a comment), then reads the entire central directory in one shot into a
+`BytesIO` buffer.
+
+For archives > 4 GB, `_EndRecData64()` additionally reads the **ZIP64 End of
+Central Directory Locator** (`0x07064b50`) and the **ZIP64 EOCD** record
+(`0x06064b50`) which hold 64-bit values for offsets and counts.
+
+Each central directory entry provides a `ZipInfo` object with:
+
+| `ZipInfo` field | Format | Notes |
+|---|---|---|
+| `filename` | UTF-8 or CP437 | UTF-8 flag in `flag_bits & 0x800`; else CP437 |
+| `date_time` | 6-tuple, DOS format | 2-second granularity, years 1980–2107, local time |
+| `compress_type` | integer | 0=store, 8=deflate, 12=bzip2, 14=lzma |
+| `CRC` | uint32 | CRC32 of uncompressed data |
+| `compress_size` | uint32/uint64 | ZIP64 if central dir shows 0xFFFFFFFF |
+| `file_size` | uint32/uint64 | ZIP64 if central dir shows 0xFFFFFFFF |
+| `flag_bits` | uint16 | encryption (bit 0), data descriptor (bit 3), UTF-8 (bit 11), strong encryption (bit 6) |
+| `create_system` | uint8 | 0=DOS, 3=UNIX, 19=macOS, etc. |
+| `create_version` | uint8 | version made by (major*10 + minor) |
+| `extract_version` | uint8 | minimum version needed to extract |
+| `external_attr` | uint32 | upper 16 bits = Unix mode; lower 16 bits = DOS attributes |
+| `internal_attr` | uint16 | bit 0 = text file |
+| `comment` | bytes | per-file comment (raw bytes, no encoding) |
+| `extra` | bytes | raw extra fields (not parsed beyond ZIP64 by stdlib) |
+| `header_offset` | int | offset of local file header |
+| `volume` | int | disk number (multi-disk not supported) |
+
+`ZipInfo._decodeExtra()` is called automatically and parses one extra field:
+`0x0001` (ZIP64) to replace 0xFFFFFFFF placeholders with 64-bit values.  All
+other extra field tags are silently ignored.
+
+### 2.2 Compression support
+
+`zipfile` supports four compression methods natively:
+
+| Method ID | Name | Dependency |
+|---|---|---|
+| 0 | stored | none |
+| 8 | deflated | `zlib` |
+| 12 | bzip2 | `bz2` |
+| 14 | lzma | `lzma` |
+
+Any other method raises `NotImplementedError("That compression method is not
+supported")`.  Historical methods (shrink, reduce×4, implode, tokenize) and
+modern ones (deflate64, brotli, zstd, wavpack, ppmd) are not implemented.
+
+### 2.3 Encryption
+
+Only **ZipCrypto** (Traditional PKWARE Encryption, sometimes called "ZipCrypto"
+or "classic encryption") is supported.  The implementation (`_ZipDecrypter`,
+lines 611–645) uses a 3-word key schedule updated per byte.
+
+Strong encryption (flag bit 6, `_MASK_STRONG_ENCRYPTION`) raises
+`NotImplementedError("strong encryption (flag bit 6)")` — this covers WinZip
+AES (method 99) and PKWARE Strong Encryption.  There is no path to support
+WinZip AES-256 without a third-party library.
+
+Password check: the first 12 encrypted bytes are a random header; byte 12 is
+compared against either the high byte of the CRC32 (normal) or the high byte of
+`_raw_time` (if the data descriptor flag is set).
+
+### 2.4 The `open()` return value (`ZipExtFile`)
+
+`ZipFile.open(name, mode="r", pwd=None)` returns a `ZipExtFile`
+(`io.BufferedIOBase` subclass) that:
+
+- Reads and decompresses on-the-fly in 4 KB blocks (`MIN_READ_SIZE = 4096`).
+- Supports `read(n)`, `read1(n)`, `readline()`, `peek(n)`.
+- Supports **seeking** if the underlying file is seekable — backward seeking
+  restarts decompression from the local file header.
+- Verifies CRC32 on close.
+- Decrypts transparently if password is provided.
+
+### 2.5 Data descriptor records
+
+When a file is written to a non-seekable output (flag bit 3,
+`_MASK_USE_DATA_DESCRIPTOR`), the CRC and sizes are unknown at the time the
+local header is written and appear in a trailing data descriptor block instead.
+`zipfile` handles this transparently during reading: it uses `_end_offset` (the
+offset of the next entry's local header, computed from the central directory) to
+know when the compressed data ends, then reads and discards the data descriptor
+for CRC verification.
+
+---
+
+## 3. Limitations zipfile does NOT handle — archivey workarounds
+
+### 3.1 Timestamp precision and timezone
+
+**The problem**: `ZipInfo.date_time` is a 6-tuple derived from the DOS timestamp
+format, which has 2-second granularity and stores local time with no timezone
+info.  The year range is 1980–2107.
+
+**Extra field 0x5455 — Extended Timestamp**: InfoZIP and many modern tools write
+this extra field in both the local file header and the central directory.  It
+stores one or more Unix timestamps (4-byte signed integers, seconds since epoch)
+which are UTC and have 1-second precision.  The central-directory version
+typically stores only `mtime` (bit 0 of flags); the local-header version may
+also have `atime` (bit 1) and `ctime` (bit 2).
+
+`zipfile` never parses `0x5455`.  It stores the raw extra bytes in `ZipInfo.extra`
+but does nothing with them.
+
+**Archivey's workaround** (`get_zipinfo_timestamp()`, lines 40–92 of
+`zip_reader.py`): manually parses the `extra` field, scans for tag `0x5455`,
+reads the Unix modtime, and returns a UTC-aware `datetime` object.  Falls back
+to the DOS `date_time` tuple (naive, no timezone) if the field is absent or the
+flag bit is not set.
+
+**Implication**: archivey timestamps from ZIP are UTC-aware when the extended
+field is present (most modern archives), naive local time otherwise.
+
+### 3.2 Encoding of filenames and comments
+
+**The problem**: The ZIP specification originally required CP437 encoding for
+filenames.  Flag bit 11 (`_MASK_UTF_FILENAME`) signals UTF-8, but many legacy
+tools wrote non-UTF-8, non-CP437 filenames without setting the flag — for
+example, Windows tools using the system codepage (CP1252, Shift-JIS, etc.).
+
+`zipfile` decodes filenames as UTF-8 if the flag is set, else CP437.  It does
+not try other encodings on failure.  `ZipInfo.comment` is returned as raw bytes
+without any decoding.
+
+**Archivey's workaround**: `_ZIP_ENCODINGS = ["utf-8", "cp437", "cp1252",
+"latin-1"]` (line 35).  The `decode_bytes_with_fallback()` utility tries each
+encoding in order until one succeeds without errors.  Applied to member comments
+(line 204).
+
+For `ZipInfo.filename`, archivey relies on stdlib's decoding but the fallback
+chain is not applied — the stdlib-decoded string is used as-is.  This could
+silently produce wrong filenames for archives with CP1252 filenames and no UTF-8
+flag.
+
+### 3.3 Symlinks
+
+**The problem**: ZIP has no native symlink entry type.  Unix tools (InfoZIP,
+7-Zip on Unix) store symlinks as regular files with the Unix mode bits in
+`external_attr >> 16` set to `S_IFLNK (0o120000)` and the symlink target as
+the file content.
+
+`zipfile` does not recognise or expose this convention.  `ZipInfo.is_dir()` and
+the internal flags only look at the filename (trailing slash) and the MS-DOS
+attribute bits.
+
+**Archivey's workaround** (`_zipinfo_to_archive_member()`, lines 181–231):
+
+```python
+mode = info.external_attr >> 16
+is_link = stat.S_ISLNK(mode)   # checks S_IFLNK bit
+```
+
+If `is_link` is True, archivey immediately opens the member and reads its
+content as the symlink target (`_read_link_target()`, line 224–231), then stores
+it in `ArchiveMember.link_target`.  The member type is set to
+`MemberType.SYMLINK`.
+
+**Limitation**: This only works for Unix-created archives.  Windows-created
+archives store `external_attr` with DOS attributes in the low 16 bits and zero
+in the high 16 bits (or Windows attribute flags), so symlinks created by Windows
+tools may not be detected.
+
+### 3.4 Hardlinks
+
+**The problem**: ZIP has no hardlink concept.  There is no standard way to
+encode hardlinks in a ZIP file.
+
+**Archivey's stance**: Hardlinks are not detected or supported in ZIP.  A file
+that is a hardlink appears as a regular file.
+
+### 3.5 Compression method name
+
+`ZipInfo.compress_type` is an integer.  `zipfile` provides a `compressor_names`
+dict but it is not stored on `ZipInfo`.
+
+**Archivey's workaround**: `ZIP_COMPRESSION_METHODS` dict (lines 96–114) maps
+method IDs to human-readable names.  Archivey stores the name as
+`ArchiveMember.compression_method`.  Unknown IDs produce `"unknown"`.
+
+### 3.6 AES-256 / WinZip strong encryption
+
+`zipfile` raises `NotImplementedError` for flag bit 6 (strong encryption) and
+does not parse the AES extra field (method 99, tag `0x9901`).
+
+**Current archivey stance**: Not supported.  The `_translate_exception` handler
+maps `RuntimeError("password required")` and `RuntimeError("Bad password")` to
+`ArchiveEncryptedError`, but WinZip AES archives will raise `NotImplementedError`
+which propagates as an unhandled exception (or could be mapped to
+`ArchiveUnsupportedFeatureError`).
+
+**What it would take to fix**: Parse extra field `0x9901` to get the AES key
+strength (128/192/256) and the authentication code; use `cryptography` or
+`pycryptodome` to derive the key via PBKDF2-SHA1 (not SHA-256), decrypt, and
+verify the HMAC-SHA1 authentication code.  This cannot reuse zipfile internals
+at all.
+
+### 3.7 `external_attr` mode when archive is from a non-Unix system
+
+When `create_system != 3` (UNIX), `external_attr >> 16` is not a Unix mode and
+should not be interpreted as permissions.
+
+**Archivey's workaround** (line 201):
+```python
+mode=stat.S_IMODE(mode) if info.external_attr != 0 else None,
+```
+Only extracts permissions if `external_attr` is non-zero.  However, it does not
+check `create_system`, so DOS-created archives with non-zero `external_attr`
+low bits could produce a spurious mode value (the DOS attribute byte in the low
+16 bits shifts into the mode field).
+
+### 3.8 `is_encrypted` archive-level flag
+
+`zipfile` does not expose an archive-level "is encrypted" flag.
+
+**Archivey's workaround** (lines 266–268):
+```python
+"is_encrypted": any(info.flag_bits & 0x1 for info in self._archive.infolist())
+```
+Scans all members for the encryption flag.
+
+### 3.9 Non-seekable streams
+
+Architecturally impossible with `zipfile`; rejected at construction.
+
+---
+
+## 4. What zipfile handles well (no workaround needed)
+
+| Feature | Status |
+|---|---|
+| ZIP64 large files (>4 GB) | Automatic via `_decodeExtra` |
+| Data descriptor records | Transparent |
+| Multi-entry decompression | Each `open()` is independent |
+| CRC32 verification | Automatic on `close()` |
+| Archive and member comments | Exposed as bytes |
+| Zip bomb detection | `_end_offset` overlap check |
+| Deflated, BZip2, LZMA | Built-in decompressors |
+| Stored (uncompressed) | Direct reads |
+| UTF-8 filenames | Automatic via flag bit 11 |
+| Thread safety (per-member) | Each `open()` uses a `_SharedFile` slice |
+
+---
+
+## 5. Config options (ZIP-specific)
+
+None.  All ZIP behaviour is hardcoded in the reader.  The global
+`extraction_filter` and `overwrite_mode` apply as for all formats.
+
+---
+
+## 6. TarInfo / ZipInfo fields exposed vs hidden
+
+Fields that are in the format but not exposed by `ZipInfo` / archivey:
+
+| Field | In format | Exposed | Notes |
+|---|---|---|---|
+| Access time | Extra 0x5455 bits 1 | No | Only mtime from central dir extra |
+| Creation time | Extra 0x5455 bits 2 | No | Only in local header extra |
+| NTFS timestamps | Extra 0x000A | No | stdlib ignores entirely |
+| Unix UID/GID | Extra 0x7875 (Info-ZIP Unix3) | No | stdlib ignores |
+| Extended attributes | Extra 0x756E (ASi Unix) | No | stdlib ignores |
+| AES info | Extra 0x9901 | No | WinZip AES not supported |
+| Strong encryption type | flag bit 6 | Via exception | Raises NotImplementedError |
+| Internal attributes | `ZipInfo.internal_attr` | Via `extra` dict | Not surfaced as a field |
+
+---
+
+## 7. Known zipfile bugs / quirks
+
+- **DOS timestamp epoch**: year 0 in DOS format maps to 1980, not the Unix
+  epoch.  `ZipInfo.date_time = (1980, 0, 0, 0, 0, 0)` is used as a sentinel
+  for "no timestamp"; archivey's `get_zipinfo_timestamp()` returns `None` in
+  this case (line 47).
+- **Invalid dates**: Some archivers write invalid DOS dates (e.g. month 0, day
+  0).  Archivey catches `ValueError` from `datetime(*zip_info.date_time)` and
+  falls back to `None` (lines 52–56).
+- **Trailing slash ambiguity**: `ZipInfo.is_dir()` checks for trailing slash
+  only.  A file whose name ends in `/` is treated as a directory even if it has
+  content.
+- **Multi-disk archives**: Not supported; `BadZipFile` is raised if
+  `disk_number_start != 0`.
+- **`ZipExtFile` seeking**: Backward seeking in `ZipExtFile` restarts the
+  decompressor from scratch (re-reads from the local file header).  This is
+  slow but correct.
+- **LZMA extra field**: `zipfile`'s LZMA decompressor reads filter properties
+  from the first 4 bytes of the compressed data's extra field (2 bytes ID + 2
+  bytes properties size).  LZMA-compressed ZIP members from some tools may have
+  a slightly different format and fail.
+
+---
+
+## 8. Useful references
+
+- PKWARE APPNOTE.TXT (ZIP format specification): https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+- InfoZIP extra field specification (0x5455, 0x7875, 0x756E, etc.)
+- Python stdlib zipfile source: `/usr/lib/python3.11/zipfile.py`
+- Current implementation: `src/archivey/formats/zip_reader.py`


### PR DESCRIPTION
## Summary

Research docs and OpenSpec design artifacts for the archivey major rewrite. No code changes.

**Research docs** (`docs/`): format-specific limitations and architecture comparisons covering RAR, 7z, ZIP, TAR, and ISO.

**OpenSpec artifacts** (`openspec/changes/archivey-rewrite/`):
- `proposal.md`, `design.md`, `tasks.md` — scope, architecture, 52-task breakdown across 8 groups
- Specs for archive-reader API, ZIP reader, RAR reader, 7z reader, ISO reader, extraction, and test infrastructure

**Key design decisions captured:**
- `streaming=True` = single forward data pass; a one-time metadata seek (ZIP central directory, 7z end header) is explicitly acceptable — the goal is avoiding redundant seeks into compressed data and avoiding re-decompression of solid blocks
- Non-seekable sources supported only for naturally sequential formats (TAR); ZIP/7z/ISO require seekable sources even in streaming mode
- `ArchiveMember` extended with `raw_filename`, `atime`, `ctime`, `windows_attrs`, `is_junction`
- Extraction: plan-then-execute for random-access; event-driven `PendingState` for streaming
- 7z: `FolderDecompressor` pull model (no threads); solid blocks decompressed once in order

## Test plan

- [ ] Review openspec artifacts for internal consistency
- [ ] Verify streaming design principles match format capabilities documented in `docs/`