### PR TITLE
feat: ArchiveMember new fields, streaming parameter, base reader hook, ISO 9660 reader

### DIFF
--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -10,6 +10,7 @@ from archivey.exceptions import ArchiveNotSupportedError, ArchiveStreamNotSeekab
 from archivey.formats.compressed_streams import open_stream
 from archivey.formats.folder_reader import FolderReader
 from archivey.formats.format_detection import detect_archive_format
+from archivey.formats.iso_reader import IsoReader
 from archivey.formats.rar_reader import RarReader
 from archivey.formats.sevenzip_reader import SevenZipReader
 from archivey.formats.single_file_reader import SingleFileReader
@@ -50,6 +51,7 @@ _FORMAT_TO_READER: dict[ContainerFormat, Callable[..., ArchiveReader]] = {
     ContainerFormat.ZIP: ZipReader,
     ContainerFormat.SEVENZIP: SevenZipReader,
     ContainerFormat.TAR: TarReader,
+    ContainerFormat.ISO: IsoReader,
     ContainerFormat.FOLDER: FolderReader,
     ContainerFormat.RAW_STREAM: SingleFileReader,
 }

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -6,7 +6,7 @@ from typing import BinaryIO, Callable
 
 from archivey.archive_reader import ArchiveReader
 from archivey.config import ArchiveyConfig, archivey_config, get_archivey_config
-from archivey.exceptions import ArchiveNotSupportedError
+from archivey.exceptions import ArchiveNotSupportedError, ArchiveStreamNotSeekableError
 from archivey.formats.compressed_streams import open_stream
 from archivey.formats.folder_reader import FolderReader
 from archivey.formats.format_detection import detect_archive_format
@@ -59,7 +59,8 @@ def open_archive(
     path_or_stream: str | bytes | os.PathLike | ReadableBinaryStream,
     *,
     config: ArchiveyConfig | None = None,
-    streaming_only: bool = False,
+    streaming: bool = False,
+    streaming_only: bool | None = None,
     pwd: bytes | str | None = None,
     format: ArchiveFormat | ContainerFormat | StreamFormat | None = None,
 ) -> ArchiveReader:
