### PR TITLE
Add Python 3.14 stdlib zstd support and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,8 @@ optional = [
     "indexed_bzip2>=1.6.0",
     "python-xz>=0.5.0",
     "pyzstd>=0.17.0",
-    # Not currently compatible with Python 3.14. Fix on the way, see
-    # https://github.com/indygreg/python-zstandard/pull/262
-    "zstandard>=0.23.0 ; python_full_version < '3.14'",
-    # Not currently compatible with Python 3.14. Fix on the way, see
-    # https://github.com/python-lz4/python-lz4/pull/303
-    "lz4>=4.4.4 ; python_full_version < '3.14'",
+    "zstandard>=0.25.0",
+    "lz4>=4.4.5",
     "pycdlib>=1.14.0",
     "uncompresspy>=0.4.0; python_full_version >= '3.11'",
     "brotli>=1.1.0",
@@ -51,7 +47,8 @@ optional-freethreaded = [
     "indexed_bzip2==1.6.0",  # 1.7.0 does not compile in Github actions for free-threaded builds
     "python-xz>=0.5.0",
     "pyzstd>=0.17.0",
-    "lz4>=4.4.4 ; python_full_version < '3.14'",
+    "zstandard>=0.25.0",
+    "lz4>=4.4.5",
     "pycdlib>=1.14.0",
     "uncompresspy>=0.4.0",
     "brotli>=1.1.0",

--- a/src/archivey/filters.py
+++ b/src/archivey/filters.py
@@ -35,9 +35,7 @@ def _check_target_inside_archive_root(
     target_path: str, dest_path: str | None, target_type_str: str
 ) -> None:
     if os.path.isabs(target_path) or ntpath.isabs(target_path):
-        raise ArchiveFilterError(
-            f"Absolute path not allowed: {target_path}"
-        )
+        raise ArchiveFilterError(f"Absolute path not allowed: {target_path}")
 
     if target_path.startswith("..") or "/../" in target_path:
         raise ArchiveFilterError(

--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -48,7 +48,10 @@ else:
     try:
         import pyzstd
     except ImportError:
-        pyzstd = None
+        try:
+            import compression.zstd as pyzstd  # type: ignore[no-redef]
+        except ImportError:
+            pyzstd = None
 
     try:
         import rapidgzip

--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -49,6 +49,7 @@ else:
         import pyzstd
     except ImportError:
         try:
+            # Built-in in Python >= 3.14
             import compression.zstd as pyzstd  # type: ignore[no-redef]
         except ImportError:
             pyzstd = None

--- a/src/archivey/internal/dependency_checker.py
+++ b/src/archivey/internal/dependency_checker.py
@@ -24,6 +24,7 @@ class DependencyVersions:
     brotli_version: Optional[str] = None
     unrar_version: Optional[str] = None
     pyzstd_version: Optional[str] = None
+    stdlib_zstd_version: Optional[str] = None
 
 
 def get_dependency_versions() -> DependencyVersions:
@@ -57,6 +58,12 @@ def get_dependency_versions() -> DependencyVersions:
             setattr(versions, attr, version(package))
         except PackageNotFoundError:
             pass
+
+    try:
+        import compression.zstd as _stdlib_zstd  # noqa: F401
+        versions.stdlib_zstd_version = f"stdlib ({versions.python_version})"
+    except ImportError:
+        pass
 
     # Check if the unrar command is available
     unrar_path = shutil.which("unrar")

--- a/src/archivey/internal/dependency_checker.py
+++ b/src/archivey/internal/dependency_checker.py
@@ -60,7 +60,8 @@ def get_dependency_versions() -> DependencyVersions:
             pass
 
     try:
-        import compression.zstd as _stdlib_zstd  # noqa: F401
+        import compression.zstd  # type: ignore[import-not-found]  # noqa: F401
+
         versions.stdlib_zstd_version = f"stdlib ({versions.python_version})"
     except ImportError:
         pass

--- a/tests/archivey/test_missing_packages.py
+++ b/tests/archivey/test_missing_packages.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -113,6 +114,15 @@ def test_missing_package_raises_exception(
         open_archive(archive_path, config=config)
 
     assert f"{library_name} package is not installed" in str(excinfo.value)
+
+
+def test_stdlib_zstd_version():
+    versions = get_dependency_versions()
+    if sys.version_info >= (3, 14):
+        assert versions.stdlib_zstd_version is not None
+        assert versions.stdlib_zstd_version.startswith("stdlib (")
+    else:
+        assert versions.stdlib_zstd_version is None
 
 
 @pytest.mark.skipif(

--- a/tests/archivey/test_nested_compressed_archives.py
+++ b/tests/archivey/test_nested_compressed_archives.py
@@ -30,7 +30,6 @@ from tests.archivey.sample_archives import (
 from tests.archivey.test_open_nonseekable import EXPECTED_NON_SEEKABLE_FAILURES
 from tests.archivey.testing_utils import skip_if_package_missing
 
-
 _NESTED_ARCHIVES_DIR = os.path.join(
     os.path.dirname(__file__), "..", "test_archives", "nested"
 )

--- a/tests/archivey/test_read_archives.py
+++ b/tests/archivey/test_read_archives.py
@@ -13,7 +13,10 @@ from archivey.core import open_archive
 from archivey.exceptions import ArchiveError, ArchiveMemberCannotBeOpenedError
 from archivey.filters import create_filter
 from archivey.internal.dependency_checker import get_dependency_versions
-from archivey.internal.utils import get_current_user_and_group, platform_supports_setting_symlink_mtime
+from archivey.internal.utils import (
+    get_current_user_and_group,
+    platform_supports_setting_symlink_mtime,
+)
 from archivey.types import (
     ArchiveMember,
     ContainerFormat,

--- a/tests/archivey/testing_utils.py
+++ b/tests/archivey/testing_utils.py
@@ -101,7 +101,11 @@ def skip_if_package_missing(format: ArchiveFormat, config: Optional[ArchiveyConf
     elif format.stream == StreamFormat.ZSTD and config.use_zstandard:
         pytest.importorskip("zstandard")
     elif format.stream == StreamFormat.ZSTD:
-        pytest.importorskip("pyzstd")
+        import sys
+
+        if sys.version_info < (3, 14):
+            pytest.importorskip("pyzstd")
+        # On Python 3.14+, compression.zstd is always available as stdlib fallback
     elif format.stream == StreamFormat.BROTLI:
         pytest.importorskip("brotli")
     elif format.stream == StreamFormat.UNIX_COMPRESS:

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ deps =
     newlibs: indexed_bzip2==1.7.0
     newlibs: python-xz==0.5.0
     newlibs: pyzstd==0.17.0
-    newlibs: zstandard==0.23.0
-    newlibs: lz4==4.4.4
+    newlibs: zstandard==0.25.0
+    newlibs: lz4==4.4.5
     py3.{11..14}-newlibs: uncompresspy==0.4.0
     newlibs: brotli==1.1.0
 


### PR DESCRIPTION
## Summary
This PR adds support for Python 3.14's standard library `compression.zstd` module as a fallback when third-party zstd libraries are unavailable, while updating minimum dependency versions to ensure Python 3.14 compatibility.

## Key Changes
- **Stdlib zstd fallback**: Added support for Python 3.14's built-in `compression.zstd` module in `compressed_streams.py` when `pyzstd` is not available
- **Dependency version tracking**: Added `stdlib_zstd_version` field to `DependencyVersions` dataclass to track when stdlib zstd is being used
- **Test utilities**: Updated `skip_if_package_missing()` to skip `pyzstd` import check on Python 3.14+ since stdlib fallback is always available
- **Dependency updates**: Bumped `zstandard>=0.25.0` and `lz4>=4.4.5` to versions with Python 3.14 support, removing version constraints that previously excluded Python 3.14

## Implementation Details
- The fallback chain now attempts to import `pyzstd` first, then falls back to `compression.zstd` (available in Python 3.14+)
- The stdlib zstd detection reports the version as "stdlib (X.Y.Z)" to clearly indicate it's using the standard library implementation
- Test skipping logic now conditionally requires `pyzstd` only on Python versions before 3.14

https://claude.ai/code/session_01J8hszTZeXYAqtCYdkKAUvg