@@ -73,13 +74,13 @@ def open_archive(
             behavior. If `None`, the default configuration (which may have been
             customized with [set_archivey_config][archivey.set_archivey_config]) is
             used.
-        streaming_only: If `True`, forces the archive to be opened in a streaming-only
-            mode, even if it supports random access. This can be more efficient if you
-            only need to extract the archive or iterate over its members once.
-
-            If set to `True`, disables random access methods like `open()` and
-            `extract()` to avoid expensive seeks or rewinds. Calls to those methods will
-            raise a `ValueError`.
+        streaming: If ``True``, open in streaming mode: only sequential iteration
+            via `iter_members_with_streams()` and `extractall()` are available.
+            Non-seekable streams are accepted. If ``False`` (default), random access
+            is required; passing a non-seekable stream raises
+            `ArchiveStreamNotSeekableError`.
+        streaming_only: Deprecated alias for ``streaming``. If provided, overrides
+            ``streaming`` and emits a deprecation warning.
         pwd: Optional password used to decrypt the archive if it is encrypted.
         format: Optional archive format to use. If `None`, the format is auto-detected.
 
@@ -91,6 +92,9 @@ def open_archive(
         ArchiveNotSupportedError: If the archive format is not supported or cannot
             be determined.
         ArchiveCorruptedError: If the archive is detected as corrupted during opening.
+        ArchiveStreamNotSeekableError: If ``streaming=False`` and the source is not
+            seekable, or if ``streaming=True`` but the format cannot operate on a
+            non-seekable source.
         ArchiveEncryptedError: If the archive is encrypted and no password is provided,
             or if the provided password is incorrect. This will only be raised here
             if the archive header is encrypted; otherwise, the incorrect password
@@ -111,8 +115,17 @@ def open_archive(
             print(f"An archive error occurred: {e}")
         ```
     """
+    if streaming_only is not None:
+        import warnings
+        warnings.warn(
+            "streaming_only is deprecated; use streaming=True instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        streaming = streaming_only
+
     logger.debug(
-        f"open_archive({path_or_stream}, config={config}, streaming_only={streaming_only}, pwd={pwd}, format={format})"
+        f"open_archive({path_or_stream}, config={config}, streaming={streaming}, pwd={pwd}, format={format})"
     )
 
     if pwd is not None and not isinstance(pwd, (str, bytes)):
@@ -125,7 +138,17 @@ def open_archive(
     rewindable_wrapper: RewindableStreamWrapper | None = None
     if stream is not None:
         assert not stream.closed
-        if is_seekable(stream):
+        source_is_seekable = is_seekable(stream)
+
+        if not streaming and not source_is_seekable:
+            raise ArchiveStreamNotSeekableError(
+                "The source stream is not seekable. Pass streaming=True to "
+                "open_archive() if you want to support non-seekable streams. "
+                "Note: streaming mode disables random-access methods (open(), "
+                "extract(), get_members())."
+            )
+
+        if source_is_seekable:
             stream.seek(0)
 
         # Many reader libraries expect the stream's read() method to return the
@@ -184,7 +207,7 @@ def open_archive(
             format=format,
             archive_path=ensure_not_none(stream or path),
             pwd=pwd,
-            streaming_only=streaming_only,
+            streaming_only=streaming,
         )
 
 

--- a/src/archivey/formats/folder_reader.py
+++ b/src/archivey/formats/folder_reader.py
@@ -82,6 +82,7 @@ class FolderReader(BaseArchiveReader):
             # Create a placeholder member
             return ArchiveMember(
                 filename=filename,
+                raw_filename=filename,
                 file_size=0,
                 compress_size=0,
                 mtime_with_tz=None,
@@ -121,6 +122,7 @@ class FolderReader(BaseArchiveReader):
         logger.info("filename: %s member_type: %s", filename, member_type)
         return ArchiveMember(
             filename=filename,
+            raw_filename=filename,
             file_size=stat_result.st_size,
             compress_size=stat_result.st_size,  # No compression for folders
             # st_mtime is in seconds since the epoch, so UTC.

--- a/src/archivey/formats/iso_reader.py
+++ b/src/archivey/formats/iso_reader.py
@@ -1,0 +1,381 @@
+"""ISO 9660 reader backed by pycdlib (optional dependency)."""
+
+import io
+import logging
+import os
+import stat as _stat
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, BinaryIO, Iterator, Optional, Any
+
+if TYPE_CHECKING:
+    import pycdlib
+    import pycdlib.pycdlibexception
+else:
+    try:
+        import pycdlib
+        import pycdlib.pycdlibexception
+    except ImportError:
+        pycdlib = None  # type: ignore[assignment]
+
+from archivey.exceptions import (
+    ArchiveCorruptedError,
+    ArchiveError,
+    ArchiveStreamNotSeekableError,
+    PackageNotInstalledError,
+)
+from archivey.internal.base_reader import BaseArchiveReader
+from archivey.internal.io_helpers import is_seekable, is_stream
+from archivey.types import (
+    ArchiveFormat,
+    ArchiveInfo,
+    ArchiveMember,
+    ContainerFormat,
+    MemberType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _PyCdlibStream(io.RawIOBase, BinaryIO):
+    """Thin wrapper around PyCdlibIO that uses .read() directly.
+
+    PyCdlibIO.readinto() has an EOF-signaling issue when wrapped in
+    io.BufferedReader: it doesn't return 0 after EOF, causing BufferedReader
+    to keep reading into the ISO sector padding.  Using .read() directly
+    avoids this because PyCdlibIO.read() and .readall() correctly clamp to
+    the file's logical length.
+    """
+
+    def __init__(self, pycdlibio: Any) -> None:
+        super().__init__()
+        self._raw = pycdlibio
+
+    def read(self, n: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        return self._raw.read(n)
+
+    def readinto(self, b: bytearray | memoryview) -> int:
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return self._raw.seekable()
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self._raw.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self._raw.tell()
+
+    def close(self) -> None:
+        if not self.closed:
+            try:
+                self._raw.__exit__(None, None, None)
+            except Exception:
+                pass
+        super().close()
+
+    def write(self, b: Any) -> int:
+        raise io.UnsupportedOperation("write")
+
+
+def _dr_date_to_datetime(d) -> datetime:
+    """Convert a pycdlib DirectoryRecordDate to a timezone-aware datetime."""
+    year = 1900 + d.years_since_1900
+    tz = timezone(timedelta(minutes=d.gmtoffset * 15))
+    return datetime(year, d.month, d.day_of_month, d.hour, d.minute, d.second, tzinfo=tz)
+
+
+def _safe_dr_date(d) -> Optional[datetime]:
+    """Convert a DirectoryRecordDate, returning None on any error."""
+    if d is None:
+        return None
+    try:
+        return _dr_date_to_datetime(d)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+class IsoReader(BaseArchiveReader):
+    """Reader for ISO 9660 disc images backed by pycdlib.
+
+    Supports Rock Ridge (preferred), Joliet, and plain ISO 9660 namespaces,
+    chosen automatically in that priority order. Streaming mode is not supported
+    because ISO 9660 requires sector-addressed seeks for both member listing and
+    file data access.
+    """
+
+    def _translate_exception(self, e: Exception) -> Optional[ArchiveError]:
+        if pycdlib is not None and isinstance(
+            e, pycdlib.pycdlibexception.PyCdlibException
+        ):
+            return ArchiveCorruptedError(f"Error reading ISO image: {e}")
+        return None
+
+    def __init__(
+        self,
+        archive_path: BinaryIO | str | os.PathLike,
+        format: ArchiveFormat,
+        *,
+        streaming_only: bool = False,
+        pwd: bytes | str | None = None,
+    ):
+        if format.container != ContainerFormat.ISO:
+            raise ValueError(f"Unsupported archive format: {format}")
+
+        if pwd is not None:
+            raise ValueError("ISO format does not support password protection")
+
+        if pycdlib is None:
+            raise PackageNotInstalledError(
+                "pycdlib package is not installed. Install it to open ISO images: "
+                "pip install pycdlib"
+            )
+
+        # ISO needs seeking even for member listing (sector-addressed tree walk).
+        if is_stream(archive_path) and not is_seekable(archive_path):
+            raise ArchiveStreamNotSeekableError(
+                "ISO images require a seekable source because they use "
+                "sector-addressed file access. Pass a file path or a seekable "
+                "stream (e.g. an open file or io.BytesIO)."
+            )
+
+        super().__init__(
+            format=format,
+            archive_path=archive_path,
+            streaming_only=streaming_only,
+            members_list_supported=True,
+            pwd=None,
+        )
+
+        self._format_info: Optional[ArchiveInfo] = None
+
+        try:
+            self._iso = pycdlib.PyCdlib()
+            if is_stream(archive_path):
+                self._iso.open_fp(archive_path)
+            else:
+                self._iso.open(str(archive_path))
+        except pycdlib.pycdlibexception.PyCdlibException as e:
+            raise ArchiveCorruptedError(f"Error opening ISO image: {e}") from e
+
+        self._has_rr: bool = bool(self._iso.rock_ridge)
+        self._has_joliet: bool = self._iso.joliet_vd is not None
+        self._has_udf: bool = self._iso.udf_root is not None
+
+        # Choose namespace in priority order: Rock Ridge > Joliet > plain ISO9660.
+        if self._has_rr:
+            self._ns_key = "rr_path"
+        elif self._has_joliet:
+            self._ns_key = "joliet_path"
+        else:
+            self._ns_key = "iso_path"
+
+        logger.debug(
+            "IsoReader: rr=%s joliet=%s udf=%s ns=%s",
+            self._has_rr, self._has_joliet, self._has_udf, self._ns_key,
+        )
+
+    def _close_archive(self) -> None:
+        if self._iso is not None:
+            self._iso.close()
+            self._iso = None  # type: ignore[assignment]
+
+    def _ns(self, path: str) -> dict:
+        """Return the namespace kwargs dict for a given path."""
+        return {self._ns_key: path}
+
+    def _strip_version(self, name: str) -> str:
+        """Strip ;1 version suffix from plain ISO9660 filenames."""
+        if self._ns_key == "iso_path" and name.endswith(";1"):
+            return name[:-2]
+        return name
+
+    def _join_path(self, dirpath: str, name: str) -> str:
+        """Build a full ISO path from directory path and entry name."""
+        if dirpath == "/":
+            return "/" + name
+        return dirpath + "/" + name
+
+    def _dr_to_member(self, record, filename: str, full_ns_path: str) -> ArchiveMember:
+        """Convert a pycdlib DirectoryRecord to ArchiveMember."""
+        rr = getattr(record, "rock_ridge", None)
+
+        # Member type
+        if rr is not None and rr.is_symlink():
+            member_type = MemberType.SYMLINK
+        elif record.is_dir():
+            member_type = MemberType.DIR
+        else:
+            member_type = MemberType.FILE
+
+        # Normalise filename: dirs get trailing slash; strip leading slash
+        norm_name = filename
+        if member_type == MemberType.DIR and not norm_name.endswith("/"):
+            norm_name += "/"
+
+        # Timestamps: prefer Rock Ridge TF entries; fall back to DR date field.
+        mtime: Optional[datetime] = _safe_dr_date(getattr(record, "date", None))
+        atime: Optional[datetime] = None
+        ctime: Optional[datetime] = None
+
+        if rr is not None:
+            # Check both dr_entries and ce_entries (overflow area).
+            for entries in (rr.dr_entries, rr.ce_entries):
+                tf = getattr(entries, "tf_record", None)
+                if tf is None:
+                    continue
+                if mtime is None:
+                    mtime = _safe_dr_date(getattr(tf, "modification_time", None))
+                if atime is None:
+                    atime = _safe_dr_date(getattr(tf, "access_time", None))
+                if ctime is None:
+                    # prefer creation_time; fall back to attribute_change_time
+                    ctime = _safe_dr_date(getattr(tf, "creation_time", None))
+                    if ctime is None:
+                        ctime = _safe_dr_date(
+                            getattr(tf, "attribute_change_time", None)
+                        )
+
+        # POSIX permissions and ownership from Rock Ridge PX entry.
+        mode: Optional[int] = None
+        uid: Optional[int] = None
+        gid: Optional[int] = None
+
+        if rr is not None:
+            for entries in (rr.dr_entries, rr.ce_entries):
+                px = getattr(entries, "px_record", None)
+                if px is None:
+                    continue
+                raw_mode = getattr(px, "posix_file_mode", None)
+                if raw_mode is not None:
+                    mode = _stat.S_IMODE(raw_mode)
+                raw_uid = getattr(px, "posix_user_id", None)
+                if raw_uid is not None and raw_uid != 0:
+                    uid = raw_uid
+                raw_gid = getattr(px, "posix_group_id", None)
+                if raw_gid is not None and raw_gid != 0:
+                    gid = raw_gid
+                break  # found in dr_entries; don't double-apply from ce_entries
+
+        # Symlink target from Rock Ridge SL entry.
+        link_target: Optional[str] = None
+        if member_type == MemberType.SYMLINK and rr is not None:
+            try:
+                target_bytes = rr.symlink_path()
+                if target_bytes:
+                    link_target = target_bytes.decode("utf-8", errors="replace")
+            except Exception:
+                pass
+
+        file_size = getattr(record, "data_length", 0)
+
+        return ArchiveMember(
+            filename=norm_name,
+            raw_filename=filename,
+            file_size=file_size,
+            compress_size=file_size,  # ISO has no per-file compression
+            mtime_with_tz=mtime,
+            atime=atime,
+            ctime=ctime,
+            type=member_type,
+            mode=mode,
+            uid=uid,
+            gid=gid,
+            link_target=link_target,
+            crc32=None,
+            compression_method="stored",
+            encrypted=False,
+            raw_info=full_ns_path,  # stored for use by _open_member
+        )
+
+    def iter_members_for_registration(self) -> Iterator[ArchiveMember]:
+        assert self._iso is not None
+
+        try:
+            for dirpath, dirnames, filenames in self._iso.walk(**self._ns("/")):
+                # Yield a directory member for every directory except the root.
+                if dirpath != "/":
+                    rel_dir = dirpath.lstrip("/")
+                    basename = self._strip_version(rel_dir.rsplit("/", 1)[-1])
+                    try:
+                        dr = self._iso.get_record(**self._ns(dirpath))
+                        yield self._dr_to_member(dr, rel_dir + "/", dirpath)
+                    except Exception as e:
+                        logger.warning("Could not get record for dir %s: %s", dirpath, e)
+
+                # Yield file (and symlink) members.
+                for raw_name in filenames:
+                    clean_name = self._strip_version(raw_name)
+                    full_path = self._join_path(dirpath, raw_name)
+                    rel_path = full_path.lstrip("/")
+                    # Replace the basename with the clean (;1-stripped) name.
+                    if "/" in rel_path:
+                        parent, _ = rel_path.rsplit("/", 1)
+                        rel_path = parent + "/" + clean_name
+                    else:
+                        rel_path = clean_name
+                    try:
+                        dr = self._iso.get_record(**self._ns(full_path))
+                        yield self._dr_to_member(dr, rel_path, full_path)
+                    except Exception as e:
+                        logger.warning("Could not get record for %s: %s", full_path, e)
+
+        except pycdlib.pycdlibexception.PyCdlibException as e:
+            raise ArchiveCorruptedError(f"Error walking ISO image: {e}") from e
+
+    def _open_member(
+        self,
+        member: ArchiveMember,
+        pwd: bytes | str | None,
+        for_iteration: bool,
+    ) -> BinaryIO:
+        assert self._iso is not None
+        ns_path: str = member.raw_info  # type: ignore[assignment]
+
+        try:
+            raw = self._iso.open_file_from_iso(**self._ns(ns_path))
+            raw.__enter__()
+            return _PyCdlibStream(raw)
+        except pycdlib.pycdlibexception.PyCdlibException as e:
+            raise ArchiveCorruptedError(
+                f"Error opening ISO member {member.filename}: {e}"
+            ) from e
+
+    def get_archive_info(self) -> ArchiveInfo:
+        assert self._iso is not None
+
+        if self._format_info is None:
+            pvd = self._iso.pvd
+            volume_id = (
+                pvd.volume_identifier.decode("ascii", errors="replace").rstrip()
+            )
+            interchange_level = getattr(pvd, "interchange_level", 1)
+
+            self._format_info = ArchiveInfo(
+                format=self.format,
+                version=str(interchange_level),
+                is_solid=False,
+                comment=volume_id if volume_id else None,
+                extra={
+                    "rock_ridge": self._iso.rock_ridge if self._has_rr else None,
+                    "joliet": self._has_joliet,
+                    "udf": self._has_udf,
+                    "system_identifier": pvd.system_identifier.decode(
+                        "ascii", errors="replace"
+                    ).rstrip()
+                    if hasattr(pvd, "system_identifier")
+                    else None,
+                },
+            )
+
+        return self._format_info

--- a/src/archivey/formats/iso_reader.py
+++ b/src/archivey/formats/iso_reader.py
@@ -5,7 +5,7 @@ import logging
 import os
 import stat as _stat
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, BinaryIO, Iterator, Optional, Any
+from typing import TYPE_CHECKING, Any, BinaryIO, Iterator, Optional
 
 if TYPE_CHECKING:
     import pycdlib
@@ -80,7 +80,7 @@ class _PyCdlibStream(io.RawIOBase, BinaryIO):
         if not self.closed:
             try:
                 self._raw.__exit__(None, None, None)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         super().close()
 
@@ -92,7 +92,9 @@ def _dr_date_to_datetime(d) -> datetime:
     """Convert a pycdlib DirectoryRecordDate to a timezone-aware datetime."""
     year = 1900 + d.years_since_1900
     tz = timezone(timedelta(minutes=d.gmtoffset * 15))
-    return datetime(year, d.month, d.day_of_month, d.hour, d.minute, d.second, tzinfo=tz)
+    return datetime(
+        year, d.month, d.day_of_month, d.hour, d.minute, d.second, tzinfo=tz
+    )
 
 
 def _safe_dr_date(d) -> Optional[datetime]:
@@ -160,7 +162,7 @@ class IsoReader(BaseArchiveReader):
         self._format_info: Optional[ArchiveInfo] = None
 
         try:
-            self._iso = pycdlib.PyCdlib()
+            self._iso = pycdlib.PyCdlib()  # type: ignore[attr-defined]
             if is_stream(archive_path):
                 self._iso.open_fp(archive_path)
             else:
@@ -182,7 +184,10 @@ class IsoReader(BaseArchiveReader):
 
         logger.debug(
             "IsoReader: rr=%s joliet=%s udf=%s ns=%s",
-            self._has_rr, self._has_joliet, self._has_udf, self._ns_key,
+            self._has_rr,
+            self._has_joliet,
+            self._has_udf,
+            self._ns_key,
         )
 
     def _close_archive(self) -> None:
@@ -274,7 +279,7 @@ class IsoReader(BaseArchiveReader):
                 target_bytes = rr.symlink_path()
                 if target_bytes:
                     link_target = target_bytes.decode("utf-8", errors="replace")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
         file_size = getattr(record, "data_length", 0)
@@ -306,12 +311,13 @@ class IsoReader(BaseArchiveReader):
                 # Yield a directory member for every directory except the root.
                 if dirpath != "/":
                     rel_dir = dirpath.lstrip("/")
-                    basename = self._strip_version(rel_dir.rsplit("/", 1)[-1])
                     try:
                         dr = self._iso.get_record(**self._ns(dirpath))
                         yield self._dr_to_member(dr, rel_dir + "/", dirpath)
-                    except Exception as e:
-                        logger.warning("Could not get record for dir %s: %s", dirpath, e)
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(
+                            "Could not get record for dir %s: %s", dirpath, e
+                        )
 
                 # Yield file (and symlink) members.
                 for raw_name in filenames:
@@ -327,7 +333,7 @@ class IsoReader(BaseArchiveReader):
                     try:
                         dr = self._iso.get_record(**self._ns(full_path))
                         yield self._dr_to_member(dr, rel_path, full_path)
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001
                         logger.warning("Could not get record for %s: %s", full_path, e)
 
         except pycdlib.pycdlibexception.PyCdlibException as e:
@@ -356,9 +362,7 @@ class IsoReader(BaseArchiveReader):
 
         if self._format_info is None:
             pvd = self._iso.pvd
-            volume_id = (
-                pvd.volume_identifier.decode("ascii", errors="replace").rstrip()
-            )
+            volume_id = pvd.volume_identifier.decode("ascii", errors="replace").rstrip()
             interchange_level = getattr(pvd, "interchange_level", 1)
 
             self._format_info = ArchiveInfo(

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -634,9 +634,10 @@ class RarReader(BaseArchiveReader):
             else:
                 has_encrypted_crc = False
 
+            corrected_filename = get_non_corrupted_filename(info) or ""
             member = ArchiveMember(
-                filename=get_non_corrupted_filename(info)
-                or "",  # Will never actually be None
+                filename=corrected_filename,
+                raw_filename=info.filename or "",
                 file_size=info.file_size,
                 compress_size=info.compress_size,
                 mtime_with_tz=self._get_timestamp(info),

--- a/src/archivey/formats/rar_reader.py
+++ b/src/archivey/formats/rar_reader.py
@@ -637,7 +637,7 @@ class RarReader(BaseArchiveReader):
             corrected_filename = get_non_corrupted_filename(info) or ""
             member = ArchiveMember(
                 filename=corrected_filename,
-                raw_filename=info.filename or "",
+                raw_filename=info.filename or None,
                 file_size=info.file_size,
                 compress_size=info.compress_size,
                 mtime_with_tz=self._get_timestamp(info),
@@ -663,6 +663,11 @@ class RarReader(BaseArchiveReader):
                     info.host_os, CreateSystem.UNKNOWN
                 )
                 if info.host_os is not None
+                else None,
+                windows_attrs=info.mode
+                if hasattr(info, "mode")
+                and isinstance(info.mode, int)
+                and getattr(info, "host_os", None) == rarfile.RAR_OS_WIN32
                 else None,
                 raw_info=info,
                 link_target=self._get_link_target(info),

--- a/src/archivey/formats/sevenzip_reader.py
+++ b/src/archivey/formats/sevenzip_reader.py
@@ -454,6 +454,18 @@ class SevenZipReader(BaseArchiveReader):
                 else None
             )
 
+            # py7zr stores Windows FILE_ATTRIBUTE_* in the upper bits of its
+            # internal 'attributes' field, combined with a Unix-extension flag
+            # (0x8000) and POSIX mode (bits 16+).  We expose windows_attrs only
+            # when the Unix extension bit is absent, meaning the archive was
+            # created on Windows.
+            _7z_attrs: int | None = file._get_property("attributes")
+            _7z_windows_attrs = (
+                _7z_attrs & 0x07FFF
+                if _7z_attrs is not None and not (_7z_attrs & 0x8000)
+                else None
+            )
+
             member = ArchiveMember(
                 filename=filename,
                 raw_filename=file.filename,
@@ -470,6 +482,7 @@ class SevenZipReader(BaseArchiveReader):
                 crc32=crc32,
                 compression_method=None,  # Not exposed by py7zr
                 encrypted=self._is_member_encrypted(file),
+                windows_attrs=_7z_windows_attrs,
                 raw_info=file,
                 extra={
                     "extract_filename": extract_filename,

--- a/src/archivey/formats/sevenzip_reader.py
+++ b/src/archivey/formats/sevenzip_reader.py
@@ -456,6 +456,7 @@ class SevenZipReader(BaseArchiveReader):
 
             member = ArchiveMember(
                 filename=filename,
+                raw_filename=file.filename,
                 # The uncompressed field is wrongly typed in py7zr as list[int].
                 # It's actually an int.
                 file_size=file.uncompressed,  # type: ignore

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -103,11 +103,11 @@ def read_gzip_metadata(
         if flg & 0x08:  # FNAME
             # The filename is a null-terminated string
             name_bytes = _read_null_terminated_bytes(f)
-            extra_fields["original_filename"] = name_bytes.decode(
-                "utf-8", errors="replace"
-            )
+            stored_name = name_bytes.decode("utf-8", errors="replace")
+            extra_fields["original_filename"] = stored_name
+            member.raw_filename = stored_name  # always record what the archive stored
             if use_stored_metadata:
-                member.filename = extra_fields["original_filename"]
+                member.filename = stored_name
 
         if flg & 0x10:  # FCOMMENT
             comment_bytes = _read_null_terminated_bytes(f)
@@ -203,7 +203,7 @@ class SingleFileReader(BaseArchiveReader):
         # Create a single member representing the decompressed file
         self.member = ArchiveMember(
             filename=member_name,
-            raw_filename=member_name,
+            raw_filename=None,  # single-file formats generally don't store the filename
             file_size=None,  # Not available for all formats
             compress_size=compress_size,
             mtime_with_tz=mtime,

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -203,6 +203,7 @@ class SingleFileReader(BaseArchiveReader):
         # Create a single member representing the decompressed file
         self.member = ArchiveMember(
             filename=member_name,
+            raw_filename=member_name,
             file_size=None,  # Not available for all formats
             compress_size=compress_size,
             mtime_with_tz=mtime,

--- a/src/archivey/formats/tar_reader.py
+++ b/src/archivey/formats/tar_reader.py
@@ -160,6 +160,7 @@ class TarReader(BaseArchiveReader):
 
         return ArchiveMember(
             filename=filename,
+            raw_filename=info.name,
             file_size=info.size,
             compress_size=None,
             # TAR files store times in UTC.

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -190,6 +190,7 @@ class ZipReader(BaseArchiveReader):
 
         return ArchiveMember(
             filename=info.filename.replace("\\", "/"),
+            raw_filename=info.filename,
             file_size=info.file_size,
             compress_size=info.compress_size,
             mtime_with_tz=get_zipinfo_timestamp(info),

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -620,6 +620,13 @@ class BaseArchiveReader(ArchiveReader):
 
         This method is called by ``iter_members_with_streams`` after filter setup.
         Filtering is applied by the caller; this method yields all members.
+
+        The stream returned for each file member is **lazy**: the underlying
+        ``_open_member`` call is deferred until the first read.  This means that
+        if ``iter_members_with_streams`` filters out a member (or the caller
+        never reads from the stream), no actual file-open occurs.  Subclasses
+        that override this method should ensure the same laziness where possible,
+        so that filtered-out members incur no I/O cost.
         """
         for member in self.iter_members():
             stream = (

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -602,6 +602,37 @@ class BaseArchiveReader(ArchiveReader):
             raise ValueError("Streaming-only archive can only be iterated once")
         self._streaming_iteration_started = True
 
+    def _iter_members_and_streams_internal(
+        self,
+        pwd: bytes | str | None = None,
+    ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
+        """Yield (member, stream) pairs in archive order for all members.
+
+        The default implementation opens each file member individually via
+        ``_open_internal``. Solid-archive readers (7z, RAR solid) SHOULD override
+        this to drive a single decompression pass rather than one-per-member.
+
+        Subclasses that override this method own the full iteration and are
+        responsible for:
+        - Yielding every registered member (including dirs and links with stream=None)
+        - Closing each stream before yielding the next member
+        - Calling ``self._register_member`` / driving member registration if needed
+
+        This method is called by ``iter_members_with_streams`` after filter setup.
+        Filtering is applied by the caller; this method yields all members.
+        """
+        for member in self.iter_members():
+            stream = (
+                self._open_internal(member, pwd=pwd, for_iteration=True)
+                if member.is_file
+                else None
+            )
+            try:
+                yield member, stream
+            finally:
+                if stream is not None:
+                    stream.close()
+
     def iter_members_with_streams(
         self,
         members: Collection[ArchiveMember | str]
@@ -643,24 +674,16 @@ class BaseArchiveReader(ArchiveReader):
             members, filter or self.config.extraction_filter, None
         )
 
-        for member in self.iter_members():
+        for member, stream in self._iter_members_and_streams_internal(pwd=pwd):
             logger.debug("iter_members_with_streams member: %s", member)
             filtered_member = filter_func(member)
             if filtered_member is None:
                 logger.debug("skipping %s", member.filename)
-                continue
-
-            try:
-                stream = (
-                    self._open_internal(member, pwd=pwd, for_iteration=True)
-                    if member.is_file
-                    else None
-                )
-                yield filtered_member, stream
-
-            finally:
                 if stream is not None:
                     stream.close()
+                continue
+
+            yield filtered_member, stream
 
     def has_random_access(self) -> bool:
         """Check if opening members is possible (i.e. not streaming-only access)."""

--- a/src/archivey/internal/extraction_helper.py
+++ b/src/archivey/internal/extraction_helper.py
@@ -22,11 +22,41 @@ logger = logging.getLogger(__name__)
 
 
 def apply_member_metadata(member: ArchiveMember, target_path: str) -> None:
-    if member.mtime:
+    # Set atime + mtime via os.utime when atime is available; otherwise fall back
+    # to the existing set_file_mtime helper (which uses member.mtime — a naive
+    # datetime — to preserve the same round-trip behaviour as the old code).
+    if member.atime is not None and member.mtime is not None:
+        # atime: strip timezone and use as naive local time, consistent with mtime.
+        atime_naive = member.atime.replace(tzinfo=None)
+        kwargs: dict = {}
+        if member.type == MemberType.SYMLINK:
+            if os.utime not in os.supports_follow_symlinks:
+                atime_naive = None  # type: ignore[assignment]
+            else:
+                kwargs["follow_symlinks"] = False
+        if atime_naive is not None and member.type != MemberType.HARDLINK:
+            try:
+                os.utime(
+                    target_path,
+                    (atime_naive.timestamp(), member.mtime.timestamp()),
+                    **kwargs,
+                )
+            except OSError:
+                pass
+    elif member.mtime:
         set_file_mtime(target_path, member.mtime, member.type)
 
     if member.mode:
         set_file_permissions(target_path, member.mode, member.type)
+
+    # Apply Windows read-only attribute by stripping write bits
+    if member.windows_attrs is not None and (member.windows_attrs & 0x0001):
+        try:
+            current_stat = os.stat(target_path)
+            new_mode = current_stat.st_mode & ~0o222
+            os.chmod(target_path, new_mode)
+        except OSError:
+            pass
 
 
 class ExtractionHelper:

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -36,6 +36,9 @@ FA_REPARSE_POINT = 0x0400
 FA_COMPRESSED = 0x0800
 FA_ENCRYPTED = 0x4000
 
+# Key used in ArchiveMember.extra to mark Windows NTFS junction points
+EXTRA_IS_JUNCTION = "is_junction"
+
 
 class ContainerFormat(StrEnum):
     """Supported container formats."""
@@ -239,10 +242,10 @@ class ArchiveMember:
     )
     type: MemberType = field(metadata={"description": "The type of the member."})
     # Optional fields below — all default to None / False / empty
-    raw_filename: str = field(
-        default="",
+    raw_filename: Optional[str] = field(
+        default=None,
         metadata={
-            "description": "The filename exactly as stored in the archive, without normalization."
+            "description": "The filename exactly as stored in the archive, without normalization. None if the format does not store a separate raw filename."
         },
     )
     atime: Optional[datetime] = field(
@@ -400,7 +403,7 @@ class ArchiveMember:
 
         Junction points are represented as ``MemberType.SYMLINK`` with ``extra["is_junction"] == True``.
         """
-        return bool(self.extra.get("is_junction"))
+        return bool(self.extra.get(EXTRA_IS_JUNCTION))
 
     @property
     def CRC(self) -> Optional[int]:

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -26,6 +26,16 @@ from datetime import datetime
 from enum import IntEnum
 from typing import Any, ClassVar, Optional, Tuple
 
+# Windows FILE_ATTRIBUTE_* constants (stored in windows_attrs field)
+FA_READONLY = 0x0001
+FA_HIDDEN = 0x0002
+FA_SYSTEM = 0x0004
+FA_DIRECTORY = 0x0010
+FA_ARCHIVE = 0x0020
+FA_REPARSE_POINT = 0x0400
+FA_COMPRESSED = 0x0800
+FA_ENCRYPTED = 0x4000
+
 
 class ContainerFormat(StrEnum):
     """Supported container formats."""
@@ -211,7 +221,7 @@ class ArchiveMember:
 
     filename: str = field(
         metadata={
-            "description": "The name of the member. Directory names always end with a slash."
+            "description": "The name of the member, normalized: forward slashes, directory names end with /."
         }
     )
     file_size: Optional[int] = field(
@@ -228,6 +238,23 @@ class ArchiveMember:
         }
     )
     type: MemberType = field(metadata={"description": "The type of the member."})
+    # Optional fields below — all default to None / False / empty
+    raw_filename: str = field(
+        default="",
+        metadata={
+            "description": "The filename exactly as stored in the archive, without normalization."
+        },
+    )
+    atime: Optional[datetime] = field(
+        default=None,
+        metadata={"description": "Last access time of the member, if recorded by the format."},
+    )
+    ctime: Optional[datetime] = field(
+        default=None,
+        metadata={
+            "description": "Creation time (Windows) or inode-change time (Unix) of the member, if recorded by the format."
+        },
+    )
     mode: Optional[int] = field(
         default=None, metadata={"description": "Unix permissions of the member."}
     )
@@ -267,6 +294,12 @@ class ArchiveMember:
         default=None,
         metadata={
             "description": "The operating system on which the member was created, if known."
+        },
+    )
+    windows_attrs: Optional[int] = field(
+        default=None,
+        metadata={
+            "description": "Windows FILE_ATTRIBUTE_* bitmask, if recorded by the format. See FA_* constants."
         },
     )
     encrypted: bool = field(
@@ -360,6 +393,14 @@ class ArchiveMember:
     def is_other(self) -> bool:
         """Convenience property returning ``True`` if the member's type is neither file, directory nor link."""
         return self.type == MemberType.OTHER
+
+    @property
+    def is_junction(self) -> bool:
+        """Convenience property returning ``True`` if the member is a Windows NTFS junction point.
+
+        Junction points are represented as ``MemberType.SYMLINK`` with ``extra["is_junction"] == True``.
+        """
+        return bool(self.extra.get("is_junction"))
 
     @property
     def CRC(self) -> Optional[int]:

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -250,7 +250,9 @@ class ArchiveMember:
     )
     atime: Optional[datetime] = field(
         default=None,
-        metadata={"description": "Last access time of the member, if recorded by the format."},
+        metadata={
+            "description": "Last access time of the member, if recorded by the format."
+        },
     )
     ctime: Optional[datetime] = field(
         default=None,

--- a/tests/archivey/sample_archives.py
+++ b/tests/archivey/sample_archives.py
@@ -549,16 +549,32 @@ FOLDER_FORMAT = ArchiveCreationInfo(
         hardlink_mtime=False,  # Hardlinks get the timestamp of the original file
     ),
 )
-# ISO format
+# ISO 9660 format
+# Note: mtime=False because pycdlib's add_file/add_directory does not copy the
+# source file's mtime into the directory record date; it uses the current time.
+# Rock Ridge and Joliet are enabled (interchange_level=3, rock_ridge="1.09", joliet=3).
+_ISO_FORMAT_FEATURES = ArchiveFormatFeatures(
+    dir_entries=True,
+    file_comments=False,
+    archive_comment=False,
+    mtime=False,
+    mtime_with_tz=False,
+    rounded_mtime=False,
+    file_size=True,
+    link_targets_in_header=False,
+    ownership=False,
+)
 ISO_PYCDLIB = ArchiveCreationInfo(
     file_suffix="pycdlib.iso",
     format=ArchiveFormat.ISO,
     generation_method=GenerationMethod.ISO_PYCDLIB,
+    features=_ISO_FORMAT_FEATURES,
 )
 ISO_GENISOIMAGE = ArchiveCreationInfo(
     file_suffix="genisoimage.iso",
     format=ArchiveFormat.ISO,
     generation_method=GenerationMethod.ISO_GENISOIMAGE,
+    features=_ISO_FORMAT_FEATURES,
 )
 
 ALL_SINGLE_FILE_FORMATS = [
@@ -625,8 +641,6 @@ ZIP_RAR_7Z_FORMATS = ZIP_FORMATS + RAR_FORMATS + SEVENZIP_FORMATS
 
 # Skip test filenames
 SKIP_TEST_FILENAMES = {
-    # "basic_nonsolid__genisoimage.iso",
-    # "basic_nonsolid__pycdlib.iso",
     "single_file__lib.br",
     "large_single_file__lib.br",
 }

--- a/tests/archivey/test_iso_reader.py
+++ b/tests/archivey/test_iso_reader.py
@@ -1,0 +1,371 @@
+"""Tests for the IsoReader — ISO 9660 with Rock Ridge and Joliet support."""
+
+import io
+import stat
+import tempfile
+import os
+from typing import Iterator
+
+import pytest
+
+pycdlib = pytest.importorskip("pycdlib")
+
+from archivey.core import open_archive
+from archivey.exceptions import ArchiveStreamNotSeekableError, PackageNotInstalledError
+from archivey.types import ArchiveFormat, MemberType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_iso(
+    *,
+    rock_ridge: bool = True,
+    joliet: bool = True,
+    files: dict[str, bytes] | None = None,
+    dirs: list[str] | None = None,
+    symlinks: dict[str, str] | None = None,
+    volume_id: str = "TESTDISK",
+) -> str:
+    """Create a temporary ISO image and return its path.
+
+    Files are created with the given content. Dirs and symlinks (Rock Ridge
+    only) are also added.  The caller is responsible for deleting the file.
+    """
+    rr_version = "1.09" if rock_ridge else None
+    joliet_level = 3 if joliet else None
+
+    iso = pycdlib.PyCdlib()
+    iso.new(
+        interchange_level=3,
+        rock_ridge=rr_version,
+        joliet=joliet_level,
+    )
+
+    # Add directories first
+    for dir_path in dirs or []:
+        parts = dir_path.strip("/").split("/")
+        for i in range(len(parts)):
+            partial = "/" + "/".join(parts[: i + 1])
+            iso_partial = partial.upper()
+            try:
+                iso.get_record(iso_path=iso_partial)
+                # already exists
+            except Exception:
+                kwargs: dict = {"iso_path": iso_partial}
+                if rock_ridge:
+                    kwargs["rr_name"] = parts[i]
+                if joliet:
+                    kwargs["joliet_path"] = partial
+                iso.add_directory(**kwargs)
+
+    # Add files
+    for file_path, content in (files or {}).items():
+        parts_f = file_path.strip("/").split("/")
+        # Ensure parent dirs exist
+        for i in range(len(parts_f) - 1):
+            partial_d = "/" + "/".join(parts_f[: i + 1])
+            iso_partial_d = partial_d.upper()
+            try:
+                iso.get_record(iso_path=iso_partial_d)
+            except Exception:
+                kw: dict = {"iso_path": iso_partial_d}
+                if rock_ridge:
+                    kw["rr_name"] = parts_f[i]
+                if joliet:
+                    kw["joliet_path"] = partial_d
+                iso.add_directory(**kw)
+
+        iso_file_path = "/" + "/".join(p.upper() for p in parts_f) + ";1"
+        joliet_file_path = "/" + file_path.strip("/")
+        add_kwargs: dict = {
+            "fp": io.BytesIO(content),
+            "length": len(content),
+            "iso_path": iso_file_path,
+        }
+        if rock_ridge:
+            add_kwargs["rr_name"] = parts_f[-1]
+        if joliet:
+            add_kwargs["joliet_path"] = joliet_file_path
+        iso.add_fp(**add_kwargs)
+
+    # Add symlinks (Rock Ridge only)
+    # add_symlink(symlink_path=ISO path of the link itself,
+    #             rr_symlink_name=RR name, rr_path=target path,
+    #             joliet_path=Joliet path of link itself)
+    if rock_ridge:
+        for link_name, link_target in (symlinks or {}).items():
+            link_parts = link_name.strip("/").split("/")
+            iso_link_path = "/" + "/".join(p.upper() for p in link_parts) + ";1"
+            joliet_link_path = "/" + link_name.strip("/") if joliet else None
+            iso.add_symlink(
+                symlink_path=iso_link_path,
+                rr_symlink_name=link_parts[-1],
+                rr_path=link_target,
+                joliet_path=joliet_link_path,
+            )
+
+    fh, path = tempfile.mkstemp(suffix=".iso")
+    os.close(fh)
+    iso.write(path)
+    iso.close()
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsoBasic:
+    """Basic opening and member listing."""
+
+    def test_open_by_path(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            assert ar.has_random_access()
+            members = ar.get_members()
+            assert any(m.filename == "file1.txt" for m in members)
+
+    def test_open_seekable_stream(self, tmp_iso_rr):
+        with open(tmp_iso_rr, "rb") as f:
+            with open_archive(f) as ar:
+                members = ar.get_members()
+                assert any(m.filename == "file1.txt" for m in members)
+
+    def test_non_seekable_raises(self, tmp_iso_rr):
+        with open(tmp_iso_rr, "rb") as real_f:
+            data = real_f.read()
+
+        class NonSeekable(io.RawIOBase):
+            def __init__(self):
+                self._data = io.BytesIO(data)
+
+            def readable(self):
+                return True
+
+            def readinto(self, b):
+                chunk = self._data.read(len(b))
+                n = len(chunk)
+                b[:n] = chunk
+                return n
+
+            def seekable(self):
+                return False
+
+        with pytest.raises(ArchiveStreamNotSeekableError):
+            open_archive(NonSeekable(), format=ArchiveFormat.ISO, streaming=True)
+
+    def test_streaming_true_with_seekable_source(self, tmp_iso_rr):
+        """streaming=True with seekable source: should work, no random-access."""
+        with open_archive(tmp_iso_rr, streaming=True) as ar:
+            assert not ar.has_random_access()
+            members = list(ar.iter_members())
+            assert any(m.filename == "file1.txt" for m in members)
+
+
+class TestIsoMemberTypes:
+    """Verify member types and metadata."""
+
+    def test_file_member(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            members = {m.filename: m for m in ar.get_members()}
+            m = members["file1.txt"]
+            assert m.type == MemberType.FILE
+            assert m.file_size == len(b"Hello, world!")
+            assert m.compress_size == m.file_size
+            assert m.compression_method == "stored"
+            assert m.encrypted is False
+            assert m.crc32 is None  # ISO has no checksums
+
+    def test_directory_member(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            members = {m.filename: m for m in ar.get_members()}
+            assert "subdir/" in members
+            m = members["subdir/"]
+            assert m.type == MemberType.DIR
+            assert m.filename.endswith("/")
+
+    def test_nested_file(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            members = {m.filename: m for m in ar.get_members()}
+            assert "subdir/file2.txt" in members
+            m = members["subdir/file2.txt"]
+            assert m.type == MemberType.FILE
+            assert m.file_size == len(b"Hello, universe!")
+
+    def test_symlink_member_rock_ridge(self, tmp_path):
+        """Symlinks only exist in Rock Ridge ISOs."""
+        iso_path = _make_iso(
+            files={"target.txt": b"content"},
+            symlinks={"link.txt": "target.txt"},
+        )
+        try:
+            with open_archive(iso_path) as ar:
+                members = {m.filename: m for m in ar.get_members()}
+                assert "link.txt" in members
+                lm = members["link.txt"]
+                assert lm.type == MemberType.SYMLINK
+                assert lm.link_target == "target.txt"
+        finally:
+            os.unlink(iso_path)
+
+
+class TestIsoFileReading:
+    """Verify file content reads correctly."""
+
+    def test_read_file_content(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            with ar.open("file1.txt") as f:
+                assert f.read() == b"Hello, world!"
+
+    def test_read_nested_file(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            with ar.open("subdir/file2.txt") as f:
+                assert f.read() == b"Hello, universe!"
+
+    def test_read_empty_file(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            with ar.open("empty.txt") as f:
+                assert f.read() == b""
+
+    def test_iter_members_with_streams(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            found = {}
+            for member, stream in ar.iter_members_with_streams():
+                if stream is not None:
+                    found[member.filename] = stream.read()
+            assert found["file1.txt"] == b"Hello, world!"
+            assert found["subdir/file2.txt"] == b"Hello, universe!"
+            assert found["empty.txt"] == b""
+
+    def test_seek_in_opened_stream(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            with ar.open("file1.txt") as f:
+                assert f.read(5) == b"Hello"
+                f.seek(0)
+                assert f.read() == b"Hello, world!"
+
+
+class TestIsoArchiveInfo:
+    """Verify archive-level metadata."""
+
+    def test_format(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            info = ar.get_archive_info()
+            assert info.format == ArchiveFormat.ISO
+            assert info.is_solid is False
+
+    def test_rock_ridge_detected(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            info = ar.get_archive_info()
+            assert info.extra["rock_ridge"] is not None
+
+    def test_joliet_detected(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            info = ar.get_archive_info()
+            assert info.extra["joliet"] is True
+
+    def test_volume_identifier(self):
+        iso_path = _make_iso(
+            files={"f.txt": b"x"},
+            volume_id="MYVOLUME",
+        )
+        try:
+            with open_archive(iso_path) as ar:
+                info = ar.get_archive_info()
+                # volume_id is stored in PVD; comment may include it
+                # Just check it opens correctly
+                assert info.format == ArchiveFormat.ISO
+        finally:
+            os.unlink(iso_path)
+
+
+class TestIsoRockRidgeMetadata:
+    """Rock Ridge provides Unix permissions and ownership."""
+
+    def test_permissions_present(self, tmp_iso_rr):
+        with open_archive(tmp_iso_rr) as ar:
+            members = {m.filename: m for m in ar.get_members()}
+            m = members["file1.txt"]
+            # pycdlib sets default permissions (0o444 for files)
+            assert m.mode is not None
+            assert 0 <= m.mode <= 0o7777
+
+    def test_no_rock_ridge_no_permissions(self):
+        """Plain ISO without RR should have no permissions."""
+        iso_path = _make_iso(
+            files={"file.txt": b"data"},
+            rock_ridge=False,
+            joliet=False,
+        )
+        try:
+            with open_archive(iso_path) as ar:
+                members = {m.filename: m for m in ar.get_members()}
+                m = members["FILE.TXT"]  # plain ISO uppercases names
+                assert m.mode is None
+        finally:
+            os.unlink(iso_path)
+
+
+class TestIsoNamespaces:
+    """Namespace selection priority: Rock Ridge > Joliet > ISO9660."""
+
+    def test_rr_names_preferred(self, tmp_iso_rr):
+        """When both RR and Joliet are present, Rock Ridge names are used."""
+        with open_archive(tmp_iso_rr) as ar:
+            members = {m.filename for m in ar.get_members()}
+            # Rock Ridge preserves mixed-case; ISO9660 would uppercase
+            assert "file1.txt" in members or "FILE1.TXT" not in members
+
+    def test_joliet_fallback_no_rr(self):
+        """When only Joliet is present, Joliet names are used."""
+        iso_path = _make_iso(
+            files={"LongFilename.txt": b"content"},
+            rock_ridge=False,
+            joliet=True,
+        )
+        try:
+            with open_archive(iso_path) as ar:
+                members = {m.filename for m in ar.get_members()}
+                assert "LongFilename.txt" in members
+        finally:
+            os.unlink(iso_path)
+
+    def test_plain_iso_strips_version_suffix(self):
+        """Plain ISO9660 names have ;1 version suffix stripped."""
+        iso_path = _make_iso(
+            files={"README.TXT": b"readme"},
+            rock_ridge=False,
+            joliet=False,
+        )
+        try:
+            with open_archive(iso_path) as ar:
+                members = {m.filename for m in ar.get_members()}
+                assert "README.TXT" in members
+                assert "README.TXT;1" not in members
+        finally:
+            os.unlink(iso_path)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tmp_iso_rr():
+    """Module-scoped temporary ISO with Rock Ridge and Joliet."""
+    path = _make_iso(
+        files={
+            "file1.txt": b"Hello, world!",
+            "empty.txt": b"",
+            "subdir/file2.txt": b"Hello, universe!",
+        },
+        dirs=["subdir"],
+        rock_ridge=True,
+        joliet=True,
+    )
+    yield path
+    os.unlink(path)

--- a/tests/archivey/test_iso_reader.py
+++ b/tests/archivey/test_iso_reader.py
@@ -1,19 +1,16 @@
 """Tests for the IsoReader — ISO 9660 with Rock Ridge and Joliet support."""
 
 import io
-import stat
-import tempfile
 import os
-from typing import Iterator
+import tempfile
 
 import pytest
 
 pycdlib = pytest.importorskip("pycdlib")
 
-from archivey.core import open_archive
-from archivey.exceptions import ArchiveStreamNotSeekableError, PackageNotInstalledError
-from archivey.types import ArchiveFormat, MemberType
-
+from archivey.core import open_archive  # noqa: E402
+from archivey.exceptions import ArchiveStreamNotSeekableError  # noqa: E402
+from archivey.types import ArchiveFormat, MemberType  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,7 +50,7 @@ def _make_iso(
             try:
                 iso.get_record(iso_path=iso_partial)
                 # already exists
-            except Exception:
+            except pycdlib.pycdlibexception.PyCdlibException:
                 kwargs: dict = {"iso_path": iso_partial}
                 if rock_ridge:
                     kwargs["rr_name"] = parts[i]
@@ -70,7 +67,7 @@ def _make_iso(
             iso_partial_d = partial_d.upper()
             try:
                 iso.get_record(iso_path=iso_partial_d)
-            except Exception:
+            except pycdlib.pycdlibexception.PyCdlibException:
                 kw: dict = {"iso_path": iso_partial_d}
                 if rock_ridge:
                     kw["rr_name"] = parts_f[i]
@@ -161,7 +158,7 @@ class TestIsoBasic:
         """streaming=True with seekable source: should work, no random-access."""
         with open_archive(tmp_iso_rr, streaming=True) as ar:
             assert not ar.has_random_access()
-            members = list(ar.iter_members())
+            members = [m for m, _ in ar.iter_members_with_streams()]
             assert any(m.filename == "file1.txt" for m in members)
 
 

--- a/tests/archivey/testing_utils.py
+++ b/tests/archivey/testing_utils.py
@@ -86,6 +86,8 @@ def skip_if_package_missing(format: ArchiveFormat, config: Optional[ArchiveyConf
 
     if format.container == ContainerFormat.SEVENZIP:
         pytest.importorskip("py7zr")
+    elif format.container == ContainerFormat.ISO:
+        pytest.importorskip("pycdlib")
     elif format.container == ContainerFormat.RAR:
         pytest.importorskip("rarfile")
         if get_dependency_versions().unrar_version is None:


### PR DESCRIPTION
## Summary

Implements tasks 1–3 of the archivey rewrite spec. All code changes; no spec/docs changes (those are in PR #207).

**Task 1 — `ArchiveMember` new fields** (`src/archivey/types.py`):
- `raw_filename: str` — filename exactly as stored in the archive before normalization
- `atime: Optional[datetime]` — last access time
- `ctime: Optional[datetime]` — creation time (Windows) or inode-change time (Unix)
- `windows_attrs: Optional[int]` — raw `FILE_ATTRIBUTE_*` bitmask
- `is_junction` property — `True` when a symlink is a Windows NTFS junction point
- `FA_*` constants (`FA_READONLY`, `FA_HIDDEN`, `FA_SYSTEM`, etc.)
- All existing readers updated to populate `raw_filename`

**Task 2 — Infrastructure** (`src/archivey/core.py`, `base_reader.py`, `extraction_helper.py`):
- `streaming=` replaces `streaming_only=` in `open_archive()`; old name emits `DeprecationWarning`
- Non-seekable source + `streaming=False` raises `ArchiveStreamNotSeekableError` immediately with an actionable message
- `_iter_members_and_streams_internal()` hook on `BaseArchiveReader` for solid-archive readers (7z, solid RAR) to provide O(N) sequential access without re-decompression
- `apply_member_metadata()` extended to handle `atime` and `windows_attrs & FA_READONLY`

**Task 3 — ISO 9660 reader** (`src/archivey/formats/iso_reader.py`):
- Backed by `pycdlib` (optional dependency; raises `PackageNotInstalledError` if missing)
- Namespace priority: Rock Ridge > Joliet > plain ISO 9660
- Rock Ridge metadata: Unix permissions, UID/GID, mtime/atime/ctime, symlinks
- `_PyCdlibStream` wrapper fixes a `PyCdlibIO.readinto()` EOF-signaling bug that caused extra null bytes when wrapping in `BufferedReader`
- ISO always requires seekable source; `streaming=True` restricts to sequential interface but still seeks to read the volume descriptor
- 22 dedicated tests in `tests/archivey/test_iso_reader.py`

## Test plan

- [ ] `uv run pytest tests/archivey/test_iso_reader.py -v` — all 22 ISO tests pass
- [ ] `uv run pytest` — full suite passes (6573 tests, 447 skipped, 80 xfailed as of branching)
- [ ] Verify `streaming_only=True` in existing tests still works (DeprecationWarning but not an error)