### PR TITLE
OpenSpec: cost introspection (§8.B–§8.E) + access-intent (§8.F) + public stream interface

### DIFF
--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -571,9 +571,9 @@ conflates two things: a format fact and a runtime fact.
 
 Split them:
 
-- **"Where does this *format* keep its member catalog?"** is a pure format-level
-  fact and belongs on the class, as a clearly-named `ClassVar`. A plain
-  `has_central_directory` bool is too coarse, because *where* the catalog lives
+- **"Where does this archive keep its member catalog?"** is a format-level fact
+  *where the layout is uniform*, and belongs on the class as a clearly-named `ClassVar`.
+  A plain `has_central_directory` bool is too coarse, because *where* the catalog lives
   decides whether it is reachable without seeking:
   ```python
   class ZipReader(BaseArchiveReader):
@@ -581,9 +581,13 @@ Split them:
   ```
   The locations are: **header-resident** (read while streaming forward),
   **tail-resident** (ZIP's end-of-file central directory), **single-known-member**
-  (single-file streams), or **none** (TAR). The exact per-format mapping (e.g. whether
-  RAR/7z/ISO are header- or tail-resident) is confirmed per reader, notably when the
-  native readers land.
+  (single-file streams), or **none** (TAR). But it is **not always a `ClassVar`** — for
+  some formats the location is *per file*. RAR is the case: its member headers precede
+  each file (no front index), and an upfront catalog exists only when the optional
+  **"quick open" service block** — an index at the *end* of the archive — is present, so
+  one `.rar` is tail-indexed and another is scan-only. Such readers determine the location
+  at open. The exact per-format mapping/variation (RAR/7z/ISO) is confirmed per reader,
+  notably when the native readers land.
 - **"Can *this opened archive* be listed cheaply (`INDEXED`)?"** is the *realized*
   cost, **not** read from the ClassVar alone: it depends on the location **and**
   seekability. `INDEXED` when the catalog (or single member) is reachable without a
@@ -686,10 +690,12 @@ does no I/O):
 
 ```text
 member_listing_cost(reader):           # per instance: catalog location (§C) + seekability
-    cat = member_catalog               # HEADER | TRAILER | SINGLE_MEMBER | NONE
+    cat = member_catalog               # HEADER | TRAILER | SINGLE_MEMBER | NONE;
+                                       #   ClassVar where uniform, else decided at open
+                                       #   (RAR: TRAILER iff quick-open index present)
     if cat in (HEADER, SINGLE_MEMBER): -> INDEXED        # reachable forward, no back-seek
-    if cat == TRAILER:                 -> INDEXED if seekable else SEQUENTIAL_ONLY  # ZIP EOCD
-    # cat == NONE (TAR)
+    if cat == TRAILER:                 -> INDEXED if seekable else SEQUENTIAL_ONLY  # ZIP/RAR
+    # cat == NONE (TAR, or RAR without quick-open)
     -> SCAN_REQUIRED if seekable else SEQUENTIAL_ONLY
 
 seek_cost(stream):                     # per stream, fixed at construction

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -563,20 +563,30 @@ only when its decompressor is genuinely non-seekable for this instance. The
 runtime streaming flag then means "user requested streaming OR format cannot
 random-access".
 
-#### C. `members_list_supported` should be a class attribute
+#### C. `has_central_directory` ClassVar (replacing the `members_list_supported` argument)
 
-Currently passed to `__init__()` as a constructor argument.  But it's
-determined solely by the format type, not by any runtime condition.
+Currently `members_list_supported` is passed to `__init__()` as a constructor
+argument. The name is misleading (it sounds like it returns the list) and it
+conflates two things: a format fact and a runtime fact.
 
-Exception: TAR sets it based on whether the stream has a seekable structure,
-but the flag actually doesn't matter for TAR since `streaming_only` already
-captures the relevant behaviour.
+Split them:
 
-Making it a `ClassVar` would clarify that it is a format-level property:
-```python
-class ZipReader(BaseArchiveReader):
-    members_list_supported = True
-```
+- **"Does this *format* have a catalog/central directory?"** is a pure format-level
+  fact — `True` for ZIP/7z/RAR/ISO/folder, `False` for TAR. That genuinely belongs
+  on the class, as a clearly-named `ClassVar`:
+  ```python
+  class ZipReader(BaseArchiveReader):
+      has_central_directory = True
+  ```
+- **"Can *this opened archive* be listed cheaply (`INDEXED`)?"** is the *realized*
+  cost, and it is **not** read from the ClassVar alone: a catalog at end-of-file is
+  only reachable when the source is seekable. So `member_listing_cost` (§E) is
+  computed per instance from `has_central_directory` **and** seekability — exactly the
+  same capability-vs-runtime split as §B. Deriving `INDEXED` from the ClassVar alone
+  is wrong for a catalog format opened from a non-seekable source.
+
+The standalone `members_list_supported` boolean then disappears: it is precisely
+`member_listing_cost == INDEXED`.
 
 #### D. Typed compression method enum
 
@@ -645,6 +655,48 @@ conservatively when the structure isn't known, never measured per call.
 `get_members_if_available()` returns the list only when `member_listing_cost` is
 `INDEXED` (or members are already registered) and never triggers a
 `SCAN_REQUIRED` pass.
+
+Crucially, `seek_cost` is owned by the **decompressor-stream abstraction** (the
+stdlib rewind wrapper, rapidgzip, indexed_bzip2, `XzDecompressorStream`, lzip, a
+plain file), each of which reports its own tier. Readers whose access is a seek on
+such a stream (TAR) *read* that `seek_cost` rather than re-deriving it from
+`config.use_*` flags — one source of truth, and no drift (e.g. a multi-block
+`tar.xz` is correctly `LIMITED` instead of being mis-reported `EXPENSIVE`).
+
+#### F. Access intent — the input dual of the cost surface
+
+§E lets callers *read* how expensive access is. But on its own it leaves them
+responsible for *configuring* the backend that produces a good cost: to get cheap
+random access on a `tar.gz` today you must already know to set `use_rapidgzip=True`.
+The low-level `use_*` flags leak archivey's cost model.
+
+**Proposed addition**: an `AccessIntent` enum and an `access_intent` parameter on
+`open_archive`, letting the caller state the *goal* and have archivey pick the
+backend:
+
+```python
+class AccessIntent(StrEnum):
+    AUTO = "auto"              # default: today's behavior; honor explicit use_* flags
+    SEQUENTIAL = "sequential"  # forward iteration; cheapest streaming backend
+    RANDOM = "random"          # out-of-order / repeated access; prefer indexed backends
+
+archive = open_archive("big.tar.gz", access_intent=AccessIntent.RANDOM)
+# → archivey enables rapidgzip if installed; member_access_cost == LIMITED
+```
+
+`access_intent` is **resolved into the existing `use_*` flags** (one selection
+mechanism, not a parallel one). It is **best-effort**: explicit `use_*` flags stay
+mandatory (raise if their package is missing), but `RANDOM` falls back to the stdlib
+backend when an optional package is absent and lets the §E cost properties report the
+realized (`EXPENSIVE`) cost rather than raising. A format that simply cannot do cheap
+random access (solid 7z, single-block xz) likewise honors the request as best it can
+and reports the true cost. `streaming=True` together with `RANDOM` is contradictory
+and raises `ValueError`.
+
+Intent is the **request**; the §E cost properties are the **receipt**. A future
+follow-up could *warn* when intent cannot be honored (or when runtime access patterns
+contradict the declared intent), but that adds runtime tracking and is out of scope
+here.
 
 ---
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -693,10 +693,25 @@ random access (solid 7z, single-block xz) likewise honors the request as best it
 and reports the true cost. `streaming=True` together with `RANDOM` is contradictory
 and raises `ValueError`.
 
-Intent is the **request**; the §E cost properties are the **receipt**. A future
-follow-up could *warn* when intent cannot be honored (or when runtime access patterns
-contradict the declared intent), but that adds runtime tracking and is out of scope
-here.
+Intent is the **request**; the §E cost properties are the **receipt**.
+
+#### G. Inefficient-access warnings (opt-in)
+
+Some callers want to be *told* when they are using an archive badly rather than having
+to inspect the cost tier themselves. An **off-by-default** `warn_on_inefficient_access`
+flag enables a dedicated `InefficientAccessWarning`:
+
+- **at open** (the core, cheap case): when `access_intent=RANDOM` was requested but the
+  realized `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` — the preferred backend was
+  unavailable, the source is non-seekable, or the format simply cannot random-access
+  cheaply. The warning names the cause; the archive still opens and reads normally.
+- **at runtime** (secondary, may split into a follow-up): when repeated out-of-order
+  member access, or repeated re-decompressing backward seeks within a member, occur on
+  an `EXPENSIVE`-tier target — the O(N²) trap. This needs per-archive access-pattern
+  tracking, so it is the part most likely to move to its own change.
+
+Warnings are derived from the coarse `AccessCost` tier (not from measurement), are
+silent when the flag is off, and never change which bytes are returned.
 
 ---
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -694,14 +694,11 @@ member_access_cost(reader):            # per instance: reaching a member out of 
     else:                          -> EXPENSIVE          # solid 7z, single stream
 ```
 
-To guarantee `seek_cost` (and a `name`) is always present, all archivey streams
-share a common **`ArchiveyStream`** base (`io.RawIOBase, BinaryIO`). Streams handed
-back by third-party libraries (py7zr / rarfile / zipfile) are normalized into it at
-the existing `ensure_binaryio()` / `BinaryIOWrapper` wrap point — wrapping rather
-than annotating the raw object, since `setattr` on a foreign stream is fragile and
-only saves an allocation. Open questions: the exact metadata beyond `seek_cost` +
-`name` (back-reference to the `ArchiveMember`? `CompressionMethod`? `StreamFormat`?)
-and whether `ArchiveyStream` is public.
+Here, `seek_cost` is added to archivey's own stream classes. Guaranteeing it on
+*every* returned stream — including those handed back raw by third-party libraries
+(py7zr / rarfile / zipfile) — needs a shared, **public** `ArchiveyStream` base and a
+broader look at how archivey constructs and wraps streams in general. That is its own
+exploration (the `public-stream-interface` change), kept separate from the cost surface.
 
 #### F. Access intent — the input dual of the cost surface
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -693,25 +693,10 @@ random access (solid 7z, single-block xz) likewise honors the request as best it
 and reports the true cost. `streaming=True` together with `RANDOM` is contradictory
 and raises `ValueError`.
 
-Intent is the **request**; the §E cost properties are the **receipt**.
-
-#### G. Inefficient-access warnings (opt-in)
-
-Some callers want to be *told* when they are using an archive badly rather than having
-to inspect the cost tier themselves. An **off-by-default** `warn_on_inefficient_access`
-flag enables a dedicated `InefficientAccessWarning`:
-
-- **at open** (the core, cheap case): when `access_intent=RANDOM` was requested but the
-  realized `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` — the preferred backend was
-  unavailable, the source is non-seekable, or the format simply cannot random-access
-  cheaply. The warning names the cause; the archive still opens and reads normally.
-- **at runtime** (secondary, may split into a follow-up): when repeated out-of-order
-  member access, or repeated re-decompressing backward seeks within a member, occur on
-  an `EXPENSIVE`-tier target — the O(N²) trap. This needs per-archive access-pattern
-  tracking, so it is the part most likely to move to its own change.
-
-Warnings are derived from the coarse `AccessCost` tier (not from measurement), are
-silent when the flag is off, and never change which bytes are returned.
+Intent is the **request**; the §E cost properties are the **receipt**. A future
+follow-up could *warn* when intent cannot be honored (or when runtime access patterns
+contradict the declared intent), but that adds runtime tracking and is out of scope
+here.
 
 ---
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -591,10 +591,18 @@ The standalone `members_list_supported` boolean then disappears: it is precisely
 #### D. Typed compression method enum
 
 `ArchiveMember.compression_method` is an untyped string.  Adding a
-`CompressionMethod` enum (or `StrEnum`) with known values like `STORED`,
-`DEFLATE`, `LZMA`, `ZSTD`, `BZIP2`, `LZMA2`, `BCJ2`, `PPMD`, etc. and a
-fallback `UNKNOWN` would allow callers to make programmatic decisions without
-parsing strings.
+`CompressionMethod` enum (or `StrEnum`) with a fallback `UNKNOWN` would allow
+callers to make programmatic decisions without parsing strings. The enum must be
+**exhaustive over the formats archivey handles, not a sample**: a value for every
+`StreamFormat` — `STORED`, `DEFLATE` (gzip/zlib), `BZIP2`, `LZMA2` (xz), `LZMA`
+(lzip), `ZSTD`, `LZ4`, `BROTLI`, `LZW` (Unix `compress`) — **plus** the
+container-internal codecs that never appear standalone (`PPMD`, `BCJ2`,
+`DEFLATE64`, `DELTA`, …). A regression test should assert every `StreamFormat`
+resolves to a non-`UNKNOWN` codec, so adding a format without its codec fails CI.
+(The mapping is many-to-one: gzip and zlib both decode to `DEFLATE`; `StreamFormat`
+is the wrapper, `CompressionMethod` is the codec.) A multi-filter chain that a
+closed enum cannot express (7z `LZMA2 + BCJ2`) is preserved verbatim in a separate
+free-form `compression_method_detail`.
 
 #### E. Capability introspection
 
@@ -662,6 +670,38 @@ plain file), each of which reports its own tier. Readers whose access is a seek 
 such a stream (TAR) *read* that `seek_cost` rather than re-deriving it from
 `config.use_*` flags — one source of truth, and no drift (e.g. a multi-block
 `tar.xz` is correctly `LIMITED` instead of being mis-reported `EXPENSIVE`).
+
+The three properties are *derived from mechanism, never measured* (reading them
+does no I/O):
+
+```text
+member_listing_cost(reader):           # per instance: §C ClassVar + seekability
+    if not source.seekable():      -> SEQUENTIAL_ONLY
+    if has_central_directory:      -> INDEXED          # catalog one bounded seek away
+    else:                          -> SCAN_REQUIRED     # seekable, no catalog (TAR)
+
+seek_cost(stream):                     # per stream, fixed at construction
+    if not seekable():             -> UNAVAILABLE
+    if plain file / stored:        -> DIRECT
+    if intermediate seek points:   -> LIMITED           # rapidgzip, indexed_bzip2,
+                                                        #   multi-block xz/lzip
+    else:                          -> EXPENSIVE          # rewind / single block
+
+member_access_cost(reader):            # per instance: reaching a member out of order
+    if not random_access_possible: -> UNAVAILABLE       # streaming / non-seekable
+    if members from one stream:    -> decompressed_stream.seek_cost   # TAR
+    if stored independently:       -> DIRECT             # ZIP / stored
+    else:                          -> EXPENSIVE          # solid 7z, single stream
+```
+
+To guarantee `seek_cost` (and a `name`) is always present, all archivey streams
+share a common **`ArchiveyStream`** base (`io.RawIOBase, BinaryIO`). Streams handed
+back by third-party libraries (py7zr / rarfile / zipfile) are normalized into it at
+the existing `ensure_binaryio()` / `BinaryIOWrapper` wrap point — wrapping rather
+than annotating the raw object, since `setattr` on a foreign stream is fragile and
+only saves an allocation. Open questions: the exact metadata beyond `seek_cost` +
+`name` (back-reference to the `ArchiveMember`? `CompressionMethod`? `StreamFormat`?)
+and whether `ArchiveyStream` is public.
 
 #### F. Access intent — the input dual of the cost surface
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -670,33 +670,49 @@ responsible for *configuring* the backend that produces a good cost: to get chea
 random access on a `tar.gz` today you must already know to set `use_rapidgzip=True`.
 The low-level `use_*` flags leak archivey's cost model.
 
-**Proposed addition**: an `AccessIntent` enum and an `access_intent` parameter on
-`open_archive`, letting the caller state the *goal* and have archivey pick the
-backend:
+**Proposed addition** (split into its own `access-intent` change): an `AccessIntent`
+enum and an `access_intent` parameter on `open_archive`, letting the caller state the
+*goal* and have archivey pick the backend. It **replaces** the `streaming` /
+`streaming_only` parameters (forward-only use becomes `SEQUENTIAL`; the random-access
+default becomes `AUTO`):
 
 ```python
 class AccessIntent(StrEnum):
-    AUTO = "auto"              # default: today's behavior; honor explicit use_* flags
-    SEQUENTIAL = "sequential"  # forward iteration; cheapest streaming backend
-    RANDOM = "random"          # out-of-order / repeated access; prefer indexed backends
+    AUTO = "auto"              # default == old streaming=False; random methods on a
+                               #   seekable source, no optional backend enabled for you
+    SEQUENTIAL = "sequential"  # == old streaming=True; forward-only, accepts non-seekable
+    RANDOM = "random"          # out-of-order / within-member seeking; pay to make it cheap
 
 archive = open_archive("big.tar.gz", access_intent=AccessIntent.RANDOM)
 # → archivey enables rapidgzip if installed; member_access_cost == LIMITED
 ```
 
-`access_intent` is **resolved into the existing `use_*` flags** (one selection
-mechanism, not a parallel one). It is **best-effort**: explicit `use_*` flags stay
-mandatory (raise if their package is missing), but `RANDOM` falls back to the stdlib
-backend when an optional package is absent and lets the §E cost properties report the
-realized (`EXPENSIVE`) cost rather than raising. A format that simply cannot do cheap
-random access (solid 7z, single-block xz) likewise honors the request as best it can
-and reports the true cost. `streaming=True` together with `RANDOM` is contradictory
-and raises `ValueError`.
+**One axis for now**: `RANDOM` covers both reaching members out of order *and* seeking
+within a member. The cost surface already separates the two (`member_access_cost` vs
+`seek_cost`), so a within-member "content seek" facet can be added later (additively)
+when a reader differentiates on it — e.g. a native ZIP reader choosing rapidgzip *per
+member* only when the caller will seek inside files.
+
+**`AUTO` vs `RANDOM`** is "don't pay vs pay to make random access cheap": both expose
+random methods on a seekable source and both raise on a non-seekable one, but only
+`RANDOM` proactively activates `"auto"` seekable/indexed backends and tells the reader to
+keep seek points. `access_intent` is **resolved into the same backend selection** (one
+mechanism, not a parallel one) and is also handed to the reader so it can adapt strategy.
+
+The backend flags become **tri-state** (`True` / `False` / `"auto"`, default `"auto"`):
+`True` forces use (raises if the package is missing), `False` forbids it, `"auto"` uses it
+iff installed and the intent warrants it. The new default (`"auto"` + `AUTO`) activates
+nothing — identical to today's all-`False` default.
+
+Intent is **best-effort**: `RANDOM` falls back to the stdlib backend when an optional
+package is absent or the format cannot random-access cheaply (solid 7z, single-block xz),
+and the §E cost properties report the realized (`EXPENSIVE`) cost rather than raising.
+The one hard failure on account of intent is random access on a non-seekable source
+(impossible), preserving today's `streaming=False` behavior.
 
 Intent is the **request**; the §E cost properties are the **receipt**. A future
 follow-up could *warn* when intent cannot be honored (or when runtime access patterns
-contradict the declared intent), but that adds runtime tracking and is out of scope
-here.
+contradict the declared intent), but that adds runtime tracking and is out of scope.
 
 ---
 
@@ -719,8 +735,14 @@ Given the analysis above, the natural sequencing for work is:
    are done, the thread+queue pattern in 7z and the stream-reader pattern in
    RAR can be unified under a cleaner `_iter_members_and_streams()` hook.
 
-5. **`streaming_only` / capability refactor** (§8.B, §8.C, §8.E) — cosmetic
-   but improves the public API and clarifies the mental model for contributors.
+5. **Capability / cost-introspection refactor** (§8.B–§8.E,
+   `base-reader-architecture-extensions`) — adds the cost *receipt*
+   (`member_access_cost` / `seek_cost`, typed `CompressionMethod`); improves the public
+   API and clarifies the mental model for contributors.
+
+6. **Access intent** (§8.F, `access-intent`) — adds the *request* on top of the cost
+   surface: an `access_intent` parameter (replacing `streaming` / `streaming_only`) and
+   tri-state backend config. Lands after the cost refactor it depends on.
 
 ---
 

--- a/docs/format-architecture-comparison.md
+++ b/docs/format-architecture-comparison.md
@@ -563,7 +563,7 @@ only when its decompressor is genuinely non-seekable for this instance. The
 runtime streaming flag then means "user requested streaming OR format cannot
 random-access".
 
-#### C. `has_central_directory` ClassVar (replacing the `members_list_supported` argument)
+#### C. Catalog-location ClassVar (replacing the `members_list_supported` argument)
 
 Currently `members_list_supported` is passed to `__init__()` as a constructor
 argument. The name is misleading (it sounds like it returns the list) and it
@@ -571,19 +571,29 @@ conflates two things: a format fact and a runtime fact.
 
 Split them:
 
-- **"Does this *format* have a catalog/central directory?"** is a pure format-level
-  fact — `True` for ZIP/7z/RAR/ISO/folder, `False` for TAR. That genuinely belongs
-  on the class, as a clearly-named `ClassVar`:
+- **"Where does this *format* keep its member catalog?"** is a pure format-level
+  fact and belongs on the class, as a clearly-named `ClassVar`. A plain
+  `has_central_directory` bool is too coarse, because *where* the catalog lives
+  decides whether it is reachable without seeking:
   ```python
   class ZipReader(BaseArchiveReader):
-      has_central_directory = True
+      member_catalog = CatalogLocation.TRAILER   # end-of-file central directory
   ```
+  The locations are: **header-resident** (read while streaming forward),
+  **tail-resident** (ZIP's end-of-file central directory), **single-known-member**
+  (single-file streams), or **none** (TAR). The exact per-format mapping (e.g. whether
+  RAR/7z/ISO are header- or tail-resident) is confirmed per reader, notably when the
+  native readers land.
 - **"Can *this opened archive* be listed cheaply (`INDEXED`)?"** is the *realized*
-  cost, and it is **not** read from the ClassVar alone: a catalog at end-of-file is
-  only reachable when the source is seekable. So `member_listing_cost` (§E) is
-  computed per instance from `has_central_directory` **and** seekability — exactly the
-  same capability-vs-runtime split as §B. Deriving `INDEXED` from the ClassVar alone
-  is wrong for a catalog format opened from a non-seekable source.
+  cost, **not** read from the ClassVar alone: it depends on the location **and**
+  seekability. `INDEXED` when the catalog (or single member) is reachable without a
+  backward seek — a header catalog, a single-member stream, or a tail catalog on a
+  seekable source; `SCAN_REQUIRED` for a seekable no-catalog format; `SEQUENTIAL_ONLY`
+  otherwise. So a `.gz` single-member stream is `INDEXED` even on a pipe, and a
+  header-resident catalog can be `INDEXED` on a non-seekable source once a native reader
+  parses it forward (today's seek-requiring third-party readers raise at open instead).
+  This is the same capability-vs-runtime split as §B; deriving `INDEXED` from a "has a
+  catalog" bool alone is wrong on both seekability and location.
 
 The standalone `members_list_supported` boolean then disappears: it is precisely
 `member_listing_cost == INDEXED`.
@@ -675,10 +685,12 @@ The three properties are *derived from mechanism, never measured* (reading them
 does no I/O):
 
 ```text
-member_listing_cost(reader):           # per instance: §C ClassVar + seekability
-    if not source.seekable():      -> SEQUENTIAL_ONLY
-    if has_central_directory:      -> INDEXED          # catalog one bounded seek away
-    else:                          -> SCAN_REQUIRED     # seekable, no catalog (TAR)
+member_listing_cost(reader):           # per instance: catalog location (§C) + seekability
+    cat = member_catalog               # HEADER | TRAILER | SINGLE_MEMBER | NONE
+    if cat in (HEADER, SINGLE_MEMBER): -> INDEXED        # reachable forward, no back-seek
+    if cat == TRAILER:                 -> INDEXED if seekable else SEQUENTIAL_ONLY  # ZIP EOCD
+    # cat == NONE (TAR)
+    -> SCAN_REQUIRED if seekable else SEQUENTIAL_ONLY
 
 seek_cost(stream):                     # per stream, fixed at construction
     if not seekable():             -> UNAVAILABLE
@@ -687,12 +699,24 @@ seek_cost(stream):                     # per stream, fixed at construction
                                                         #   multi-block xz/lzip
     else:                          -> EXPENSIVE          # rewind / single block
 
+seek_cost_of(stream):                  # tolerant helper: not every stream is ours yet
+    if has attr seek_cost:         -> stream.seek_cost
+    if not seekable():             -> UNAVAILABLE
+    else:                          -> EXPENSIVE          # conservative; mechanism unknown
+
 member_access_cost(reader):            # per instance: reaching a member out of order
     if not random_access_possible: -> UNAVAILABLE       # streaming / non-seekable
-    if members from one stream:    -> decompressed_stream.seek_cost   # TAR
+    if members from one stream:    -> seek_cost_of(decompressed_stream)   # TAR
     if stored independently:       -> DIRECT             # ZIP / stored
     else:                          -> EXPENSIVE          # solid 7z, single stream
 ```
+
+So a `.gz` single-member stream lists `INDEXED` even on a pipe, and a header-resident
+catalog can list `INDEXED` from a non-seekable source once a reader parses it forward
+(today's seek-requiring third-party readers raise at open instead). The `seek_cost_of`
+helper is a deliberate stopgap for this phase, where some decompressor streams are still
+raw third-party objects without a `seek_cost`; it collapses into a direct read once the
+public `ArchiveyStream` base guarantees the property.
 
 Here, `seek_cost` is added to archivey's own stream classes. Guaranteeing it on
 *every* returned stream — including those handed back raw by third-party libraries

--- a/openspec/changes/access-intent/design.md
+++ b/openspec/changes/access-intent/design.md
@@ -1,0 +1,91 @@
+# Design
+
+Full rationale and per-format fit are in **`docs/format-architecture-comparison.md`**
+§8.E–§8.F. This file records the spec-facing decisions for the access-intent change.
+
+## Scope
+
+This is **§8.F**, split out of `base-reader-architecture-extensions` because it is a
+larger, externally-facing redesign (a new open-time input, removal of two parameters,
+and a tri-state config) that builds on the cost surface (`member_access_cost` /
+`seek_cost`) added there. It lands after that change.
+
+## Starting point (verified against current code)
+
+- `open_archive(streaming=False)` (the default) requires a seekable source and raises
+  `ArchiveStreamNotSeekableError` otherwise (`core.py:145`); `streaming=True` accepts a
+  non-seekable source and opens in forward-only "streaming mode".
+- `streaming` is already passed into the reader as `streaming_only=streaming`
+  (`core.py:212`), so a reader already receives the access mode — this change generalizes
+  that hand-off to the full intent.
+- `streaming_only` is already a deprecated alias (`archive-opening` spec).
+- The `use_*` flags are plain `bool`, default `False`; there is no auto-detection.
+
+## What is observable vs internal
+
+| Item | Observable? | Spec impact |
+|---|---|---|
+| `AccessIntent` enum + `access_intent` parameter (one axis) | **Yes** (new public input) | `archive-opening` |
+| Removal of `streaming` / `streaming_only` | **Yes** (breaking) | `archive-opening`, `archive-reading` |
+| Non-seekable-source rule rebinds to intent | **Yes** | `archive-opening` |
+| Tri-state backend flags (`True`/`False`/`"auto"`, default `"auto"`) | **Yes** | `configuration` |
+| `access_intent` → backend resolution | **Yes** | `configuration` |
+| Intent passed to the reader for strategy | No (internal hand-off; behavior captured by cost) | none directly |
+
+## Decisions
+
+- **One axis now; `RANDOM` means both** (member-level out-of-order access *and*
+  within-member seeking). The cost surface already separates the two
+  (`member_access_cost` vs `seek_cost`), so the model *can* grow a second intent facet,
+  but no current reader differentiates on within-member seeking — a ZIP gives cheap
+  across-member access from its central directory regardless of whether you seek inside
+  an entry. The case that would need the split (use rapidgzip *per member* only when the
+  caller will seek within files) arrives with the planned native ZIP reader; adding a
+  `content`-level facet then is a purely additive parameter, not a break. Building it now
+  would be speculative surface with no consumer.
+
+- **`AUTO` vs `RANDOM` is "don't pay vs pay to make random access cheap."** Both allow
+  random-access methods on a seekable source and both raise on a non-seekable one (so the
+  default's footgun-guard is preserved). They differ only in proactivity:
+  - `AUTO` (default): never enables an optional backend on the caller's behalf, so an
+    out-of-order open on a `tar.gz` just pays the stdlib rewind. Equivalent to today's
+    `streaming=False` with all `use_*` at their default.
+  - `RANDOM`: turns on `"auto"`-tagged seekable/indexed backends (rapidgzip,
+    indexed_bzip2, multi-block xz) **when installed**, and signals the reader to keep
+    seek points. This is the *only* intent under which an `"auto"` backend is activated.
+  - `SEQUENTIAL`: forward-only; prefers the cheapest streaming backend, skips eager index
+    building, and (like today's `streaming=True`) accepts a non-seekable source.
+
+- **Remove `streaming` and `streaming_only` outright** (not a deprecation alias —
+  `streaming_only` was already the deprecation step). The forward-only mode is unchanged;
+  only its entry point moves. Mapping is exact: `streaming=True` → `SEQUENTIAL`,
+  `streaming=False` → `AUTO`. The internal "streaming mode" concept and all its
+  `archive-reading` requirements (single-pass iteration, restricted `open()`/`extract()`)
+  stay; they are now entered by `SEQUENTIAL` or a non-seekable source. The existing
+  `archive-reading` scenarios that invoke `streaming=True`/`streaming=False` are reworded
+  mechanically to `access_intent="sequential"` / the default (see tasks).
+
+- **Tri-state backend config as `bool | Literal["auto"]`, default `"auto"`.** This matches
+  the requested "AUTO / true / false" ergonomically (`True`/`False` keep their meaning;
+  `"auto"` is the new default) without forcing callers onto an enum. `True` = force, raise
+  `PackageNotInstalledError` if missing (today's explicit-`True` behavior, unchanged);
+  `False` = never; `"auto"` = use iff installed and intent warrants it. **The new default
+  is behavior-preserving**: `"auto"` + default intent `AUTO` activates nothing, exactly
+  like today's all-`False` default. An optional backend is auto-activated only under
+  `RANDOM`. (A `LibraryUsage` `StrEnum` was considered; the `bool | "auto"` literal is
+  less ceremony and round-trips through the existing string-literal config conversion.)
+
+- **Intent resolves into the existing backend selection, and is also handed to the
+  reader.** `open_archive` computes an effective config from `access_intent` + the
+  tri-state flags and passes it down the unchanged stream-opening path (one selection
+  mechanism, not two). Separately, `access_intent` is passed to the reader constructor
+  (replacing the `streaming_only=streaming` hand-off) so a reader may adapt strategy —
+  e.g. build a seek-point index under `RANDOM`, skip it under `SEQUENTIAL`.
+
+- **Best-effort, with one hard failure.** Explicit `True` on a flag whose package is
+  missing still raises `PackageNotInstalledError`. `RANDOM` is otherwise a preference: a
+  missing optional package or a format that cannot random-access cheaply (solid 7z,
+  single-block xz) falls back, and `member_access_cost` / `seek_cost` report the realized
+  (`EXPENSIVE`) cost. The single intent that *raises* is random access on a **non-seekable
+  source** (`AUTO` or `RANDOM`), because it is genuinely impossible — preserving today's
+  `streaming=False` + non-seekable behavior.

--- a/openspec/changes/access-intent/proposal.md
+++ b/openspec/changes/access-intent/proposal.md
@@ -1,0 +1,116 @@
+# Access intent (§8.F)
+
+## Why
+
+`open_archive` today makes the caller speak in two awkward vocabularies at once:
+
+- a `streaming` boolean (plus its deprecated `streaming_only` alias) that **bundles two
+  unrelated things** — "I will only iterate forward" (an access *intent*) and "accept a
+  non-seekable source" (a fact about the input); and
+- low-level backend booleans (`use_rapidgzip`, `use_indexed_bzip2`, `use_python_xz`, …)
+  that leak archivey's cost model: to get cheap random access on a `tar.gz` you must
+  already know to set `use_rapidgzip=True`.
+
+The `base-reader-architecture-extensions` change adds the **cost receipt** —
+`member_access_cost` / `seek_cost` tell a caller *what they got*. This change adds the
+matching **request**: a single `access_intent` declaring *how the caller will use the
+archive*, and a **tri-state** backend config so an `AUTO` backend can be turned on (or
+not) to honor that intent. Intent is resolved into the existing backend-selection path,
+not a parallel one, and is also handed to the reader so a reader can adapt its own
+strategy (e.g. build vs. skip a seek-point index) — not just pick a backend.
+
+This replaces `streaming`/`streaming_only` outright: forward-only use becomes
+`access_intent=SEQUENTIAL`, and the random-access default becomes `access_intent=AUTO`.
+
+**Current state (verified):** `open_archive(streaming=False)` requires a seekable source
+(raises `ArchiveStreamNotSeekableError` otherwise) and passes `streaming_only=streaming`
+into the reader (`core.py:212`); `streaming_only` is already a deprecated alias
+(`archive-opening` spec). The `use_*` flags are plain `bool`, default `False` — there is
+no auto-detection and no `access_intent` input.
+
+## What Changes
+
+- **`AccessIntent` enum — one axis** *(public, new)*: a `StrEnum`
+  `AUTO` (default) / `SEQUENTIAL` / `RANDOM`. `RANDOM` covers **both** reaching members
+  out of order **and** seeking within a member's content — the two are treated as one
+  intent for now. (Splitting out a within-member "content seek" facet — relevant once a
+  native ZIP reader can opt into rapidgzip *per member* — is a future, purely additive
+  extension; see Non-Goals.)
+- **`access_intent` replaces `streaming` and `streaming_only`** *(public, breaking)*: both
+  parameters are **removed** from `open_archive`. The mapping is exact:
+  - old `streaming=True`  → `access_intent=SEQUENTIAL` (forward-only; non-seekable
+    sources accepted; random-access methods restricted as in streaming mode);
+  - old `streaming=False` (default) → `access_intent=AUTO` (random access on a seekable
+    source; a non-seekable source still raises `ArchiveStreamNotSeekableError`).
+- **`AUTO` vs `RANDOM`** — both expose random-access methods on a seekable source and
+  both raise on a non-seekable one; they differ only in **whether archivey proactively
+  pays to make random access cheap**. `AUTO` does the cheap thing and never enables an
+  optional backend on the caller's behalf (so default behavior is unchanged). `RANDOM`
+  turns on `AUTO`-tagged seekable/indexed backends (rapidgzip, indexed_bzip2, multi-block
+  xz) **when installed** and tells the reader to keep seek points. `SEQUENTIAL` favors the
+  cheapest streaming backend and skips eager index building.
+- **Intent is carried into the reader**, generalizing today's `streaming_only=streaming`
+  hand-off: the reader receives `access_intent` and may adapt its strategy (eager vs
+  lazy, build vs skip a seek index), in addition to backend selection.
+- **Tri-state backend config** *(public)*: each optional-backend flag (`use_rapidgzip`,
+  `use_indexed_bzip2`, `use_zstandard`, `use_python_xz`, `use_rar_stream`) accepts
+  `True` / `False` / `"auto"`, **default `"auto"`**:
+  - `True` = always use, raise `PackageNotInstalledError` if its package is missing
+    (unchanged from today's explicit `True`);
+  - `False` = never use;
+  - `"auto"` = use iff the package is installed **and** the resolved intent makes it
+    worthwhile (`RANDOM` enables a seekable/indexed backend; `AUTO`/`SEQUENTIAL` do not).
+  - The new default (`"auto"` + default intent `AUTO`) selects **no** optional backend —
+    identical to today's all-`False` default.
+- **`RANDOM` is best-effort and reported through cost**: if a preferred package is absent
+  or the format cannot random-access cheaply (solid 7z, single-block xz), archivey falls
+  back and the cost properties report the realized (`EXPENSIVE`) outcome rather than
+  raising. It raises only when random access is *impossible* (a non-seekable source).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `archive-opening`: adds the `access_intent` parameter and the `AccessIntent` enum,
+  removes `streaming` and `streaming_only`, and rebinds the non-seekable-source rule to
+  intent (`SEQUENTIAL` accepts a non-seekable source; `AUTO`/`RANDOM` raise).
+- `configuration`: the optional-backend flags become tri-state (`True`/`False`/`"auto"`,
+  default `"auto"`); adds the rule that `access_intent` resolves into that same backend
+  selection (`RANDOM` activates `"auto"` seekable/indexed backends; explicit `True`/`False`
+  override intent).
+- `archive-reading`: the forward-only "streaming mode" is now entered via
+  `access_intent=SEQUENTIAL` (or a non-seekable source) rather than `streaming=True`; the
+  mode's behavior is otherwise unchanged.
+
+## Non-Goals
+
+- **A separate within-member "content seek" facet.** `RANDOM` means both out-of-order
+  member access and within-member seeking for now. A second facet (e.g. choosing
+  rapidgzip *per ZIP member* only when the caller will seek inside files) becomes
+  load-bearing only when a reader differentiates on it (the planned native ZIP reader);
+  adding it later is additive (a new parameter / enum), not a breaking change.
+- **Access-pattern warnings.** Warning when realized usage contradicts the declared
+  intent (e.g. repeated backward seeks on an `EXPENSIVE` stream) needs runtime tracking
+  and is left for a possible future change.
+- **Measured cost or per-call prediction** — owned by the cost surface in
+  `base-reader-architecture-extensions`; intent is resolved by mechanism, not measurement.
+
+## Dependencies / Sequencing
+
+**Lands after `base-reader-architecture-extensions`** — `RANDOM`'s best-effort contract
+reports the realized outcome through `member_access_cost` / `seek_cost`, which that
+change introduces. No other change depends on this one; the native readers are
+unaffected (they gain intent handling for free via the shared reader hand-off).
+
+## Impact
+
+- **Files**: `core.py` (`open_archive`: remove `streaming`/`streaming_only`, add
+  `access_intent`, resolve it into an effective config, pass it to the reader; the
+  non-seekable check at `core.py:145` keys on intent), `config.py` (backend fields become
+  `bool | Literal["auto"]` default `"auto"`; `ConfigOverrides`; literal conversion),
+  `types.py` (`AccessIntent` enum), the backend-selection sites that read `config.use_*`
+  (`formats/compressed_streams.py`, `formats/xz_stream.py`, the gzip/bzip2/zstd backend
+  picks) so `"auto"` consults the resolved intent, `internal/base_reader.py` + the format
+  readers (accept and act on `access_intent`).
+- **Live specs touched**: `archive-opening`, `configuration`, `archive-reading`.
+- **Design reference**: `docs/format-architecture-comparison.md` §8.E–§8.F.

--- a/openspec/changes/access-intent/proposal.md
+++ b/openspec/changes/access-intent/proposal.md
@@ -102,6 +102,13 @@ reports the realized outcome through `member_access_cost` / `seek_cost`, which t
 change introduces. No other change depends on this one; the native readers are
 unaffected (they gain intent handling for free via the shared reader hand-off).
 
+Recommended order: `test-suite-parametrization` → `base-reader-architecture-extensions`
+→ **this change** → native readers (`rar-native-metadata-reader`, `sevenzip-native-reader`)
+→ `unify-junction-handling` → `public-stream-interface`. Sequence this change **early**
+(right after the cost foundation): it is the one **breaking** API change here (removing
+`streaming` / `streaming_only`), so the sooner it lands the fewer `streaming=` call sites
+accumulate to migrate.
+
 ## Impact
 
 - **Files**: `core.py` (`open_archive`: remove `streaming`/`streaming_only`, add

--- a/openspec/changes/access-intent/specs/archive-opening/spec.md
+++ b/openspec/changes/access-intent/specs/archive-opening/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: open_archive accepts an access_intent
+
+`open_archive()` SHALL accept an `access_intent` parameter — an `AccessIntent` value or
+the equivalent string literal (`"auto"`, `"sequential"`, `"random"`) — defaulting to
+`AccessIntent.AUTO`, declaring how the caller intends to access the archive. The value
+SHALL be passed to the reader so that both backend selection and reader strategy can
+honor it.
+
+- `AUTO` (default) — no declared pattern. Random-access methods are available when the
+  source is seekable; archivey SHALL NOT enable any optional backend on the caller's
+  behalf.
+- `SEQUENTIAL` — the caller will iterate forward only. The archive opens in streaming
+  (forward-only) mode; random-access methods are restricted as in streaming mode.
+- `RANDOM` — the caller will reach members out of order and/or seek within members.
+  archivey SHALL proactively prefer installed seekable/indexed backends that the
+  configuration permits, and SHALL signal the reader to retain seek points.
+
+The `streaming` and `streaming_only` parameters SHALL NOT exist; their behavior is
+expressed through `access_intent` (`streaming=True` → `SEQUENTIAL`; `streaming=False`,
+the previous default → `AUTO`).
+
+#### Scenario: Default access intent is AUTO
+- **WHEN** `open_archive(seekable_source)` is called without `access_intent`
+- **THEN** the archive opens with `AccessIntent.AUTO` and random-access methods are
+  available, and no optional backend is enabled implicitly
+
+#### Scenario: Sequential intent opens streaming mode
+- **WHEN** `open_archive(source, access_intent="sequential")` is called
+- **THEN** the archive opens in forward-only streaming mode
+
+#### Scenario: String literal is accepted
+- **WHEN** `open_archive(source, access_intent="random")` is called
+- **THEN** it is treated as `AccessIntent.RANDOM`
+
+#### Scenario: Removed streaming parameter is rejected
+- **WHEN** `open_archive(path, streaming=True)` is called
+- **THEN** a `TypeError` is raised (unexpected keyword argument), because `streaming`
+  has been removed in favor of `access_intent`
+
+## MODIFIED Requirements
+
+### Requirement: Non-seekable sources require streaming mode
+
+`open_archive()` SHALL raise `ArchiveStreamNotSeekableError` when opening from a stream
+that is not seekable while `access_intent` is `AUTO` (the default) or `RANDOM`, rather
+than attempting random access. Under `access_intent=SEQUENTIAL` a non-seekable source is
+accepted, except that it SHALL still raise `ArchiveStreamNotSeekableError` when the
+resolved format cannot operate on a non-seekable source (e.g. ZIP, which requires the
+end-of-central-directory record at the tail of the stream).
+
+#### Scenario: Non-seekable source without sequential intent
+- **WHEN** `open_archive(non_seekable_stream)` is called with the default intent (`AUTO`)
+  or `access_intent="random"`
+- **THEN** `ArchiveStreamNotSeekableError` is raised
+
+#### Scenario: Non-seekable source with sequential intent, format supports sequential reading
+- **WHEN** `open_archive(non_seekable_stream, access_intent="sequential")` is called and
+  the format supports sequential reading
+- **THEN** an `ArchiveReader` is returned in streaming mode
+
+#### Scenario: Non-seekable source with sequential intent, format cannot stream
+- **WHEN** `open_archive(non_seekable_stream, access_intent="sequential")` is called and
+  the resolved format cannot operate on a non-seekable source (such as ZIP)
+- **THEN** `ArchiveStreamNotSeekableError` is raised
+
+#### Scenario: Seekable source is rewound
+- **WHEN** a seekable stream is passed to `open_archive()`
+- **THEN** the stream is seeked to position 0 before reading begins
+
+## REMOVED Requirements
+
+### Requirement: streaming_only is a deprecated alias for streaming
+
+**Reason**: the `streaming` parameter is removed in favor of `access_intent`, so its
+already-deprecated alias `streaming_only` is removed together with it.
+
+**Migration**: replace `streaming_only=True` (or `streaming=True`) with
+`access_intent="sequential"`; the previous default `streaming=False` is the default
+`access_intent="auto"`.

--- a/openspec/changes/access-intent/specs/archive-reading/spec.md
+++ b/openspec/changes/access-intent/specs/archive-reading/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Streaming mode is selected by access intent
+
+The archive SHALL enter forward-only "streaming mode" when `access_intent=SEQUENTIAL` or
+when the source is non-seekable, and SHALL provide random access when `access_intent` is
+`AUTO` or `RANDOM` and the source is seekable. In streaming mode
+`iter_members_with_streams()` is usable for a single pass and the random-access methods
+`open()` / `extract()` / `get_members()` are restricted. The behavior of streaming mode
+SHALL be otherwise unchanged; all existing streaming-mode requirements apply regardless
+of how the mode was entered.
+
+This replaces `streaming=True` / `streaming=False` as the way streaming mode is selected;
+existing scenarios that referenced those parameters are reworded to the corresponding
+`access_intent` value.
+
+#### Scenario: Sequential intent enters streaming mode
+- **WHEN** an archive is opened with `access_intent="sequential"` from a seekable source
+- **THEN** it is in streaming mode: iteration is single-pass and `open()` raises
+  `ValueError`
+
+#### Scenario: Default intent provides random access
+- **WHEN** an archive is opened with the default intent (`AUTO`) from a seekable source
+- **THEN** random-access methods (`open()`, `get_members()`) are available
+
+#### Scenario: Non-seekable source forces streaming mode
+- **WHEN** an archive is opened with `access_intent="sequential"` from a non-seekable
+  source whose format supports sequential reading
+- **THEN** it is in streaming mode

--- a/openspec/changes/access-intent/specs/configuration/spec.md
+++ b/openspec/changes/access-intent/specs/configuration/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: ArchiveyConfig exposes documented behavior flags
+
+`ArchiveyConfig` SHALL provide the following fields with the stated defaults. The
+optional-backend selection flags `use_rapidgzip`, `use_indexed_bzip2`, `use_zstandard`,
+`use_python_xz`, and `use_rar_stream` SHALL each be **tri-state** — accepting `True`,
+`False`, or the string literal `"auto"` — with a default of `"auto"`. The remaining
+fields are unchanged: `use_single_file_stored_metadata` (False), `tar_check_integrity`
+(True), `overwrite_mode` (`OverwriteMode.ERROR`), and `extraction_filter`
+(`ExtractionFilter.DATA`).
+
+#### Scenario: Default configuration values
+- **WHEN** an `ArchiveyConfig()` is created with no arguments
+- **THEN** every optional-backend flag is `"auto"`, `use_single_file_stored_metadata` is
+  `False`, `tar_check_integrity` is `True`, `overwrite_mode` is `ERROR`, and
+  `extraction_filter` is `DATA`
+
+### Requirement: Optional-backend flags select alternative libraries
+
+The `use_*` backend flags SHALL select alternative backend libraries instead of the
+default implementation for their respective formats (rapidgzip for gzip, indexed_bzip2
+for bzip2, zstandard instead of pyzstd for zstd, python-xz for xz, and the
+unrar-streaming reader for RAR). Each flag is tri-state:
+
+- `True` — always use the alternative; raise `PackageNotInstalledError` if its package
+  is not installed.
+- `False` — never use the alternative; always fall back to the default implementation,
+  regardless of `access_intent`.
+- `"auto"` (default) — use the alternative **iff** its package is installed **and** the
+  resolved `access_intent` makes it worthwhile (`RANDOM` activates a seekable/indexed
+  backend; `AUTO` and `SEQUENTIAL` do not).
+
+#### Scenario: Forcing a backend on
+- **WHEN** `ArchiveyConfig(use_rapidgzip=True)` is used to open a gzip stream
+- **THEN** the rapidgzip backend is used instead of the stdlib gzip module (or
+  `PackageNotInstalledError` is raised if rapidgzip is not installed)
+
+#### Scenario: Forcing a backend off
+- **WHEN** `ArchiveyConfig(use_rapidgzip=False)` is used and the archive is opened with
+  `access_intent="random"`
+- **THEN** the stdlib gzip module is used (the explicit `False` overrides intent)
+
+#### Scenario: Auto activates under RANDOM intent
+- **WHEN** the default `use_rapidgzip="auto"` is in effect, rapidgzip is installed, and a
+  gzip-compressed archive is opened with `access_intent="random"`
+- **THEN** the rapidgzip backend is used
+
+#### Scenario: Auto stays off without RANDOM intent
+- **WHEN** the default `use_rapidgzip="auto"` is in effect and an archive is opened with
+  the default intent (`AUTO`)
+- **THEN** the stdlib gzip module is used (no optional backend is activated)
+
+## ADDED Requirements
+
+### Requirement: access_intent resolves into backend selection
+
+`access_intent` SHALL be resolved into the same backend selection governed by the `use_*`
+configuration — a high-level shorthand over one selection mechanism, not a parallel one.
+For a flag left at `"auto"`, the resolved choice SHALL depend on intent: `RANDOM` enables
+an installed seekable/indexed backend; `AUTO` and `SEQUENTIAL` do not enable it. A flag
+set explicitly to `True` or `False` SHALL override intent (force or forbid). Resolution
+SHALL be best-effort: when `RANDOM` cannot be honored — a preferred package is absent, or
+the format cannot random-access cheaply (a solid 7z, a single-block xz) — archivey SHALL
+fall back to an available backend and the cost properties (`member_access_cost`,
+`seek_cost`) SHALL report the realized cost rather than raising. archivey SHALL raise
+solely on account of intent only when random access is impossible because the source is
+non-seekable.
+
+#### Scenario: RANDOM enables an installed auto backend
+- **WHEN** a `tar.gz` is opened with `access_intent="random"`, rapidgzip is installed,
+  and the configuration is left at defaults
+- **THEN** the rapidgzip backend is used and `member_access_cost` is `AccessCost.LIMITED`
+
+#### Scenario: RANDOM falls back when the package is missing
+- **WHEN** a `tar.gz` is opened with `access_intent="random"` but rapidgzip is not
+  installed
+- **THEN** the stdlib backend is used, `member_access_cost` is `AccessCost.EXPENSIVE`,
+  and no exception is raised
+
+#### Scenario: Explicit False overrides RANDOM
+- **WHEN** a `tar.gz` is opened with `use_rapidgzip=False` and `access_intent="random"`
+- **THEN** the stdlib backend is used
+
+#### Scenario: Default intent selects no optional backend
+- **WHEN** a `tar.gz` is opened with the default configuration and default intent
+- **THEN** no optional backend is selected (behavior identical to the previous all-`False`
+  default)

--- a/openspec/changes/access-intent/tasks.md
+++ b/openspec/changes/access-intent/tasks.md
@@ -1,0 +1,49 @@
+# Implementation Tasks: Access intent (§8.F)
+
+> Depends on `base-reader-architecture-extensions` (cost surface: `member_access_cost`,
+> `seek_cost`). Land after it.
+
+## 1. AccessIntent enum and the open parameter
+
+- [ ] 1.1 Add an `AccessIntent` `StrEnum` (`AUTO` / `SEQUENTIAL` / `RANDOM`) to `types.py`
+- [ ] 1.2 Add an `access_intent` parameter to `open_archive` (default `AccessIntent.AUTO`,
+      accepting the string literal `"auto"`/`"sequential"`/`"random"` too)
+- [ ] 1.3 Pass `access_intent` into the reader constructor in place of
+      `streaming_only=streaming` (`core.py:212`); derive forward-only mode from
+      `access_intent == SEQUENTIAL` or a non-seekable source
+
+## 2. Remove streaming / streaming_only
+
+- [ ] 2.1 Remove the `streaming` and `streaming_only` parameters from `open_archive`
+- [ ] 2.2 Rebind the non-seekable-source check (`core.py:145`): raise
+      `ArchiveStreamNotSeekableError` when the source is non-seekable and intent is
+      `AUTO` or `RANDOM`; accept it under `SEQUENTIAL` (raising only if the format cannot
+      operate sequentially)
+- [ ] 2.3 Migrate internal callers, tests, docs, and CLI from `streaming=` to
+      `access_intent=` (`streaming=True` → `"sequential"`, `streaming=False` → default)
+
+## 3. Tri-state backend configuration
+
+- [ ] 3.1 Change the optional-backend fields (`use_rapidgzip`, `use_indexed_bzip2`,
+      `use_zstandard`, `use_python_xz`, `use_rar_stream`) to `bool | Literal["auto"]`,
+      default `"auto"`; update `ConfigOverrides` and the string-literal conversion
+- [ ] 3.2 At each backend-selection site (gzip/bzip2/zstd/xz/rar picks), implement the
+      tri-state: `True` = use or raise `PackageNotInstalledError`; `False` = never;
+      `"auto"` = use iff installed **and** the resolved intent warrants it
+- [ ] 3.3 Resolve `access_intent` into the effective backend choice: `RANDOM` activates an
+      installed `"auto"` seekable/indexed backend; `AUTO`/`SEQUENTIAL` do not; explicit
+      `True`/`False` override intent. Verify default (`"auto"` + `AUTO`) selects no
+      optional backend (behavior-preserving)
+
+## 4. Best-effort semantics
+
+- [ ] 4.1 Make `RANDOM` fall back (no raise) when a preferred optional package is missing
+      or the format cannot random-access cheaply, leaving `member_access_cost` /
+      `seek_cost` to report the realized (`EXPENSIVE`) outcome
+- [ ] 4.2 Keep explicit `True` flags mandatory (still raise `PackageNotInstalledError`)
+
+## 5. Validation
+
+- [ ] 5.1 `openspec validate access-intent --type change --strict`
+- [ ] 5.2 `hatch run lint` and `hatch run test`; confirm the default open path is
+      byte-for-byte unchanged (no optional backend activated without `RANDOM`)

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -73,32 +73,41 @@ regression contract). §8.F (access intent) is specified in the separate
   (§8.B). Whether a compressed TAR can random-access is decided at construction by
   the decompressor backend (stdlib-on-pipe vs stdlib-on-file vs
   rapidgzip/indexed_bzip2), so it is set in `__init__`, not declared on the class.
-- **The catalog *location* is a `ClassVar`; the realized listing cost is not**
-  (§8.C). This splits a capability from a runtime fact, exactly as §8.B does for
-  random access:
-  - A `ClassVar` names the pure **format** fact — *where* this format keeps its member
-    catalog: header-resident (read while streaming forward), tail-resident (ZIP's
-    end-of-file central directory), a single-known-member stream, or no catalog (TAR).
-    This generalizes the bool `has_central_directory` PR #221 used: "has a catalog" is
-    too coarse, because *where* the catalog lives decides whether it is reachable on a
-    non-seekable source. (The exact per-format mapping — e.g. whether RAR/7z/ISO are
-    header- or tail-resident — is settled per reader, notably when the native readers
-    land; the model only needs the location, not a fixed list here.)
-  - **`member_listing_cost` is computed per instance** from that location **and**
-    seekability, because reachability depends on both. The rule: `INDEXED` when the
-    catalog (or single known member) is reachable **without a backward seek** — a
+- **The catalog *location* is determined per instance; the realized listing cost is not
+  a pure `ClassVar`** (§8.C). This splits a capability from a runtime fact, exactly as
+  §8.B does for random access:
+  - The reader determines, **at open**, where (if anywhere) an upfront member catalog
+    sits and whether it is reachable: header-resident (read while streaming forward),
+    tail-resident (ZIP's end-of-file central directory), a single-known-member stream,
+    or none (members discovered only by scanning, as in TAR). This generalizes the bool
+    `has_central_directory` PR #221 used — "has a catalog" is too coarse, because *where*
+    the catalog lives decides reachability on a non-seekable source.
+  - **It is not purely a `ClassVar`, because for some formats the location is per-file.**
+    RAR is the clear case: its member headers precede each file (no front index), and an
+    upfront catalog exists only when the optional **"quick open" service block** — an
+    index at the *end* of the archive — is present. So a given `.rar` is tail-indexed
+    when that block is present and reachable, and otherwise scan/sequential. A `ClassVar`
+    can carry a baseline where a format's layout is uniform (ZIP is always TRAILER, TAR
+    always NONE), but the realized location is decided at open by inspection where it
+    varies. (The exact per-format mapping — RAR/7z/ISO included — is settled per reader,
+    notably when the native readers land; the model only needs the per-instance location,
+    not a fixed list here.)
+  - **`member_listing_cost` is computed per instance** from that realized location
+    **and** seekability, because reachability depends on both. The rule: `INDEXED` when
+    the catalog (or single known member) is reachable **without a backward seek** — a
     header-resident catalog, a single-member stream, or a tail-resident catalog on a
-    *seekable* source; `SCAN_REQUIRED` when there is no catalog but the source is
-    seekable (a TAR that can be scanned); `SEQUENTIAL_ONLY` when there is no catalog and
-    the source is non-seekable. So a `.gz` single-member stream is `INDEXED` even on a
-    pipe, and a header-resident catalog can be `INDEXED` on a non-seekable source once a
-    reader can parse it forward (today's third-party readers that require seeking raise
-    at open instead — see `archive-opening`). The user's `streaming=True` preference does
-    **not** by itself downgrade listing while the catalog stays reachable.
+    *seekable* source; `SCAN_REQUIRED` when there is no upfront catalog but the source is
+    seekable (a TAR, or a RAR with no quick-open block, that can be scanned);
+    `SEQUENTIAL_ONLY` when there is no upfront catalog and the source is non-seekable. So
+    a `.gz` single-member stream is `INDEXED` even on a pipe, and a header-resident
+    catalog can be `INDEXED` on a non-seekable source once a reader can parse it forward
+    (today's third-party readers that require seeking raise at open instead — see
+    `archive-opening`). The user's `streaming=True` preference does **not** by itself
+    downgrade listing while the catalog stays reachable.
   - The standalone `members_list_supported` boolean is dropped: it is now exactly
     `member_listing_cost == INDEXED`. Deriving `INDEXED` from a "has a catalog" bool
-    alone (as PR #221 did) is the bug this split fixes — it ignores both seekability and
-    catalog location.
+    alone (as PR #221 did) is the bug this split fixes — it ignores seekability, catalog
+    location, *and* per-file variation like RAR's optional index.
 - **Cost introspection is redesigned around two orthogonal axes, each a
   cost-classifying enum** (§8.E), because the old `streaming` / `has_random_access()`
   / "member list supported" set conflated listing cost, access cost, and the user's
@@ -164,12 +173,14 @@ regression contract). §8.F (access intent) is specified in the separate
     ```text
     # member_listing_cost — per reader instance, from catalog location (§C) + seekability
     def member_listing_cost(self):
-        cat = type(self).member_catalog            # HEADER | TRAILER | SINGLE_MEMBER | NONE
+        cat = self.member_catalog          # HEADER | TRAILER | SINGLE_MEMBER | NONE;
+                                           #   ClassVar where uniform, else decided at open
+                                           #   (e.g. RAR: TRAILER iff quick-open index present)
         if cat in (HEADER, SINGLE_MEMBER):    return INDEXED        # reachable forward, no
                                                                    #   backward seek needed
-        if cat == TRAILER:                                          # ZIP end-of-file catalog
+        if cat == TRAILER:                                          # ZIP EOCD / RAR quick-open
             return INDEXED if self.source.seekable() else SEQUENTIAL_ONLY
-        # cat == NONE  (TAR: no catalog)
+        # cat == NONE  (TAR, or RAR without a quick-open index)
         return SCAN_REQUIRED if self.source.seekable() else SEQUENTIAL_ONLY
 
     # seek_cost — per decompressor / seekable stream, fixed at construction

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -51,6 +51,17 @@ regression contract). §8.F (access intent) is specified in the separate
   remains optional (`None` when the format doesn't report it). The enum names the
   recognized **primary** codec; when the format reports a codec we don't map, it is
   `UNKNOWN` rather than `None`.
+- **The enum is exhaustive over the formats Archivey handles, not a sample.** PR #221
+  added only the codecs that appeared as examples; this is a bug-in-waiting. The enum
+  SHALL carry a value for **every `StreamFormat` member** — `STORED`/uncompressed,
+  `DEFLATE` (gzip, zlib), `BZIP2`, `XZ`/`LZMA2` (xz), `LZMA` (lzip), `ZSTD`, `LZ4`,
+  `BROTLI` (the one PR #221 missed), `LZW` (Unix `compress`, `StreamFormat.UNIX_COMPRESS`)
+  — **plus** the container-internal codecs that never appear as a standalone stream
+  (`LZMA`, `PPMD`, `BCJ2`, `DEFLATE64`, `DELTA`, …) used by ZIP/7z/RAR. A regression test
+  SHALL assert that every `StreamFormat` resolves to a non-`UNKNOWN` `CompressionMethod`,
+  so adding a new `StreamFormat` without its codec fails CI. (Note the mapping is
+  many-to-one: gzip and zlib both decode to `DEFLATE`; `StreamFormat` is the wrapper,
+  `CompressionMethod` is the codec.)
 - **Lossless detail is preserved separately (Design A).** A closed enum can't
   represent 7z filter chains (`"LZMA2 + BCJ2 + Delta"`) or a third-party reader's
   own codec name, so the verbatim/full description is kept in a free-form
@@ -140,6 +151,58 @@ regression contract). §8.F (access intent) is specified in the separate
     triggers a `SCAN_REQUIRED` pass** (that is `get_members()`'s job) — aligning the
     method with its already-documented "avoids full traversal" contract, which the
     current code violates for seekable TAR.
+  - **Computing the cost properties (pseudocode).** All three are *derived from
+    mechanism*, never measured; reading them does no I/O. The algorithm:
+
+    ```text
+    # member_listing_cost — per reader instance, from the §C ClassVar + seekability
+    def member_listing_cost(self):
+        if not self.source.seekable():        return SEQUENTIAL_ONLY
+        if type(self).has_central_directory:  return INDEXED        # catalog 1 seek away
+        return SCAN_REQUIRED                                        # seekable, no catalog (TAR)
+
+    # seek_cost — per decompressor / seekable stream, fixed at construction
+    def seek_cost(self):
+        if not self.seekable():               return UNAVAILABLE    # forward-only source
+        if self.is_plain_file_or_stored:      return DIRECT         # true random access
+        if self.has_intermediate_seek_points: return LIMITED        # rapidgzip, indexed_bzip2,
+                                                                    #   multi-block xz/lzip
+        return EXPENSIVE                                            # rewind-from-start / 1 block
+
+    # member_access_cost — per reader instance; reaching a member out of order
+    def member_access_cost(self):
+        if not self.member_random_access_possible:  return UNAVAILABLE  # streaming / non-seekable
+        if self.serves_members_from_decompressed_stream:               # TAR: a member IS a
+            return self.decompressed_stream.seek_cost                  #   seek on that stream
+        if self.members_stored_independently_seekably:  return DIRECT  # ZIP / stored entries
+        return EXPENSIVE                                               # solid 7z, single stream
+    ```
+
+    The single source of truth for `LIMITED`/`EXPENSIVE` is the stream's own `seek_cost`
+    (the `has_intermediate_seek_points` line); TAR reads it rather than re-deriving from
+    `config.use_*`, which is the PR-#221 bug above.
+  - **All returned streams share a common Archivey base carrying `seek_cost` and a
+    `name`.** Today each archivey stream class (`ArchiveStream`, `DecompressorStream`,
+    `BinaryIOWrapper`, …) independently subclasses `io.RawIOBase, BinaryIO`, and a stream
+    handed back from a third-party library (py7zr / rarfile / zipfile) may not be an
+    archivey type at all — so nothing *guarantees* `seek_cost` is present on a returned
+    stream. This change introduces a shared base — `ArchiveyStream` (subclass of
+    `io.RawIOBase, BinaryIO`) — declaring `seek_cost: AccessCost` (kept consistent with
+    `seekable()`) and `name: str | None` (the member path / source name, mirroring stdlib
+    file objects' `.name`). The existing classes inherit it, and **every** stream archivey
+    returns from `open()` / `iter_members_with_streams()` is an `ArchiveyStream`.
+    - **Foreign streams are normalised at the existing wrap point.** Library streams
+      already pass through `ensure_binaryio()` / `BinaryIOWrapper` (`internal/io_helpers.py`)
+      to satisfy the `BinaryIO` protocol; making that wrapper an `ArchiveyStream` means
+      carrying `seek_cost` / `name` is free wherever a wrapper is already built.
+      **Recommendation: wrap, don't annotate** — `setattr`-ing `seek_cost` onto the raw
+      third-party object is fragile (`__slots__`, immutable handles) and only saves one
+      allocation; annotating-in-place is left as a profiled optimization if the wrapper
+      is ever shown to be a hotspot.
+    - **Open questions (for review):** the exact metadata beyond `seek_cost` + `name`
+      (candidates: a back-reference to the `ArchiveMember`, the member's
+      `CompressionMethod`, the source `StreamFormat`), and whether `ArchiveyStream` is a
+      public type or internal-only.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -73,25 +73,32 @@ regression contract). §8.F (access intent) is specified in the separate
   (§8.B). Whether a compressed TAR can random-access is decided at construction by
   the decompressor backend (stdlib-on-pipe vs stdlib-on-file vs
   rapidgzip/indexed_bzip2), so it is set in `__init__`, not declared on the class.
-- **`has_central_directory` is a `ClassVar`; the realized listing cost is not**
+- **The catalog *location* is a `ClassVar`; the realized listing cost is not**
   (§8.C). This splits a capability from a runtime fact, exactly as §8.B does for
   random access:
-  - `has_central_directory: ClassVar[bool]` names the pure **format** fact — does this
-    format carry a catalog/central directory at all? `True` for ZIP/7z/RAR/ISO/folder,
-    `False` for TAR. As a class fact it is honestly a `ClassVar`, and the name says
-    what it means (unlike `members_list_supported`, which sounded like it returned the
-    list and hid the seekability dependency).
-  - **`member_listing_cost` is computed per instance**, because a catalog sitting at
-    end-of-file is only `INDEXED` if the source is *seekable*. The rule is
-    `INDEXED` when `has_central_directory` **and the source is seekable**;
-    `SCAN_REQUIRED` when there is no catalog but the source is seekable (a TAR that can
-    be scanned); `SEQUENTIAL_ONLY` when the source is non-seekable. The user's
-    `streaming=True` preference does **not** by itself downgrade listing for a seekable
-    catalog format (the catalog is still one seek away — see the independence scenario
-    in the spec).
+  - A `ClassVar` names the pure **format** fact — *where* this format keeps its member
+    catalog: header-resident (read while streaming forward), tail-resident (ZIP's
+    end-of-file central directory), a single-known-member stream, or no catalog (TAR).
+    This generalizes the bool `has_central_directory` PR #221 used: "has a catalog" is
+    too coarse, because *where* the catalog lives decides whether it is reachable on a
+    non-seekable source. (The exact per-format mapping — e.g. whether RAR/7z/ISO are
+    header- or tail-resident — is settled per reader, notably when the native readers
+    land; the model only needs the location, not a fixed list here.)
+  - **`member_listing_cost` is computed per instance** from that location **and**
+    seekability, because reachability depends on both. The rule: `INDEXED` when the
+    catalog (or single known member) is reachable **without a backward seek** — a
+    header-resident catalog, a single-member stream, or a tail-resident catalog on a
+    *seekable* source; `SCAN_REQUIRED` when there is no catalog but the source is
+    seekable (a TAR that can be scanned); `SEQUENTIAL_ONLY` when there is no catalog and
+    the source is non-seekable. So a `.gz` single-member stream is `INDEXED` even on a
+    pipe, and a header-resident catalog can be `INDEXED` on a non-seekable source once a
+    reader can parse it forward (today's third-party readers that require seeking raise
+    at open instead — see `archive-opening`). The user's `streaming=True` preference does
+    **not** by itself downgrade listing while the catalog stays reachable.
   - The standalone `members_list_supported` boolean is dropped: it is now exactly
-    `member_listing_cost == INDEXED`. Deriving `INDEXED` from the `ClassVar` alone (as
-    PR #221 did) is the bug this split fixes.
+    `member_listing_cost == INDEXED`. Deriving `INDEXED` from a "has a catalog" bool
+    alone (as PR #221 did) is the bug this split fixes — it ignores both seekability and
+    catalog location.
 - **Cost introspection is redesigned around two orthogonal axes, each a
   cost-classifying enum** (§8.E), because the old `streaming` / `has_random_access()`
   / "member list supported" set conflated listing cost, access cost, and the user's
@@ -155,11 +162,15 @@ regression contract). §8.F (access intent) is specified in the separate
     mechanism*, never measured; reading them does no I/O. The algorithm:
 
     ```text
-    # member_listing_cost — per reader instance, from the §C ClassVar + seekability
+    # member_listing_cost — per reader instance, from catalog location (§C) + seekability
     def member_listing_cost(self):
-        if not self.source.seekable():        return SEQUENTIAL_ONLY
-        if type(self).has_central_directory:  return INDEXED        # catalog 1 seek away
-        return SCAN_REQUIRED                                        # seekable, no catalog (TAR)
+        cat = type(self).member_catalog            # HEADER | TRAILER | SINGLE_MEMBER | NONE
+        if cat in (HEADER, SINGLE_MEMBER):    return INDEXED        # reachable forward, no
+                                                                   #   backward seek needed
+        if cat == TRAILER:                                          # ZIP end-of-file catalog
+            return INDEXED if self.source.seekable() else SEQUENTIAL_ONLY
+        # cat == NONE  (TAR: no catalog)
+        return SCAN_REQUIRED if self.source.seekable() else SEQUENTIAL_ONLY
 
     # seek_cost — per decompressor / seekable stream, fixed at construction
     def seek_cost(self):
@@ -169,18 +180,33 @@ regression contract). §8.F (access intent) is specified in the separate
                                                                     #   multi-block xz/lzip
         return EXPENSIVE                                            # rewind-from-start / 1 block
 
+    # seek_cost_of(stream) — tolerant helper, since not every stream is ours yet
+    def seek_cost_of(stream):
+        if hasattr(stream, "seek_cost"):      return stream.seek_cost
+        if not stream.seekable():             return UNAVAILABLE
+        return EXPENSIVE                       # conservative: seekable, mechanism unknown
+
     # member_access_cost — per reader instance; reaching a member out of order
     def member_access_cost(self):
         if not self.member_random_access_possible:  return UNAVAILABLE  # streaming / non-seekable
-        if self.serves_members_from_decompressed_stream:               # TAR: a member IS a
-            return self.decompressed_stream.seek_cost                  #   seek on that stream
-        if self.members_stored_independently_seekably:  return DIRECT  # ZIP / stored entries
-        return EXPENSIVE                                               # solid 7z, single stream
+        if self.serves_members_from_decompressed_stream:                # TAR: a member IS a
+            return seek_cost_of(self.decompressed_stream)               #   seek on that stream
+        if self.members_stored_independently_seekably:  return DIRECT   # ZIP / stored entries
+        return EXPENSIVE                                                # solid 7z, single stream
     ```
 
     The single source of truth for `LIMITED`/`EXPENSIVE` is the stream's own `seek_cost`
-    (the `has_intermediate_seek_points` line); TAR reads it rather than re-deriving from
-    `config.use_*`, which is the PR-#221 bug above.
+    (the `has_intermediate_seek_points` line); TAR reads it via `seek_cost_of(...)` rather
+    than re-deriving from `config.use_*`, which is the PR-#221 bug above.
+  - **`seek_cost` is read through a tolerant helper in this phase.** Because not every
+    decompressor/member stream is an Archivey type yet — some are raw third-party streams
+    with no `seek_cost` — readers MUST NOT assume the attribute exists. The `seek_cost_of`
+    helper above returns the stream's `seek_cost` when present and otherwise a conservative
+    estimate from its type / `seekable()` (seekable-but-unknown → `EXPENSIVE`,
+    non-seekable → `UNAVAILABLE`). This is a deliberate stopgap: once the public
+    `ArchiveyStream` base (the `public-stream-interface` change) guarantees `seek_cost` on
+    every returned stream, the helper collapses into a direct read. Erring toward
+    `EXPENSIVE` is safe — it never over-promises cheap random access.
   - **`seek_cost` is added to archivey's own stream classes here** (the per-member
     `ArchiveStream` and each decompressor stream). Guaranteeing it on *every* returned
     stream — including those handed back raw by third-party libraries — needs a shared,

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -6,31 +6,41 @@ decisions.
 
 ## Scope (and what moved out)
 
-This change is **§8.B–§8.E**. §8.A (the 7z/RAR co-iteration migration) is a pure
-refactor with no spec delta and is handled inside the native-reader changes, which
-already rewrite those readers; see the note under Decisions.
+This change is **§8.B–§8.F** (§8.F — access intent — is new, not in the original doc
+list). §8.A (the 7z/RAR co-iteration migration) is a pure refactor with no spec delta
+and is handled inside the native-reader changes, which already rewrite those readers;
+see the note under Decisions.
 
 ## Starting point (verified against current code)
 
-- **§8.B–E**: not implemented. `compression_method` is `Optional[str]`,
+- **§8.B–F**: not implemented. `compression_method` is `Optional[str]`,
   `members_list_supported` is a constructor argument, there is no
-  `_format_supports_random_access` flag, and the only capability accessor is the
-  `has_random_access()` method.
+  `_format_supports_random_access` flag, the only capability accessor is the
+  `has_random_access()` method, and there is no `access_intent` input (callers set the
+  `use_*` backend flags by hand).
 - **§8.A** (for reference): the hook `_iter_members_and_streams_internal()` already
   exists in `base_reader.py` (added in #209) and `iter_members_with_streams()` routes
   through it with central filtering; `SevenZipReader`/`RarReader` still override the
   public method. Migrating them onto the hook is owned by the native-reader changes.
+- **PR #221 (`claude/gracious-tesla-lg0VK`)** is a draft implementation reviewed while
+  writing this change. Two defects it surfaced are now pinned down by the decisions
+  below: (1) it made `members_list_supported` a `ClassVar` and derived `INDEXED` from
+  it alone, ignoring seekability; (2) it added `seek_cost` to the per-member
+  `ArchiveStream` but **not** to the underlying decompressor streams, forcing
+  `TarReader` to re-derive the cost from `config.use_*` flags (which already
+  mis-reports multi-block `tar.xz`).
 
 ## What is observable vs internal
 
 | Item | Observable? | Spec impact |
 |---|---|---|
 | §8.B `_format_supports_random_access` (per-instance flag) | No (same errors/modes) | none |
-| §8.C `members_list_supported` as ClassVar | No | none |
+| §8.C `has_central_directory` ClassVar (replaces `members_list_supported` arg) | No (listing cost unchanged where reachable) | none directly; feeds §8.E |
 | §8.D `CompressionMethod` enum | **Yes** (`compression_method` value type) | `archive-metadata` |
-| §8.E capability introspection (`MemberListingCost` + `AccessCost` enums, `member_listing_cost` / `member_access_cost`, add stream `seek_cost` alongside `seekable()`, drop `has_random_access`) | **Yes** (public API surface change) | `archive-reading` |
+| §8.E cost introspection (`MemberListingCost` + `AccessCost` enums, `member_listing_cost` / `member_access_cost`, stream + decompressor `seek_cost` alongside `seekable()`, drop `has_random_access`) | **Yes** (public API surface change) | `archive-reading` |
+| §8.F `AccessIntent` enum + `access_intent` open parameter | **Yes** (new public input; affects backend selection) | `archive-reading` |
 
-So only §8.D and §8.E get delta specs; §8.B/§8.C are captured as tasks because they
+So §8.D, §8.E and §8.F get delta specs; §8.B/§8.C are captured as tasks because they
 must not change behavior (the existing `archive-reading` requirements are the
 regression contract).
 
@@ -52,16 +62,34 @@ regression contract).
   (§8.B). Whether a compressed TAR can random-access is decided at construction by
   the decompressor backend (stdlib-on-pipe vs stdlib-on-file vs
   rapidgzip/indexed_bzip2), so it is set in `__init__`, not declared on the class.
-- **Capability introspection is redesigned around two orthogonal axes, each a
+- **`has_central_directory` is a `ClassVar`; the realized listing cost is not**
+  (§8.C). This splits a capability from a runtime fact, exactly as §8.B does for
+  random access:
+  - `has_central_directory: ClassVar[bool]` names the pure **format** fact — does this
+    format carry a catalog/central directory at all? `True` for ZIP/7z/RAR/ISO/folder,
+    `False` for TAR. As a class fact it is honestly a `ClassVar`, and the name says
+    what it means (unlike `members_list_supported`, which sounded like it returned the
+    list and hid the seekability dependency).
+  - **`member_listing_cost` is computed per instance**, because a catalog sitting at
+    end-of-file is only `INDEXED` if the source is *seekable*. The rule is
+    `INDEXED` when `has_central_directory` **and the source is seekable**;
+    `SCAN_REQUIRED` when there is no catalog but the source is seekable (a TAR that can
+    be scanned); `SEQUENTIAL_ONLY` when the source is non-seekable. The user's
+    `streaming=True` preference does **not** by itself downgrade listing for a seekable
+    catalog format (the catalog is still one seek away — see the independence scenario
+    in the spec).
+  - The standalone `members_list_supported` boolean is dropped: it is now exactly
+    `member_listing_cost == INDEXED`. Deriving `INDEXED` from the `ClassVar` alone (as
+    PR #221 did) is the bug this split fixes.
+- **Cost introspection is redesigned around two orthogonal axes, each a
   cost-classifying enum** (§8.E), because the old `streaming` / `has_random_access()`
   / "member list supported" set conflated listing cost, access cost, and the user's
   streaming preference — and used booleans, which forced genuinely different costs to
   share a value:
   - `member_listing_cost: MemberListingCost` (`INDEXED` / `SCAN_REQUIRED` / `SEQUENTIAL_ONLY`)
-    — *listing cost*. A boolean here is what made TAR lie: "one bounded seek to a
-    catalog" (ZIP) and "O(N) full pass" (seekable TAR) are different costs, so they
-    get different values. `INDEXED` means the list is readable with ≤ one seek without
-    exhausting the stream.
+    — *listing cost* (computed as above). A boolean here is what made TAR lie: "one
+    bounded seek to a catalog" (ZIP) and "O(N) full pass" (seekable TAR) are different
+    costs, so they get different values.
   - `member_access_cost: AccessCost` (`DIRECT` / `LIMITED` / `EXPENSIVE` / `UNAVAILABLE`)
     — *cost of opening a member out of order*. **Replaces** both `has_random_access()`
     and a `supports_random_access` boolean: the boolean equalled `not streaming` for
@@ -86,16 +114,22 @@ regression contract).
     consistent (`seekable()` is `False` iff `seek_cost` is `UNAVAILABLE`). Listing keeps
     its own vocabulary because enumerating a catalog is a different operation from
     reaching bytes; the two reach-bytes operations share `AccessCost`.
-  - **A TAR reader derives its own `member_access_cost` from the seek cost of the
-    decompressed stream it opens.** Reaching a member out of order means seeking that
-    inner stream to the member's offset, so the archive's access cost *is* the stream's
-    `seek_cost`: an uncompressed seekable tar inherits `DIRECT`, a rapidgzip-backed
-    `tar.gz` inherits `LIMITED`, a rewind-from-start `tar.gz` inherits `EXPENSIVE`, and a
-    non-seekable piped stream inherits `UNAVAILABLE` (forcing streaming). This is the
-    concrete payoff of sharing one scale across both axes — the archive-level tier is
-    computed from the stream-level tier rather than re-derived. (Today `TarReader` only
-    checks the inner stream's `seekable()` bool at `tar_reader.py:112`; the tiers refine
-    that same decision.)
+  - **`seek_cost` is a property of the seekable-stream abstraction, and readers read it
+    rather than re-deriving it.** Each decompressor/seekable stream knows its own seek
+    capability: a plain file or stored member → `DIRECT`; rapidgzip / indexed_bzip2 /
+    multi-block `XzDecompressorStream` → `LIMITED`; a single xz block or a
+    rewind-from-start stdlib wrapper → `EXPENSIVE`; a forward-only stream →
+    `UNAVAILABLE`. A `TarReader` then sets its `member_access_cost` (and the
+    `seek_cost` of the member streams it serves) **from the decompressed stream's
+    `seek_cost`** — reaching a member out of order is a seek on that stream, so the
+    archive tier *is* the stream tier. This is the concrete payoff of one shared scale,
+    and it keeps the single source of truth in the stream layer (where backend
+    selection actually happens) instead of duplicating `config.use_*` logic in each
+    reader. (PR #221 added `seek_cost` only to the per-member `ArchiveStream` and made
+    `TarReader` re-derive the cost from config — already wrong for multi-block
+    `tar.xz`, which it reported `EXPENSIVE` despite `XzDecompressorStream`'s block-level
+    seeking. Hoisting `seek_cost` onto the decompressor streams removes the
+    duplication and the bug.)
   - Both enums are classified **per archive/stream by mechanism** (worst-case tier),
     decided **at open** from what the backend/format header reveals (a footer block
     index read during construction is fine) and conservatively (report the worse tier)
@@ -106,6 +140,35 @@ regression contract).
     triggers a `SCAN_REQUIRED` pass** (that is `get_members()`'s job) — aligning the
     method with its already-documented "avoids full traversal" contract, which the
     current code violates for seekable TAR.
+- **Access intent is the input dual of the cost surface** (§8.F). Cost introspection
+  alone tells callers *what they got* but makes them responsible for *configuring* the
+  backend that produces a good cost (today: knowing to set `use_rapidgzip=True`). The
+  `access_intent` parameter lets the caller state the *goal* and have archivey choose:
+  - **`AccessIntent` is a `StrEnum`**: `AUTO` (default), `SEQUENTIAL`, `RANDOM`.
+    `AUTO` preserves today's behavior exactly — honor the explicit `use_*` config flags
+    and select no optional backend on the caller's behalf — so the change is additive
+    and the default is unsurprising. `SEQUENTIAL` favors the cheapest streaming backend
+    and skips eager index building. `RANDOM` prefers seekable/indexed backends
+    (rapidgzip, indexed_bzip2, multi-block xz) **when their packages are installed**.
+  - **`access_intent` is resolved into the existing low-level `use_*` flags**, not a
+    parallel selection mechanism. `open_archive` computes an effective config from the
+    intent and passes it down the unchanged stream-opening path. This keeps one
+    backend-selection codepath and means intent is purely a high-level shorthand.
+  - **Intent is best-effort; explicit flags are mandatory.** Setting `use_rapidgzip=True`
+    explicitly is a hard requirement (raises `PackageNotInstalledError` if rapidgzip is
+    absent — unchanged). `access_intent=RANDOM` is a preference: if the preferred
+    optional package is missing it falls back to the stdlib backend and lets
+    `member_access_cost`/`seek_cost` report the realized (`EXPENSIVE`) outcome rather
+    than raising. Likewise a format that simply cannot do cheap random access (solid 7z,
+    single-block xz) honors the request as best it can and reports the true cost.
+  - **`streaming=True` + `RANDOM` is contradictory → `ValueError`.** `streaming=True`
+    asserts forward-only use; `RANDOM` asserts out-of-order use. `streaming=True` with
+    `AUTO`/`SEQUENTIAL` is fine (and implies sequential).
+  - **A warning when `RANDOM` cannot be honored is explicitly deferred.** Detecting and
+    warning about unmet intent (or, more ambitiously, runtime access-pattern misuse) is
+    a reasonable future improvement but adds runtime tracking and policy that this
+    change does not take on. The honest cost properties are the mechanism callers use
+    in the meantime.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -181,28 +181,12 @@ regression contract). §8.F (access intent) is specified in the separate
     The single source of truth for `LIMITED`/`EXPENSIVE` is the stream's own `seek_cost`
     (the `has_intermediate_seek_points` line); TAR reads it rather than re-deriving from
     `config.use_*`, which is the PR-#221 bug above.
-  - **All returned streams share a common Archivey base carrying `seek_cost` and a
-    `name`.** Today each archivey stream class (`ArchiveStream`, `DecompressorStream`,
-    `BinaryIOWrapper`, …) independently subclasses `io.RawIOBase, BinaryIO`, and a stream
-    handed back from a third-party library (py7zr / rarfile / zipfile) may not be an
-    archivey type at all — so nothing *guarantees* `seek_cost` is present on a returned
-    stream. This change introduces a shared base — `ArchiveyStream` (subclass of
-    `io.RawIOBase, BinaryIO`) — declaring `seek_cost: AccessCost` (kept consistent with
-    `seekable()`) and `name: str | None` (the member path / source name, mirroring stdlib
-    file objects' `.name`). The existing classes inherit it, and **every** stream archivey
-    returns from `open()` / `iter_members_with_streams()` is an `ArchiveyStream`.
-    - **Foreign streams are normalised at the existing wrap point.** Library streams
-      already pass through `ensure_binaryio()` / `BinaryIOWrapper` (`internal/io_helpers.py`)
-      to satisfy the `BinaryIO` protocol; making that wrapper an `ArchiveyStream` means
-      carrying `seek_cost` / `name` is free wherever a wrapper is already built.
-      **Recommendation: wrap, don't annotate** — `setattr`-ing `seek_cost` onto the raw
-      third-party object is fragile (`__slots__`, immutable handles) and only saves one
-      allocation; annotating-in-place is left as a profiled optimization if the wrapper
-      is ever shown to be a hotspot.
-    - **Open questions (for review):** the exact metadata beyond `seek_cost` + `name`
-      (candidates: a back-reference to the `ArchiveMember`, the member's
-      `CompressionMethod`, the source `StreamFormat`), and whether `ArchiveyStream` is a
-      public type or internal-only.
+  - **`seek_cost` is added to archivey's own stream classes here** (the per-member
+    `ArchiveStream` and each decompressor stream). Guaranteeing it on *every* returned
+    stream — including those handed back raw by third-party libraries — needs a shared,
+    **public** stream base (`ArchiveyStream`) and a broader look at how archivey
+    constructs and wraps streams. That is **split into the separate `public-stream-interface`
+    change** (exploration stage), so this change stays scoped to the cost surface.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -6,15 +6,14 @@ decisions.
 
 ## Scope (and what moved out)
 
-This change is **§8.B–§8.G** (§8.F — access intent — and §8.G — inefficient-access
-warnings — are new, not in the original doc list). §8.A (the 7z/RAR co-iteration
-migration) is a pure refactor with no spec delta
+This change is **§8.B–§8.F** (§8.F — access intent — is new, not in the original doc
+list). §8.A (the 7z/RAR co-iteration migration) is a pure refactor with no spec delta
 and is handled inside the native-reader changes, which already rewrite those readers;
 see the note under Decisions.
 
 ## Starting point (verified against current code)
 
-- **§8.B–G**: not implemented. `compression_method` is `Optional[str]`,
+- **§8.B–F**: not implemented. `compression_method` is `Optional[str]`,
   `members_list_supported` is a constructor argument, there is no
   `_format_supports_random_access` flag, the only capability accessor is the
   `has_random_access()` method, and there is no `access_intent` input (callers set the
@@ -40,10 +39,9 @@ see the note under Decisions.
 | §8.D `CompressionMethod` enum | **Yes** (`compression_method` value type) | `archive-metadata` |
 | §8.E cost introspection (`MemberListingCost` + `AccessCost` enums, `member_listing_cost` / `member_access_cost`, stream + decompressor `seek_cost` alongside `seekable()`, drop `has_random_access`) | **Yes** (public API surface change) | `archive-reading` |
 | §8.F `AccessIntent` enum + `access_intent` open parameter | **Yes** (new public input; affects backend selection) | `archive-reading` |
-| §8.G `warn_on_inefficient_access` flag + `InefficientAccessWarning` | **Yes** (opt-in, default off) | `archive-reading` |
 
-So §8.D, §8.E, §8.F and §8.G get delta specs; §8.B/§8.C are captured as tasks because
-they must not change behavior (the existing `archive-reading` requirements are the
+So §8.D, §8.E and §8.F get delta specs; §8.B/§8.C are captured as tasks because they
+must not change behavior (the existing `archive-reading` requirements are the
 regression contract).
 
 ## Decisions
@@ -166,22 +164,11 @@ regression contract).
   - **`streaming=True` + `RANDOM` is contradictory → `ValueError`.** `streaming=True`
     asserts forward-only use; `RANDOM` asserts out-of-order use. `streaming=True` with
     `AUTO`/`SEQUENTIAL` is fine (and implies sequential).
-- **Inefficient-access warnings are opt-in and off by default** (§8.G). A
-  `warn_on_inefficient_access` config flag (default `False`) gates a dedicated
-  `InefficientAccessWarning` category, so the default experience is unchanged and there
-  is no warning spam. Two triggers, in increasing implementation cost:
-  - **Open-time (core):** when `access_intent=RANDOM` was requested but the realized
-    `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE`, warn once at open, naming the
-    cause (preferred package missing, non-seekable source, or a format that cannot
-    random-access cheaply). This is cheap — it reads the cost already computed at open.
-  - **Runtime (secondary):** when repeated out-of-order member access, or repeated
-    re-decompressing backward seeks within a member, occur on an `EXPENSIVE` target,
-    warn about the O(N²) pattern. This needs per-archive access-pattern tracking;
-    it is specified at the behavioral level and MAY be split into a follow-up change if
-    the bookkeeping grows. The open-time warning is the part that must land here.
-  - Warnings are derived from the coarse `AccessCost` tier, **not** from measurement,
-    and never change which bytes are returned. The honest cost properties remain the
-    primary mechanism; warnings are a convenience for callers who opt in.
+  - **A warning when `RANDOM` cannot be honored is explicitly deferred.** Detecting and
+    warning about unmet intent (or, more ambitiously, runtime access-pattern misuse) is
+    a reasonable future improvement but adds runtime tracking and policy that this
+    change does not take on. The honest cost properties are the mechanism callers use
+    in the meantime.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -6,14 +6,15 @@ decisions.
 
 ## Scope (and what moved out)
 
-This change is **§8.B–§8.F** (§8.F — access intent — is new, not in the original doc
-list). §8.A (the 7z/RAR co-iteration migration) is a pure refactor with no spec delta
+This change is **§8.B–§8.G** (§8.F — access intent — and §8.G — inefficient-access
+warnings — are new, not in the original doc list). §8.A (the 7z/RAR co-iteration
+migration) is a pure refactor with no spec delta
 and is handled inside the native-reader changes, which already rewrite those readers;
 see the note under Decisions.
 
 ## Starting point (verified against current code)
 
-- **§8.B–F**: not implemented. `compression_method` is `Optional[str]`,
+- **§8.B–G**: not implemented. `compression_method` is `Optional[str]`,
   `members_list_supported` is a constructor argument, there is no
   `_format_supports_random_access` flag, the only capability accessor is the
   `has_random_access()` method, and there is no `access_intent` input (callers set the
@@ -39,9 +40,10 @@ see the note under Decisions.
 | §8.D `CompressionMethod` enum | **Yes** (`compression_method` value type) | `archive-metadata` |
 | §8.E cost introspection (`MemberListingCost` + `AccessCost` enums, `member_listing_cost` / `member_access_cost`, stream + decompressor `seek_cost` alongside `seekable()`, drop `has_random_access`) | **Yes** (public API surface change) | `archive-reading` |
 | §8.F `AccessIntent` enum + `access_intent` open parameter | **Yes** (new public input; affects backend selection) | `archive-reading` |
+| §8.G `warn_on_inefficient_access` flag + `InefficientAccessWarning` | **Yes** (opt-in, default off) | `archive-reading` |
 
-So §8.D, §8.E and §8.F get delta specs; §8.B/§8.C are captured as tasks because they
-must not change behavior (the existing `archive-reading` requirements are the
+So §8.D, §8.E, §8.F and §8.G get delta specs; §8.B/§8.C are captured as tasks because
+they must not change behavior (the existing `archive-reading` requirements are the
 regression contract).
 
 ## Decisions
@@ -164,11 +166,22 @@ regression contract).
   - **`streaming=True` + `RANDOM` is contradictory → `ValueError`.** `streaming=True`
     asserts forward-only use; `RANDOM` asserts out-of-order use. `streaming=True` with
     `AUTO`/`SEQUENTIAL` is fine (and implies sequential).
-  - **A warning when `RANDOM` cannot be honored is explicitly deferred.** Detecting and
-    warning about unmet intent (or, more ambitiously, runtime access-pattern misuse) is
-    a reasonable future improvement but adds runtime tracking and policy that this
-    change does not take on. The honest cost properties are the mechanism callers use
-    in the meantime.
+- **Inefficient-access warnings are opt-in and off by default** (§8.G). A
+  `warn_on_inefficient_access` config flag (default `False`) gates a dedicated
+  `InefficientAccessWarning` category, so the default experience is unchanged and there
+  is no warning spam. Two triggers, in increasing implementation cost:
+  - **Open-time (core):** when `access_intent=RANDOM` was requested but the realized
+    `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE`, warn once at open, naming the
+    cause (preferred package missing, non-seekable source, or a format that cannot
+    random-access cheaply). This is cheap — it reads the cost already computed at open.
+  - **Runtime (secondary):** when repeated out-of-order member access, or repeated
+    re-decompressing backward seeks within a member, occur on an `EXPENSIVE` target,
+    warn about the O(N²) pattern. This needs per-archive access-pattern tracking;
+    it is specified at the behavioral level and MAY be split into a follow-up change if
+    the bookkeeping grows. The open-time warning is the part that must land here.
+  - Warnings are derived from the coarse `AccessCost` tier, **not** from measurement,
+    and never change which bytes are returned. The honest cost properties remain the
+    primary mechanism; warnings are a convenience for callers who opt in.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/design.md
+++ b/openspec/changes/base-reader-architecture-extensions/design.md
@@ -6,14 +6,14 @@ decisions.
 
 ## Scope (and what moved out)
 
-This change is **§8.B–§8.F** (§8.F — access intent — is new, not in the original doc
-list). §8.A (the 7z/RAR co-iteration migration) is a pure refactor with no spec delta
-and is handled inside the native-reader changes, which already rewrite those readers;
-see the note under Decisions.
+This change is **§8.B–§8.E**. §8.F (access intent) is split into its own `access-intent`
+change, which depends on the cost surface added here. §8.A (the 7z/RAR co-iteration
+migration) is a pure refactor with no spec delta and is handled inside the native-reader
+changes, which already rewrite those readers; see the note under Decisions.
 
 ## Starting point (verified against current code)
 
-- **§8.B–F**: not implemented. `compression_method` is `Optional[str]`,
+- **§8.B–E**: not implemented. `compression_method` is `Optional[str]`,
   `members_list_supported` is a constructor argument, there is no
   `_format_supports_random_access` flag, the only capability accessor is the
   `has_random_access()` method, and there is no `access_intent` input (callers set the
@@ -38,11 +38,11 @@ see the note under Decisions.
 | §8.C `has_central_directory` ClassVar (replaces `members_list_supported` arg) | No (listing cost unchanged where reachable) | none directly; feeds §8.E |
 | §8.D `CompressionMethod` enum | **Yes** (`compression_method` value type) | `archive-metadata` |
 | §8.E cost introspection (`MemberListingCost` + `AccessCost` enums, `member_listing_cost` / `member_access_cost`, stream + decompressor `seek_cost` alongside `seekable()`, drop `has_random_access`) | **Yes** (public API surface change) | `archive-reading` |
-| §8.F `AccessIntent` enum + `access_intent` open parameter | **Yes** (new public input; affects backend selection) | `archive-reading` |
 
-So §8.D, §8.E and §8.F get delta specs; §8.B/§8.C are captured as tasks because they
+So §8.D and §8.E get delta specs; §8.B/§8.C are captured as tasks because they
 must not change behavior (the existing `archive-reading` requirements are the
-regression contract).
+regression contract). §8.F (access intent) is specified in the separate
+`access-intent` change.
 
 ## Decisions
 
@@ -140,35 +140,6 @@ regression contract).
     triggers a `SCAN_REQUIRED` pass** (that is `get_members()`'s job) — aligning the
     method with its already-documented "avoids full traversal" contract, which the
     current code violates for seekable TAR.
-- **Access intent is the input dual of the cost surface** (§8.F). Cost introspection
-  alone tells callers *what they got* but makes them responsible for *configuring* the
-  backend that produces a good cost (today: knowing to set `use_rapidgzip=True`). The
-  `access_intent` parameter lets the caller state the *goal* and have archivey choose:
-  - **`AccessIntent` is a `StrEnum`**: `AUTO` (default), `SEQUENTIAL`, `RANDOM`.
-    `AUTO` preserves today's behavior exactly — honor the explicit `use_*` config flags
-    and select no optional backend on the caller's behalf — so the change is additive
-    and the default is unsurprising. `SEQUENTIAL` favors the cheapest streaming backend
-    and skips eager index building. `RANDOM` prefers seekable/indexed backends
-    (rapidgzip, indexed_bzip2, multi-block xz) **when their packages are installed**.
-  - **`access_intent` is resolved into the existing low-level `use_*` flags**, not a
-    parallel selection mechanism. `open_archive` computes an effective config from the
-    intent and passes it down the unchanged stream-opening path. This keeps one
-    backend-selection codepath and means intent is purely a high-level shorthand.
-  - **Intent is best-effort; explicit flags are mandatory.** Setting `use_rapidgzip=True`
-    explicitly is a hard requirement (raises `PackageNotInstalledError` if rapidgzip is
-    absent — unchanged). `access_intent=RANDOM` is a preference: if the preferred
-    optional package is missing it falls back to the stdlib backend and lets
-    `member_access_cost`/`seek_cost` report the realized (`EXPENSIVE`) outcome rather
-    than raising. Likewise a format that simply cannot do cheap random access (solid 7z,
-    single-block xz) honors the request as best it can and reports the true cost.
-  - **`streaming=True` + `RANDOM` is contradictory → `ValueError`.** `streaming=True`
-    asserts forward-only use; `RANDOM` asserts out-of-order use. `streaming=True` with
-    `AUTO`/`SEQUENTIAL` is fine (and implies sequential).
-  - **A warning when `RANDOM` cannot be honored is explicitly deferred.** Detecting and
-    warning about unmet intent (or, more ambitiously, runtime access-pattern misuse) is
-    a reasonable future improvement but adds runtime tracking and policy that this
-    change does not take on. The honest cost properties are the mechanism callers use
-    in the meantime.
 - **§8.A is folded into the native readers**: because `rar-native-metadata-reader`
   and `sevenzip-native-reader` already rewrite those readers, each adopts the
   existing `_iter_members_and_streams_internal` hook (dropping its public

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -6,30 +6,29 @@ readers) are in place. None changes externally-observable archive behavior much,
 but together they clean up the reader contract and make a couple of useful
 capabilities first-class for callers.
 
-This change covers the four contract/spec items **§8.B–§8.E**, plus a new
-**§8.F — access intent**. The fifth original item, **§8.A** (migrating the 7z/RAR
-solid readers onto the existing `_iter_members_and_streams_internal()` hook), is a
-pure internal refactor with no spec delta, so it is **folded into the
-native-reader changes** (`rar-native-metadata-reader` / `sevenzip-native-reader`),
-which already rewrite those files — see their tasks.
+This change covers the four contract/spec items **§8.B–§8.E**. The fifth original
+item, **§8.A** (migrating the 7z/RAR solid readers onto the existing
+`_iter_members_and_streams_internal()` hook), is a pure internal refactor with no spec
+delta, so it is **folded into the native-reader changes**
+(`rar-native-metadata-reader` / `sevenzip-native-reader`), which already rewrite those
+files — see their tasks. The originally-grouped **§8.F — access intent** is split into
+its own **`access-intent`** change: it is a larger, externally-facing redesign (a new
+open-time input, removal of the `streaming` parameter, tri-state backend config) that
+*builds on* the cost surface added here, so the two land in sequence rather than as one.
 
 §8.E exposes **cost introspection** (how expensive is it to list members / reach a
-member / seek within one). On its own that pushes a burden onto callers: to *get*
-cheap random access on a `tar.gz` today you must already know to set
-`use_rapidgzip=True` — the low-level backend flags (`use_rapidgzip`,
-`use_indexed_bzip2`, `use_python_xz`, …) leak archivey's cost model. §8.F adds the
-**dual**: an `access_intent` *input* at open time where the caller declares how
-they will use the archive (forward iteration vs. out-of-order / repeated access),
-and archivey maps that intent onto the right backends. Intent is the request; the
-§8.E cost properties are the **receipt** — what archivey actually achieved, since
-intent cannot always be honored (a solid 7z, a single-block xz, or a missing
-optional package). The two are complementary, not redundant.
+member / seek within one). This is the foundation the `access-intent` change builds on:
+the cost properties are the **receipt** (what archivey actually achieved), and the
+later `access_intent` input is the **request** (how the caller intends to use the
+archive). Today both are missing — to *get* cheap random access on a `tar.gz` you must
+already know to set `use_rapidgzip=True`, so the low-level backend flags
+(`use_rapidgzip`, `use_indexed_bzip2`, `use_python_xz`, …) leak archivey's cost model.
+This change adds the receipt; the request follows in `access-intent`.
 
-**Current state (verified):** §8.B–F are not yet implemented —
+**Current state (verified):** §8.B–E are not yet implemented —
 `compression_method` is still a plain `str`, `members_list_supported` is still an
-`__init__` argument, there is no `_format_supports_random_access` flag or
-`*_cost` properties (only the existing `has_random_access()` method), and there is
-no access-intent input (callers must hand-pick the `use_*` backend flags).
+`__init__` argument, and there is no `_format_supports_random_access` flag or
+`*_cost` properties (only the existing `has_random_access()` method).
 
 ## What Changes
 
@@ -89,26 +88,6 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
     re-derived the cost by inspecting `config.use_rapidgzip` etc. — duplicating
     backend-selection logic and already mis-reporting multi-block `tar.xz` as
     `EXPENSIVE`. Making the stream the single source of truth fixes that.)
-- **§8.F — access intent** *(public, new)*: an `AccessIntent` `StrEnum`
-  (`AUTO` (default) / `SEQUENTIAL` / `RANDOM`) and an `access_intent` parameter on
-  `open_archive(...)`. It is a high-level declaration of how the caller will use the
-  archive that archivey **resolves into the existing low-level backend flags**:
-  - `AUTO` — preserve current behavior; honor the explicit `use_*` config flags and
-    pick no optional backend on the caller's behalf.
-  - `SEQUENTIAL` — caller iterates forward; prefer the cheapest streaming backend and
-    skip building seek indexes.
-  - `RANDOM` — caller will reach members out of order and/or seek within members,
-    possibly repeatedly; prefer seekable/indexed backends (rapidgzip, indexed_bzip2,
-    multi-block xz) **when installed**.
-
-  Intent is **best-effort**: an explicit `use_*` flag remains a hard requirement
-  (raises if its package is missing), but `RANDOM` falls back to the stdlib backend
-  when an optional package is absent and lets the §8.E cost properties report the
-  realized (`EXPENSIVE`) outcome rather than raising. `streaming=True` together with
-  `RANDOM` is contradictory and raises `ValueError`. (Emitting a *warning* when
-  `RANDOM` cannot be honored is noted as a possible future improvement, not part of
-  this change.)
-
 ## Capabilities
 
 ### New Capabilities
@@ -121,25 +100,22 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
   `member_listing_cost` / `member_access_cost` introspection properties, adds an `AccessCost`
   `seek_cost` property alongside the protocol-required `seekable()` on member streams
   **and on the decompressor-stream abstraction** (with TAR deriving its access cost
-  from it), tightens `get_members_if_available` to never scan, removes
-  `has_random_access()` (superseded) (§8.E), and adds the `AccessIntent` enum and the
-  `access_intent` open parameter that selects backends to honor the requested access
-  pattern (§8.F).
+  from it), tightens `get_members_if_available` to never scan, and removes
+  `has_random_access()` (superseded) (§8.E).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
 
 ## Non-Goals
 
 - Any change to what archives can be read or how members decode (§8.B/C are
-  internal refactors that keep observable behavior identical; §8.F only changes
-  *which backend* is selected, not decoded output).
+  internal refactors that keep observable behavior identical).
 - *Measured*, per-call cost. `AccessCost` is a coarse mechanism-based hint
   (worst-case tier), not a predicted running time; wall-clock cost (e.g. whether a
   `SCAN_REQUIRED` seek beats decompression on a given disk/network) is left
   unmodeled.
-- **Access-pattern warnings** — a runtime detector that warns when the realized
-  usage contradicts the declared intent (e.g. repeated backward seeks on an
-  `EXPENSIVE` stream) is a plausible future follow-up, but is out of scope here.
+- **Access intent (§8.F)** — the `access_intent` *input* (and the removal of the
+  `streaming` parameter and the tri-state backend config) is split into the separate
+  `access-intent` change; this change only adds the cost *receipt* it builds on.
 - The §8.A co-iteration migration — folded into the native-reader changes, since
   those rewrite the same `sevenzip_reader.py` / `rar_reader.py` iteration code.
 
@@ -148,15 +124,17 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
 **Land second** (after `test-suite-parametrization`, before the native readers).
 
 §8.D (the `CompressionMethod` enum) must land **before** the 7z native reader so
-that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F are
-independent and can ship anytime. (The §8.A migration lives in the native-reader
-changes.)
+that reader can emit typed compression methods directly. §8.B/§8.C/§8.E are
+independent and can ship anytime. The `access-intent` change (§8.F) depends on §8.E
+(it reports realized cost through `member_access_cost`/`seek_cost`), so it lands after
+this one. (The §8.A migration lives in the native-reader changes.)
 
 Recommended order across all pending changes:
 1. `test-suite-parametrization` — verification harness
-2. **this change** — §8.B–§8.F (§8.D enum prerequisite for 7z native)
-3. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
-4. `unify-junction-handling` — after native readers (junction detection in native parsers)
+2. **this change** — §8.B–§8.E (§8.D enum prerequisite for 7z native)
+3. `access-intent` — §8.F (depends on §8.E cost surface)
+4. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
+5. `unify-junction-handling` — after native readers (junction detection in native parsers)
 
 ## Impact
 
@@ -168,9 +146,8 @@ Recommended order across all pending changes:
   wrapper (`archive_stream.py`, adds `seek_cost` alongside the existing `seekable()`),
   the decompressor-stream classes (`formats/decompressor_stream.py`,
   `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
-  each exposes its own `seek_cost`), `core.py` + `config.py` (`access_intent`
-  parameter on `open_archive`, resolved into the effective backend selection),
+  each exposes its own `seek_cost`),
   `types.py` (`CompressionMethod`, `compression_method_detail`, `MemberListingCost`,
-  `AccessCost`, `AccessIntent`), `archive_reader.py` (property declarations).
+  `AccessCost`), `archive_reader.py` (property declarations).
 - **Live specs touched**: `archive-reading`, `archive-metadata`.
 - **Design reference**: `docs/format-architecture-comparison.md` §8–§9.

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -93,15 +93,10 @@ This change adds the receipt; the request follows in `access-intent`.
     re-derived the cost by inspecting `config.use_rapidgzip` etc. — duplicating
     backend-selection logic and already mis-reporting multi-block `tar.xz` as
     `EXPENSIVE`. Making the stream the single source of truth fixes that.)
-  - **All returned streams share a common base** so `seek_cost` is guaranteed present.
-    Today archivey's stream classes each subclass `io.RawIOBase, BinaryIO`
-    independently, and a stream handed back from a third-party library may not be an
-    archivey type at all — nothing guarantees the property exists. A shared
-    `ArchiveyStream` base carries `seek_cost` **and** a `name` (member path / source
-    name, like stdlib file objects' `.name`); foreign streams are normalized into it at
-    the existing `ensure_binaryio()` / `BinaryIOWrapper` wrap point (wrap, don't annotate
-    raw third-party objects). The exact extra metadata and whether the base is public are
-    open review questions (see design).
+  - `seek_cost` is added to archivey's own stream classes here. Guaranteeing it on
+    **every** returned stream (including those handed back raw by third-party libraries)
+    via a shared **public** `ArchiveyStream` base is split into the separate
+    `public-stream-interface` change (exploration stage).
 ## Capabilities
 
 ### New Capabilities
@@ -114,9 +109,7 @@ This change adds the receipt; the request follows in `access-intent`.
   `member_listing_cost` / `member_access_cost` introspection properties, adds an `AccessCost`
   `seek_cost` property alongside the protocol-required `seekable()` on member streams
   **and on the decompressor-stream abstraction** (with TAR deriving its access cost
-  from it), introduces a shared `ArchiveyStream` base (carrying `seek_cost` and a `name`)
-  that every returned stream — including wrapped third-party library streams — is an
-  instance of, tightens `get_members_if_available` to never scan, and removes
+  from it), tightens `get_members_if_available` to never scan, and removes
   `has_random_access()` (superseded) (§8.E).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
@@ -159,12 +152,10 @@ Recommended order across all pending changes:
   removed `has_random_access`), `formats/*_reader.py` (`has_central_directory`
   ClassVar, `member_listing_cost` / `member_access_cost` reporting — TAR reads
   `member_access_cost` from its decompressed stream's `seek_cost`), the member-stream
-  wrapper (`archive_stream.py`, adds `seek_cost`/`name` alongside the existing
-  `seekable()`),
+  wrapper (`archive_stream.py`, adds `seek_cost` alongside the existing `seekable()`),
   the decompressor-stream classes (`formats/decompressor_stream.py`,
   `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
-  each exposes its own `seek_cost`), `internal/io_helpers.py` (the shared `ArchiveyStream`
-  base, with `BinaryIOWrapper` / `ensure_binaryio` producing it),
+  each exposes its own `seek_cost`),
   `types.py` (`CompressionMethod` — exhaustive over `StreamFormat` —,
   `compression_method_detail`, `MemberListingCost`, `AccessCost`),
   `archive_reader.py` (property declarations).

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -105,22 +105,9 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
   (raises if its package is missing), but `RANDOM` falls back to the stdlib backend
   when an optional package is absent and lets the §8.E cost properties report the
   realized (`EXPENSIVE`) outcome rather than raising. `streaming=True` together with
-  `RANDOM` is contradictory and raises `ValueError`.
-- **§8.G — inefficient-access warnings** *(public, opt-in)*: an **off-by-default**
-  config flag (`warn_on_inefficient_access`) and a dedicated `InefficientAccessWarning`
-  category. When enabled, archivey emits a Python warning when usage is inefficient
-  relative to the declared intent or the cost tier:
-  - at **open**, when `access_intent=RANDOM` was requested but the realized
-    `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` (preferred backend unavailable, or
-    the format cannot random-access cheaply) — the cheap, primary signal;
-  - at **runtime** (the lighter, secondary detector), when repeated out-of-order member
-    access or repeated re-decompressing backward seeks occur on an `EXPENSIVE` target
-    (the O(N²) trap).
-
-  Warnings never change which bytes are returned and are silent when the flag is off
-  (the default). The runtime detector requires per-archive access-pattern tracking and
-  MAY be split into a follow-up change if it grows; the open-time intent warning is the
-  core of §8.G.
+  `RANDOM` is contradictory and raises `ValueError`. (Emitting a *warning* when
+  `RANDOM` cannot be honored is noted as a possible future improvement, not part of
+  this change.)
 
 ## Capabilities
 
@@ -135,10 +122,9 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
   `seek_cost` property alongside the protocol-required `seekable()` on member streams
   **and on the decompressor-stream abstraction** (with TAR deriving its access cost
   from it), tightens `get_members_if_available` to never scan, removes
-  `has_random_access()` (superseded) (§8.E), adds the `AccessIntent` enum and the
+  `has_random_access()` (superseded) (§8.E), and adds the `AccessIntent` enum and the
   `access_intent` open parameter that selects backends to honor the requested access
-  pattern (§8.F), and adds the opt-in `warn_on_inefficient_access` flag with the
-  `InefficientAccessWarning` category (§8.G).
+  pattern (§8.F).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
 
@@ -150,7 +136,10 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
 - *Measured*, per-call cost. `AccessCost` is a coarse mechanism-based hint
   (worst-case tier), not a predicted running time; wall-clock cost (e.g. whether a
   `SCAN_REQUIRED` seek beats decompression on a given disk/network) is left
-  unmodeled. §8.G warnings are triggered by the coarse tier, not by measurement.
+  unmodeled.
+- **Access-pattern warnings** — a runtime detector that warns when the realized
+  usage contradicts the declared intent (e.g. repeated backward seeks on an
+  `EXPENSIVE` stream) is a plausible future follow-up, but is out of scope here.
 - The §8.A co-iteration migration — folded into the native-reader changes, since
   those rewrite the same `sevenzip_reader.py` / `rar_reader.py` iteration code.
 
@@ -159,13 +148,13 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
 **Land second** (after `test-suite-parametrization`, before the native readers).
 
 §8.D (the `CompressionMethod` enum) must land **before** the 7z native reader so
-that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F/§8.G are
-independent and can ship anytime (§8.G depends on §8.E/§8.F within this change). (The
-§8.A migration lives in the native-reader changes.)
+that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F are
+independent and can ship anytime. (The §8.A migration lives in the native-reader
+changes.)
 
 Recommended order across all pending changes:
 1. `test-suite-parametrization` — verification harness
-2. **this change** — §8.B–§8.G (§8.D enum prerequisite for 7z native)
+2. **this change** — §8.B–§8.F (§8.D enum prerequisite for 7z native)
 3. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
 4. `unify-junction-handling` — after native readers (junction detection in native parsers)
 
@@ -180,10 +169,8 @@ Recommended order across all pending changes:
   the decompressor-stream classes (`formats/decompressor_stream.py`,
   `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
   each exposes its own `seek_cost`), `core.py` + `config.py` (`access_intent`
-  parameter on `open_archive`, resolved into the effective backend selection;
-  `warn_on_inefficient_access` config flag), `types.py` (`CompressionMethod`,
-  `compression_method_detail`, `MemberListingCost`, `AccessCost`, `AccessIntent`),
-  `exceptions.py` (or `types.py`) (`InefficientAccessWarning` category),
-  `archive_reader.py` (property declarations).
+  parameter on `open_archive`, resolved into the effective backend selection),
+  `types.py` (`CompressionMethod`, `compression_method_detail`, `MemberListingCost`,
+  `AccessCost`, `AccessIntent`), `archive_reader.py` (property declarations).
 - **Live specs touched**: `archive-reading`, `archive-metadata`.
 - **Design reference**: `docs/format-architecture-comparison.md` §8–§9.

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -40,21 +40,23 @@ This change adds the receipt; the request follows in `access-intent`.
   stdlib on a file rewinds; rapidgzip/indexed_bzip2 are always seekable), so it is
   set in `__init__`. The runtime streaming flag becomes "user requested OR format
   can't".
-- **§8.C — catalog-location ClassVar (replaces the `members_list_supported`
-  argument)** *(internal)*: *where* a format keeps its member catalog is a genuine
-  format-level fact, so it becomes a `ClassVar` — header-resident (read while streaming
-  forward), tail-resident (ZIP's end-of-file central directory), a single-known-member
-  stream, or none (TAR). This is richer than PR #221's bool `has_central_directory`,
-  because *where* the catalog lives decides whether it is reachable without seeking. The
-  *realized* listing cost is **not** read from that fact alone: `member_listing_cost`
-  (§8.E) is computed **per instance** from the location **and** seekability — `INDEXED`
-  when the catalog (or single member) is reachable without a backward seek (header
-  catalog, single-member stream, or tail catalog on a seekable source), so a `.gz`
-  single-member stream is `INDEXED` even on a pipe and a header catalog can be `INDEXED`
-  on a non-seekable source once a native reader parses it forward. (PR #221 derived
-  `INDEXED` from a "has a catalog" bool only — wrong on both counts.) The standalone
-  `members_list_supported` boolean is dropped; it is now exactly
-  `member_listing_cost == INDEXED`.
+- **§8.C — catalog location (replaces the `members_list_supported` argument)**
+  *(internal)*: *where* an archive keeps an upfront member catalog — header-resident
+  (read while streaming forward), tail-resident (ZIP's end-of-file central directory), a
+  single-known-member stream, or none (members found only by scanning, as in TAR) —
+  decides whether it is reachable without seeking. This is richer than PR #221's bool
+  `has_central_directory`. Crucially it is **not purely a `ClassVar`**: for some formats
+  the location is per-file. RAR is the case — member headers precede each file (no front
+  index), and an upfront catalog exists only when the optional "quick open" service block
+  (an index at the *end*) is present, so a given `.rar` is tail-indexed or scan-only
+  depending on the file. A `ClassVar` carries a baseline where the layout is uniform
+  (ZIP=TRAILER, TAR=NONE); otherwise the reader determines the location at open. The
+  *realized* listing cost is computed **per instance** from that location **and**
+  seekability (§8.E): `INDEXED` when the catalog (or single member) is reachable without
+  a backward seek, so a `.gz` single-member stream is `INDEXED` even on a pipe. (PR #221
+  derived `INDEXED` from a "has a catalog" bool only — wrong on all of seekability,
+  location, and per-file variation.) The standalone `members_list_supported` boolean is
+  dropped; it is now exactly `member_listing_cost == INDEXED`.
 - **§8.D — typed `CompressionMethod` enum + lossless detail** *(public)*: a `StrEnum`
   of known codecs (plus `UNKNOWN`) so callers can branch on compression without parsing
   free-form strings. Stays string-compatible. The enum is **exhaustive over the formats

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -52,13 +52,18 @@ This change adds the receipt; the request follows in `access-intent`.
   source.) The standalone `members_list_supported` boolean is dropped; it is now
   exactly `member_listing_cost == INDEXED`.
 - **§8.D — typed `CompressionMethod` enum + lossless detail** *(public)*: a `StrEnum`
-  of known methods (`STORED`, `DEFLATE`, `LZMA`, `LZMA2`, `ZSTD`, `BZIP2`, `PPMD`,
-  `BCJ2`, …, plus `UNKNOWN`) so callers can branch on compression without parsing
-  free-form strings. Stays string-compatible. `compression_method` holds the typed
-  **primary** codec (`UNKNOWN` if reported-but-unmapped, `None` if unreported); a new
-  free-form `compression_method_detail: Optional[str]` preserves the full,
-  lossless description — 7z filter chains (`"LZMA2 + BCJ2"`) and third-party readers'
-  own codec names that a closed enum can't represent.
+  of known codecs (plus `UNKNOWN`) so callers can branch on compression without parsing
+  free-form strings. Stays string-compatible. The enum is **exhaustive over the formats
+  Archivey handles, not a sample**: it carries a value for **every `StreamFormat`** —
+  `STORED`, `DEFLATE` (gzip/zlib), `BZIP2`, `LZMA2`/`XZ`, `LZMA` (lzip), `ZSTD`, `LZ4`,
+  `BROTLI`, `LZW` (Unix `compress`) — **plus** container-internal codecs (`PPMD`, `BCJ2`,
+  `DEFLATE64`, `DELTA`, …), with a test asserting every `StreamFormat` maps to a
+  non-`UNKNOWN` value (PR #221 only added the example codecs and missed e.g. brotli).
+  `compression_method` holds the typed **primary** codec (`UNKNOWN` if
+  reported-but-unmapped, `None` if unreported); a new free-form
+  `compression_method_detail: Optional[str]` preserves the full, lossless description —
+  7z filter chains (`"LZMA2 + BCJ2"`) and third-party readers' own codec names that a
+  closed enum can't represent.
 - **§8.E — cost introspection (redesigned surface)** *(public)*: replace the
   confusing tangle of `streaming` / `has_random_access()` / "member list supported"
   with introspection on two orthogonal axes, each a cost-classifying enum so the
@@ -88,6 +93,15 @@ This change adds the receipt; the request follows in `access-intent`.
     re-derived the cost by inspecting `config.use_rapidgzip` etc. — duplicating
     backend-selection logic and already mis-reporting multi-block `tar.xz` as
     `EXPENSIVE`. Making the stream the single source of truth fixes that.)
+  - **All returned streams share a common base** so `seek_cost` is guaranteed present.
+    Today archivey's stream classes each subclass `io.RawIOBase, BinaryIO`
+    independently, and a stream handed back from a third-party library may not be an
+    archivey type at all — nothing guarantees the property exists. A shared
+    `ArchiveyStream` base carries `seek_cost` **and** a `name` (member path / source
+    name, like stdlib file objects' `.name`); foreign streams are normalized into it at
+    the existing `ensure_binaryio()` / `BinaryIOWrapper` wrap point (wrap, don't annotate
+    raw third-party objects). The exact extra metadata and whether the base is public are
+    open review questions (see design).
 ## Capabilities
 
 ### New Capabilities
@@ -100,7 +114,9 @@ This change adds the receipt; the request follows in `access-intent`.
   `member_listing_cost` / `member_access_cost` introspection properties, adds an `AccessCost`
   `seek_cost` property alongside the protocol-required `seekable()` on member streams
   **and on the decompressor-stream abstraction** (with TAR deriving its access cost
-  from it), tightens `get_members_if_available` to never scan, and removes
+  from it), introduces a shared `ArchiveyStream` base (carrying `seek_cost` and a `name`)
+  that every returned stream — including wrapped third-party library streams — is an
+  instance of, tightens `get_members_if_available` to never scan, and removes
   `has_random_access()` (superseded) (§8.E).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
@@ -143,11 +159,14 @@ Recommended order across all pending changes:
   removed `has_random_access`), `formats/*_reader.py` (`has_central_directory`
   ClassVar, `member_listing_cost` / `member_access_cost` reporting — TAR reads
   `member_access_cost` from its decompressed stream's `seek_cost`), the member-stream
-  wrapper (`archive_stream.py`, adds `seek_cost` alongside the existing `seekable()`),
+  wrapper (`archive_stream.py`, adds `seek_cost`/`name` alongside the existing
+  `seekable()`),
   the decompressor-stream classes (`formats/decompressor_stream.py`,
   `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
-  each exposes its own `seek_cost`),
-  `types.py` (`CompressionMethod`, `compression_method_detail`, `MemberListingCost`,
-  `AccessCost`), `archive_reader.py` (property declarations).
+  each exposes its own `seek_cost`), `internal/io_helpers.py` (the shared `ArchiveyStream`
+  base, with `BinaryIOWrapper` / `ensure_binaryio` producing it),
+  `types.py` (`CompressionMethod` — exhaustive over `StreamFormat` —,
+  `compression_method_detail`, `MemberListingCost`, `AccessCost`),
+  `archive_reader.py` (property declarations).
 - **Live specs touched**: `archive-reading`, `archive-metadata`.
 - **Design reference**: `docs/format-architecture-comparison.md` §8–§9.

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -105,9 +105,22 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
   (raises if its package is missing), but `RANDOM` falls back to the stdlib backend
   when an optional package is absent and lets the §8.E cost properties report the
   realized (`EXPENSIVE`) outcome rather than raising. `streaming=True` together with
-  `RANDOM` is contradictory and raises `ValueError`. (Emitting a *warning* when
-  `RANDOM` cannot be honored is noted as a possible future improvement, not part of
-  this change.)
+  `RANDOM` is contradictory and raises `ValueError`.
+- **§8.G — inefficient-access warnings** *(public, opt-in)*: an **off-by-default**
+  config flag (`warn_on_inefficient_access`) and a dedicated `InefficientAccessWarning`
+  category. When enabled, archivey emits a Python warning when usage is inefficient
+  relative to the declared intent or the cost tier:
+  - at **open**, when `access_intent=RANDOM` was requested but the realized
+    `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` (preferred backend unavailable, or
+    the format cannot random-access cheaply) — the cheap, primary signal;
+  - at **runtime** (the lighter, secondary detector), when repeated out-of-order member
+    access or repeated re-decompressing backward seeks occur on an `EXPENSIVE` target
+    (the O(N²) trap).
+
+  Warnings never change which bytes are returned and are silent when the flag is off
+  (the default). The runtime detector requires per-archive access-pattern tracking and
+  MAY be split into a follow-up change if it grows; the open-time intent warning is the
+  core of §8.G.
 
 ## Capabilities
 
@@ -122,9 +135,10 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
   `seek_cost` property alongside the protocol-required `seekable()` on member streams
   **and on the decompressor-stream abstraction** (with TAR deriving its access cost
   from it), tightens `get_members_if_available` to never scan, removes
-  `has_random_access()` (superseded) (§8.E), and adds the `AccessIntent` enum and the
+  `has_random_access()` (superseded) (§8.E), adds the `AccessIntent` enum and the
   `access_intent` open parameter that selects backends to honor the requested access
-  pattern (§8.F).
+  pattern (§8.F), and adds the opt-in `warn_on_inefficient_access` flag with the
+  `InefficientAccessWarning` category (§8.G).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
 
@@ -136,10 +150,7 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
 - *Measured*, per-call cost. `AccessCost` is a coarse mechanism-based hint
   (worst-case tier), not a predicted running time; wall-clock cost (e.g. whether a
   `SCAN_REQUIRED` seek beats decompression on a given disk/network) is left
-  unmodeled.
-- **Access-pattern warnings** — a runtime detector that warns when the realized
-  usage contradicts the declared intent (e.g. repeated backward seeks on an
-  `EXPENSIVE` stream) is a plausible future follow-up, but is out of scope here.
+  unmodeled. §8.G warnings are triggered by the coarse tier, not by measurement.
 - The §8.A co-iteration migration — folded into the native-reader changes, since
   those rewrite the same `sevenzip_reader.py` / `rar_reader.py` iteration code.
 
@@ -148,13 +159,13 @@ no access-intent input (callers must hand-pick the `use_*` backend flags).
 **Land second** (after `test-suite-parametrization`, before the native readers).
 
 §8.D (the `CompressionMethod` enum) must land **before** the 7z native reader so
-that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F are
-independent and can ship anytime. (The §8.A migration lives in the native-reader
-changes.)
+that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F/§8.G are
+independent and can ship anytime (§8.G depends on §8.E/§8.F within this change). (The
+§8.A migration lives in the native-reader changes.)
 
 Recommended order across all pending changes:
 1. `test-suite-parametrization` — verification harness
-2. **this change** — §8.B–§8.F (§8.D enum prerequisite for 7z native)
+2. **this change** — §8.B–§8.G (§8.D enum prerequisite for 7z native)
 3. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
 4. `unify-junction-handling` — after native readers (junction detection in native parsers)
 
@@ -169,8 +180,10 @@ Recommended order across all pending changes:
   the decompressor-stream classes (`formats/decompressor_stream.py`,
   `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
   each exposes its own `seek_cost`), `core.py` + `config.py` (`access_intent`
-  parameter on `open_archive`, resolved into the effective backend selection),
-  `types.py` (`CompressionMethod`, `compression_method_detail`, `MemberListingCost`,
-  `AccessCost`, `AccessIntent`), `archive_reader.py` (property declarations).
+  parameter on `open_archive`, resolved into the effective backend selection;
+  `warn_on_inefficient_access` config flag), `types.py` (`CompressionMethod`,
+  `compression_method_detail`, `MemberListingCost`, `AccessCost`, `AccessIntent`),
+  `exceptions.py` (or `types.py`) (`InefficientAccessWarning` category),
+  `archive_reader.py` (property declarations).
 - **Live specs touched**: `archive-reading`, `archive-metadata`.
 - **Design reference**: `docs/format-architecture-comparison.md` §8–§9.

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -40,17 +40,21 @@ This change adds the receipt; the request follows in `access-intent`.
   stdlib on a file rewinds; rapidgzip/indexed_bzip2 are always seekable), so it is
   set in `__init__`. The runtime streaming flag becomes "user requested OR format
   can't".
-- **§8.C — `has_central_directory` ClassVar (replaces the `members_list_supported`
-  argument)** *(internal)*: "does this *format* have a catalog/central directory?"
-  is a genuine format-level fact (ZIP/7z/RAR/ISO/folder yes, TAR no), so it becomes
-  a `ClassVar[bool]` named `has_central_directory` — a clearer name than
-  `members_list_supported`. But the *realized* listing cost is **not** read from
-  that flag alone: a catalog at end-of-file is only reachable when the source is
-  seekable, so `member_listing_cost` (§8.E) is computed **per instance** from
-  `has_central_directory` **and** seekability. (The PR-#221 implementation derived
-  `INDEXED` from the ClassVar only — wrong for a catalog format on a non-seekable
-  source.) The standalone `members_list_supported` boolean is dropped; it is now
-  exactly `member_listing_cost == INDEXED`.
+- **§8.C — catalog-location ClassVar (replaces the `members_list_supported`
+  argument)** *(internal)*: *where* a format keeps its member catalog is a genuine
+  format-level fact, so it becomes a `ClassVar` — header-resident (read while streaming
+  forward), tail-resident (ZIP's end-of-file central directory), a single-known-member
+  stream, or none (TAR). This is richer than PR #221's bool `has_central_directory`,
+  because *where* the catalog lives decides whether it is reachable without seeking. The
+  *realized* listing cost is **not** read from that fact alone: `member_listing_cost`
+  (§8.E) is computed **per instance** from the location **and** seekability — `INDEXED`
+  when the catalog (or single member) is reachable without a backward seek (header
+  catalog, single-member stream, or tail catalog on a seekable source), so a `.gz`
+  single-member stream is `INDEXED` even on a pipe and a header catalog can be `INDEXED`
+  on a non-seekable source once a native reader parses it forward. (PR #221 derived
+  `INDEXED` from a "has a catalog" bool only — wrong on both counts.) The standalone
+  `members_list_supported` boolean is dropped; it is now exactly
+  `member_listing_cost == INDEXED`.
 - **§8.D — typed `CompressionMethod` enum + lossless detail** *(public)*: a `StrEnum`
   of known codecs (plus `UNKNOWN`) so callers can branch on compression without parsing
   free-form strings. Stays string-compatible. The enum is **exhaustive over the formats
@@ -71,7 +75,7 @@ This change adds the receipt; the request follows in `access-intent`.
   - `member_listing_cost: MemberListingCost` (`INDEXED` / `SCAN_REQUIRED` / `SEQUENTIAL_ONLY`)
     — *how cheaply the full member list is obtainable*, so "one bounded seek (ZIP
     catalog)" is no longer conflated with "O(N) full pass (seekable TAR)". Computed
-    per instance from `has_central_directory` and seekability (see §8.C).
+    per instance from catalog location and seekability (see §8.C).
     `get_members_if_available()` is tightened to return the list only for `INDEXED`
     (or already-known) and never to trigger a scan.
   - `member_access_cost: AccessCost` (`DIRECT` / `LIMITED` / `EXPENSIVE` / `UNAVAILABLE`)
@@ -87,9 +91,15 @@ This change adds the receipt; the request follows in `access-intent`.
   - **`seek_cost` is owned by the seekable-stream abstraction, not re-derived by each
     reader.** Each decompressor/seekable stream (stdlib rewind wrapper, rapidgzip,
     indexed_bzip2, `XzDecompressorStream`, lzip, a plain file) exposes its own
-    `seek_cost`. A TAR reader's `member_access_cost` is then read directly from the
-    `seek_cost` of the decompressed stream it opens (reaching a member is a seek on
-    that stream) instead of re-inferring it from config flags. (The PR-#221 TarReader
+    `seek_cost`. A TAR reader's `member_access_cost` is then read from the `seek_cost` of
+    the decompressed stream it opens (reaching a member is a seek on that stream) instead
+    of re-inferring it from config flags. **Because not every stream is an Archivey type
+    yet** (some are returned raw by third-party libraries; the public `ArchiveyStream`
+    base is the separate `public-stream-interface` change), this read goes through a
+    tolerant `seek_cost_of(stream)` helper — returns `stream.seek_cost` when present, else
+    a conservative estimate from type/`seekable()` (seekable-unknown → `EXPENSIVE`,
+    non-seekable → `UNAVAILABLE`). The helper collapses into a direct read once all
+    streams expose the property. (The PR-#221 TarReader
     re-derived the cost by inspecting `config.use_rapidgzip` etc. — duplicating
     backend-selection logic and already mis-reporting multi-block `tar.xz` as
     `EXPENSIVE`. Making the stream the single source of truth fixes that.)
@@ -140,10 +150,15 @@ this one. (The §8.A migration lives in the native-reader changes.)
 
 Recommended order across all pending changes:
 1. `test-suite-parametrization` — verification harness
-2. **this change** — §8.B–§8.E (§8.D enum prerequisite for 7z native)
-3. `access-intent` — §8.F (depends on §8.E cost surface)
+2. **this change** — §8.B–§8.E (§8.D enum prerequisite for 7z native; the foundation
+   both `access-intent` and `public-stream-interface` build on)
+3. `access-intent` — §8.F (depends on §8.E; sequence it early since it is the breaking
+   API change — removing `streaming` — and the longer it waits the more call sites accrete)
 4. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
 5. `unify-junction-handling` — after native readers (junction detection in native parsers)
+6. `public-stream-interface` — implemented **last**, after its own exploration; it hoists
+   the per-class `seek_cost` added here onto the shared `ArchiveyStream` base (a small,
+   anticipated refactor that also lets the `seek_cost_of` helper collapse into a direct read)
 
 ## Impact
 

--- a/openspec/changes/base-reader-architecture-extensions/proposal.md
+++ b/openspec/changes/base-reader-architecture-extensions/proposal.md
@@ -6,17 +6,30 @@ readers) are in place. None changes externally-observable archive behavior much,
 but together they clean up the reader contract and make a couple of useful
 capabilities first-class for callers.
 
-This change covers the four contract/spec items **§8.B–§8.E**. The fifth, **§8.A**
-(migrating the 7z/RAR solid readers onto the existing
-`_iter_members_and_streams_internal()` hook), is a pure internal refactor with no
-spec delta, so it is **folded into the native-reader changes**
-(`rar-native-metadata-reader` / `sevenzip-native-reader`), which already
-rewrite those files — see their tasks.
+This change covers the four contract/spec items **§8.B–§8.E**, plus a new
+**§8.F — access intent**. The fifth original item, **§8.A** (migrating the 7z/RAR
+solid readers onto the existing `_iter_members_and_streams_internal()` hook), is a
+pure internal refactor with no spec delta, so it is **folded into the
+native-reader changes** (`rar-native-metadata-reader` / `sevenzip-native-reader`),
+which already rewrite those files — see their tasks.
 
-**Current state (verified):** §8.B–E are not yet implemented —
-`compression_method` is still a plain `str`, `members_list_supported` is still a
-constructor argument, and there is no `_format_supports_random_access` ClassVar or
-`supports_*` properties (only the existing `has_random_access()` method).
+§8.E exposes **cost introspection** (how expensive is it to list members / reach a
+member / seek within one). On its own that pushes a burden onto callers: to *get*
+cheap random access on a `tar.gz` today you must already know to set
+`use_rapidgzip=True` — the low-level backend flags (`use_rapidgzip`,
+`use_indexed_bzip2`, `use_python_xz`, …) leak archivey's cost model. §8.F adds the
+**dual**: an `access_intent` *input* at open time where the caller declares how
+they will use the archive (forward iteration vs. out-of-order / repeated access),
+and archivey maps that intent onto the right backends. Intent is the request; the
+§8.E cost properties are the **receipt** — what archivey actually achieved, since
+intent cannot always be honored (a solid 7z, a single-block xz, or a missing
+optional package). The two are complementary, not redundant.
+
+**Current state (verified):** §8.B–F are not yet implemented —
+`compression_method` is still a plain `str`, `members_list_supported` is still an
+`__init__` argument, there is no `_format_supports_random_access` flag or
+`*_cost` properties (only the existing `has_random_access()` method), and there is
+no access-intent input (callers must hand-pick the `use_*` backend flags).
 
 ## What Changes
 
@@ -28,8 +41,17 @@ constructor argument, and there is no `_format_supports_random_access` ClassVar 
   stdlib on a file rewinds; rapidgzip/indexed_bzip2 are always seekable), so it is
   set in `__init__`. The runtime streaming flag becomes "user requested OR format
   can't".
-- **§8.C — `members_list_supported` as a ClassVar** *(internal)*: it's a format-level
-  fact, so declare it per reader class instead of passing it through `__init__`.
+- **§8.C — `has_central_directory` ClassVar (replaces the `members_list_supported`
+  argument)** *(internal)*: "does this *format* have a catalog/central directory?"
+  is a genuine format-level fact (ZIP/7z/RAR/ISO/folder yes, TAR no), so it becomes
+  a `ClassVar[bool]` named `has_central_directory` — a clearer name than
+  `members_list_supported`. But the *realized* listing cost is **not** read from
+  that flag alone: a catalog at end-of-file is only reachable when the source is
+  seekable, so `member_listing_cost` (§8.E) is computed **per instance** from
+  `has_central_directory` **and** seekability. (The PR-#221 implementation derived
+  `INDEXED` from the ClassVar only — wrong for a catalog format on a non-seekable
+  source.) The standalone `members_list_supported` boolean is dropped; it is now
+  exactly `member_listing_cost == INDEXED`.
 - **§8.D — typed `CompressionMethod` enum + lossless detail** *(public)*: a `StrEnum`
   of known methods (`STORED`, `DEFLATE`, `LZMA`, `LZMA2`, `ZSTD`, `BZIP2`, `PPMD`,
   `BCJ2`, …, plus `UNKNOWN`) so callers can branch on compression without parsing
@@ -38,13 +60,14 @@ constructor argument, and there is no `_format_supports_random_access` ClassVar 
   free-form `compression_method_detail: Optional[str]` preserves the full,
   lossless description — 7z filter chains (`"LZMA2 + BCJ2"`) and third-party readers'
   own codec names that a closed enum can't represent.
-- **§8.E — capability introspection (redesigned surface)** *(public)*: replace the
+- **§8.E — cost introspection (redesigned surface)** *(public)*: replace the
   confusing tangle of `streaming` / `has_random_access()` / "member list supported"
   with introspection on two orthogonal axes, each a cost-classifying enum so the
   surface never lies about expense the way a boolean does:
   - `member_listing_cost: MemberListingCost` (`INDEXED` / `SCAN_REQUIRED` / `SEQUENTIAL_ONLY`)
     — *how cheaply the full member list is obtainable*, so "one bounded seek (ZIP
-    catalog)" is no longer conflated with "O(N) full pass (seekable TAR)".
+    catalog)" is no longer conflated with "O(N) full pass (seekable TAR)". Computed
+    per instance from `has_central_directory` and seekability (see §8.C).
     `get_members_if_available()` is tightened to return the list only for `INDEXED`
     (or already-known) and never to trigger a scan.
   - `member_access_cost: AccessCost` (`DIRECT` / `LIMITED` / `EXPENSIVE` / `UNAVAILABLE`)
@@ -56,8 +79,35 @@ constructor argument, and there is no `_format_supports_random_access` ClassVar 
     a new `seek_cost` property. The protocol-required `seekable(): bool` is kept as-is;
     `seek_cost` is an additional property alongside it (the two stay consistent), so
     callers can tell a true random-access stream from one that is seekable only by
-    re-decompressing. A TAR reader's `member_access_cost` is derived from the `seek_cost` of
-    the decompressed stream it opens (reaching a member is a seek on that stream).
+    re-decompressing.
+  - **`seek_cost` is owned by the seekable-stream abstraction, not re-derived by each
+    reader.** Each decompressor/seekable stream (stdlib rewind wrapper, rapidgzip,
+    indexed_bzip2, `XzDecompressorStream`, lzip, a plain file) exposes its own
+    `seek_cost`. A TAR reader's `member_access_cost` is then read directly from the
+    `seek_cost` of the decompressed stream it opens (reaching a member is a seek on
+    that stream) instead of re-inferring it from config flags. (The PR-#221 TarReader
+    re-derived the cost by inspecting `config.use_rapidgzip` etc. — duplicating
+    backend-selection logic and already mis-reporting multi-block `tar.xz` as
+    `EXPENSIVE`. Making the stream the single source of truth fixes that.)
+- **§8.F — access intent** *(public, new)*: an `AccessIntent` `StrEnum`
+  (`AUTO` (default) / `SEQUENTIAL` / `RANDOM`) and an `access_intent` parameter on
+  `open_archive(...)`. It is a high-level declaration of how the caller will use the
+  archive that archivey **resolves into the existing low-level backend flags**:
+  - `AUTO` — preserve current behavior; honor the explicit `use_*` config flags and
+    pick no optional backend on the caller's behalf.
+  - `SEQUENTIAL` — caller iterates forward; prefer the cheapest streaming backend and
+    skip building seek indexes.
+  - `RANDOM` — caller will reach members out of order and/or seek within members,
+    possibly repeatedly; prefer seekable/indexed backends (rapidgzip, indexed_bzip2,
+    multi-block xz) **when installed**.
+
+  Intent is **best-effort**: an explicit `use_*` flag remains a hard requirement
+  (raises if its package is missing), but `RANDOM` falls back to the stdlib backend
+  when an optional package is absent and lets the §8.E cost properties report the
+  realized (`EXPENSIVE`) outcome rather than raising. `streaming=True` together with
+  `RANDOM` is contradictory and raises `ValueError`. (Emitting a *warning* when
+  `RANDOM` cannot be honored is noted as a possible future improvement, not part of
+  this change.)
 
 ## Capabilities
 
@@ -69,47 +119,58 @@ constructor argument, and there is no `_format_supports_random_access` ClassVar 
 
 - `archive-reading`: adds the `MemberListingCost` and shared `AccessCost` enums and the
   `member_listing_cost` / `member_access_cost` introspection properties, adds an `AccessCost`
-  `seek_cost` property alongside the protocol-required `seekable()` on member streams,
-  tightens `get_members_if_available` to never scan, and removes `has_random_access()`
-  (superseded) (§8.E).
+  `seek_cost` property alongside the protocol-required `seekable()` on member streams
+  **and on the decompressor-stream abstraction** (with TAR deriving its access cost
+  from it), tightens `get_members_if_available` to never scan, removes
+  `has_random_access()` (superseded) (§8.E), and adds the `AccessIntent` enum and the
+  `access_intent` open parameter that selects backends to honor the requested access
+  pattern (§8.F).
 - `archive-metadata`: adds the typed `CompressionMethod` enum and the lossless
   `compression_method_detail` field (§8.D).
 
 ## Non-Goals
 
 - Any change to what archives can be read or how members decode (§8.B/C are
-  internal refactors that keep observable behavior identical).
-- The §8.A co-iteration migration — folded into the native-reader changes, since
-  those rewrite the same `sevenzip_reader.py` / `rar_reader.py` iteration code.
+  internal refactors that keep observable behavior identical; §8.F only changes
+  *which backend* is selected, not decoded output).
 - *Measured*, per-call cost. `AccessCost` is a coarse mechanism-based hint
   (worst-case tier), not a predicted running time; wall-clock cost (e.g. whether a
   `SCAN_REQUIRED` seek beats decompression on a given disk/network) is left
   unmodeled.
+- **Access-pattern warnings** — a runtime detector that warns when the realized
+  usage contradicts the declared intent (e.g. repeated backward seeks on an
+  `EXPENSIVE` stream) is a plausible future follow-up, but is out of scope here.
+- The §8.A co-iteration migration — folded into the native-reader changes, since
+  those rewrite the same `sevenzip_reader.py` / `rar_reader.py` iteration code.
 
 ## Dependencies / Sequencing
 
 **Land second** (after `test-suite-parametrization`, before the native readers).
 
 §8.D (the `CompressionMethod` enum) must land **before** the 7z native reader so
-that reader can emit typed compression methods directly. §8.B/§8.C/§8.E are
+that reader can emit typed compression methods directly. §8.B/§8.C/§8.E/§8.F are
 independent and can ship anytime. (The §8.A migration lives in the native-reader
 changes.)
 
 Recommended order across all pending changes:
 1. `test-suite-parametrization` — verification harness
-2. **this change** — §8.B–§8.E (§8.D enum prerequisite for 7z native)
+2. **this change** — §8.B–§8.F (§8.D enum prerequisite for 7z native)
 3. `rar-native-metadata-reader` + `sevenzip-native-reader` (in parallel; also run junction Windows spike)
 4. `unify-junction-handling` — after native readers (junction detection in native parsers)
 
 ## Impact
 
 - **Files**: `internal/base_reader.py` (`member_listing_cost` / `member_access_cost`
-  introspection properties, tightened `get_members_if_available`, removed
-  `has_random_access`), `formats/*_reader.py` (`members_list_supported` ClassVar,
-  `member_listing_cost` / `member_access_cost` reporting — TAR derives `member_access_cost` from its
-  decompressed stream's `seek_cost`), the member-stream wrapper (adds `seek_cost`
-  alongside the existing `seekable()`), `types.py` (`CompressionMethod`,
-  `compression_method_detail`,
-  `MemberListingCost`, `AccessCost`), `archive_reader.py` (property declarations).
+  introspection properties computed per-instance, tightened `get_members_if_available`,
+  removed `has_random_access`), `formats/*_reader.py` (`has_central_directory`
+  ClassVar, `member_listing_cost` / `member_access_cost` reporting — TAR reads
+  `member_access_cost` from its decompressed stream's `seek_cost`), the member-stream
+  wrapper (`archive_stream.py`, adds `seek_cost` alongside the existing `seekable()`),
+  the decompressor-stream classes (`formats/decompressor_stream.py`,
+  `formats/compressed_streams.py`, `formats/xz_stream.py`, `formats/lzip_stream.py` —
+  each exposes its own `seek_cost`), `core.py` + `config.py` (`access_intent`
+  parameter on `open_archive`, resolved into the effective backend selection),
+  `types.py` (`CompressionMethod`, `compression_method_detail`, `MemberListingCost`,
+  `AccessCost`, `AccessIntent`), `archive_reader.py` (property declarations).
 - **Live specs touched**: `archive-reading`, `archive-metadata`.
 - **Design reference**: `docs/format-architecture-comparison.md` §8–§9.

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-metadata/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-metadata/spec.md
@@ -3,12 +3,17 @@
 ### Requirement: Compression method is available as a typed value
 
 A `CompressionMethod` enum SHALL enumerate the compression methods Archivey
-recognizes (such as `STORED`, `DEFLATE`, `LZMA`, `LZMA2`, `ZSTD`, `BZIP2`, `PPMD`,
-and `BCJ2`) with an `UNKNOWN` fallback. It SHALL be a `StrEnum` so existing string
-comparisons keep working. `ArchiveMember.compression_method` SHALL hold the
-recognized **primary** codec as a `CompressionMethod` value, SHALL be `UNKNOWN`
-when the format reports a codec Archivey does not map, and SHALL remain `None` when
-the format does not report a compression method at all.
+recognizes, with an `UNKNOWN` fallback. It SHALL be a `StrEnum` so existing string
+comparisons keep working. The enum SHALL be **exhaustive over the formats Archivey
+handles, not a sample**: it SHALL include a value for **every `StreamFormat` member** —
+covering at least `STORED` (uncompressed), `DEFLATE` (gzip and zlib), `BZIP2`, `LZMA2`
+(xz), `LZMA` (lzip), `ZSTD`, `LZ4`, `BROTLI`, and `LZW` (Unix `compress`) — **and** the
+container-internal codecs that do not appear as standalone streams (such as `PPMD`,
+`BCJ2`, `DEFLATE64`, and `DELTA`). Adding a `StreamFormat` without a corresponding
+`CompressionMethod` SHALL be treated as incomplete. `ArchiveMember.compression_method`
+SHALL hold the recognized **primary** codec as a `CompressionMethod` value, SHALL be
+`UNKNOWN` when the format reports a codec Archivey does not map, and SHALL remain `None`
+when the format does not report a compression method at all.
 
 Because a closed enum cannot represent a multi-filter chain (such as 7z
 `LZMA2 + BCJ2`) or a third-party reader's own codec name, `ArchiveMember` SHALL also
@@ -33,6 +38,11 @@ format reports that does not fit the enum SHALL be preserved in
 - **WHEN** a 7z member uses a filter chain such as LZMA2 followed by a BCJ filter
 - **THEN** `compression_method` is the typed primary codec (`CompressionMethod.LZMA2`)
   and `compression_method_detail` is the full chain string (e.g. `"LZMA2 + BCJ"`)
+
+#### Scenario: Every stream format maps to a typed codec
+- **WHEN** each `StreamFormat` member (gzip, bzip2, xz, zstd, lz4, lzip, zlib, brotli,
+  Unix-compress, uncompressed) is resolved to a `CompressionMethod`
+- **THEN** the result is a defined enum value and never `CompressionMethod.UNKNOWN`
 
 #### Scenario: Unmapped codec is UNKNOWN but not lost
 - **WHEN** the format reports a codec Archivey does not have an enum value for

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -162,58 +162,6 @@ the stream layer where backend selection happens.
   `tar.gz`, `EXPENSIVE` for a rewind-from-start `tar.gz`, and `UNAVAILABLE` for a
   non-seekable source
 
-### Requirement: AccessIntent declares the intended access pattern
-
-An `AccessIntent` enum SHALL let a caller declare at open time how they intend to access
-the archive, so archivey can choose backends accordingly:
-
-- `AUTO` (default) — no declared pattern; archivey preserves its default backend
-  selection and honors the explicit `use_*` configuration without selecting optional
-  backends on the caller's behalf.
-- `SEQUENTIAL` — the caller will iterate members in order; archivey MAY prefer the
-  cheapest streaming backend and SHALL NOT build seek indexes eagerly.
-- `RANDOM` — the caller will reach members out of order and/or seek within member
-  streams, possibly repeatedly; archivey SHALL prefer seekable/indexed backends (e.g.
-  rapidgzip, indexed_bzip2, a multi-block xz reader) when their packages are installed.
-
-`open_archive` SHALL accept an `access_intent` parameter defaulting to `AUTO`, and SHALL
-resolve it into the same backend selection driven by the explicit `use_*` configuration
-flags (a high-level shorthand over one selection mechanism, not a parallel one).
-
-#### Scenario: AUTO preserves default backend selection
-- **WHEN** an archive is opened with `access_intent=AUTO` (or the parameter omitted)
-- **THEN** backend selection is identical to opening with the explicit configuration
-  alone, and no optional backend is selected implicitly
-
-#### Scenario: RANDOM prefers an indexed backend when available
-- **WHEN** a `tar.gz` is opened with `access_intent=RANDOM` and rapidgzip is installed
-- **THEN** archivey uses the indexed (rapidgzip) backend and `member_access_cost` is
-  `AccessCost.LIMITED`
-
-### Requirement: Access intent is best-effort and reported through cost
-
-`access_intent` SHALL be a hint, not a guarantee. An explicit `use_*` configuration flag
-SHALL remain mandatory — an absent required package raises as today. `RANDOM` SHALL be
-best-effort: when a preferred optional backend's package is not installed, or the format
-cannot provide cheap random access (a solid 7z, a single-block xz), archivey SHALL fall
-back to an available backend and the cost properties (`member_access_cost`, member-stream
-`seek_cost`) SHALL report the **realized** cost rather than the requested one. archivey
-SHALL NOT raise solely because `RANDOM` could not be honored.
-
-#### Scenario: RANDOM falls back when the preferred package is missing
-- **WHEN** a `tar.gz` is opened with `access_intent=RANDOM` but rapidgzip is not installed
-- **THEN** the archive opens using the stdlib backend and `member_access_cost` is
-  `AccessCost.EXPENSIVE` (no exception is raised)
-
-#### Scenario: RANDOM on a format that cannot random-access cheaply
-- **WHEN** a solid 7z archive is opened with `access_intent=RANDOM`
-- **THEN** the archive opens and `member_access_cost` is `AccessCost.EXPENSIVE`
-
-#### Scenario: streaming=True conflicts with RANDOM
-- **WHEN** `open_archive` is called with `streaming=True` and `access_intent=RANDOM`
-- **THEN** it raises `ValueError` (forward-only and out-of-order are contradictory),
-  while `streaming=True` with `AUTO` or `SEQUENTIAL` is permitted
-
 ## MODIFIED Requirements
 
 ### Requirement: get_members_if_available avoids full traversal

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -76,15 +76,21 @@ so callers can reason about cost up front instead of discovering it at runtime:
   reachable while streaming forward, or whose single member is known up front, is **not**
   `SEQUENTIAL_ONLY` merely because the source is non-seekable.
 
-`member_listing_cost` SHALL be computed **per instance** from where the format keeps its
-member catalog (front/header-resident, tail-resident, single-known-member, or none) **and**
-the runtime seekability of the source — not from a plain "has a catalog" flag alone. The
-rule is: `INDEXED` when the catalog (or single known member) is reachable without a
+`member_listing_cost` SHALL be computed **per instance** from where the opened archive
+keeps its member catalog (header-resident, tail-resident, single-known-member, or none)
+**and** the runtime seekability of the source — not from a plain "has a catalog" flag
+alone. The catalog location itself MAY be **per file, not per format**: it MAY be a class
+fact where a format's layout is uniform (ZIP is always tail-resident, TAR always has no
+upfront catalog), but where it varies the reader SHALL determine it at open. For example,
+a RAR archive has an upfront catalog only when its optional "quick open" index (at the end
+of the archive) is present, and otherwise its per-member headers are found only by
+scanning — so the same format is tail-resident for one file and catalog-less for another.
+The rule is: `INDEXED` when the catalog (or single known member) is reachable without a
 backward seek — a header-resident catalog, a single-member stream, or a tail-resident
-catalog on a seekable source; `SCAN_REQUIRED` when there is no catalog but the source is
-seekable; `SEQUENTIAL_ONLY` when there is no catalog and the source is non-seekable. The
-caller's `streaming=True` preference alone SHALL NOT downgrade `INDEXED` when the catalog
-remains reachable.
+catalog on a seekable source; `SCAN_REQUIRED` when there is no upfront catalog but the
+source is seekable; `SEQUENTIAL_ONLY` when there is no upfront catalog and the source is
+non-seekable. The caller's `streaming=True` preference alone SHALL NOT downgrade `INDEXED`
+when the catalog remains reachable.
 
 The realized value SHALL track the reader actually in use. Listing a header-resident
 catalog from a **non-seekable** source becomes possible only when the reader can parse it
@@ -110,6 +116,14 @@ be until the stream is read).
 - **THEN** `member_listing_cost` is `MemberListingCost.INDEXED` even if the source is
   non-seekable (a capability native streaming readers unlock; a third-party reader that
   requires a seekable source instead raises at open and produces no listing cost)
+
+#### Scenario: Catalog location varies per file (RAR quick-open index)
+- **WHEN** a seekable RAR archive that carries its optional "quick open" end-of-archive
+  index is opened, versus an otherwise-identical RAR file without it
+- **THEN** `member_listing_cost` is `MemberListingCost.INDEXED` for the first (the index
+  is one seek away) and `MemberListingCost.SCAN_REQUIRED` for the second (members are
+  found only by scanning the per-member headers), showing the location is decided per
+  file rather than per format
 
 #### Scenario: Seekable tar requires a scan
 - **WHEN** a seekable tar is opened with `streaming=False`

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -61,33 +61,55 @@ written as one large block) carries a correspondingly loose bound.
 A `MemberListingCost` enum SHALL classify how the complete member list can be obtained,
 so callers can reason about cost up front instead of discovering it at runtime:
 
-- `INDEXED` — the format carries a catalog / central directory (its
-  `has_central_directory` class fact is true) **and that catalog is reachable on this
-  instance** (the source is seekable), so the list is obtainable with at most one
-  bounded seek without scanning member data (ZIP, 7z, RAR, folder, ISO on a seekable
-  source).
+- `INDEXED` — the full member list is obtainable with at most one bounded seek and
+  without scanning member data. This holds when the format's member catalog is reachable
+  **without seeking backward** — a catalog read while streaming forward (a header-resident
+  catalog), or a stream with a single, immediately-known member — **and also** when a
+  tail-resident catalog (ZIP's end-of-file central directory) is opened from a seekable
+  source.
 - `SCAN_REQUIRED` — the format has no catalog but the source is seekable, so the list
   is obtainable only by a full pass over the archive body, seeking or reading past each
   member's data (a seekable TAR opened with `streaming=False`).
-- `SEQUENTIAL_ONLY` — the source is non-seekable, or iteration is forward-only, so
-  there is no upfront list; members are discovered only as iteration proceeds (a TAR
-  opened with `streaming=True`, or any archive opened from a non-seekable source).
+- `SEQUENTIAL_ONLY` — the format has no catalog **and** the source is non-seekable (or
+  iteration is forward-only), so there is no upfront list; members are discovered only as
+  iteration proceeds (a TAR opened with `streaming=True`). A format whose catalog is
+  reachable while streaming forward, or whose single member is known up front, is **not**
+  `SEQUENTIAL_ONLY` merely because the source is non-seekable.
 
-`member_listing_cost` SHALL be computed **per instance** from the format's
-`has_central_directory` class fact **and** the runtime seekability of the source. It
-SHALL NOT be derived from `has_central_directory` alone: a catalog format opened from a
-non-seekable source cannot reach its catalog and is `SEQUENTIAL_ONLY`. The caller's
-`streaming=True` preference alone SHALL NOT downgrade `INDEXED` when the catalog
-remains reachable (the source is seekable).
+`member_listing_cost` SHALL be computed **per instance** from where the format keeps its
+member catalog (front/header-resident, tail-resident, single-known-member, or none) **and**
+the runtime seekability of the source — not from a plain "has a catalog" flag alone. The
+rule is: `INDEXED` when the catalog (or single known member) is reachable without a
+backward seek — a header-resident catalog, a single-member stream, or a tail-resident
+catalog on a seekable source; `SCAN_REQUIRED` when there is no catalog but the source is
+seekable; `SEQUENTIAL_ONLY` when there is no catalog and the source is non-seekable. The
+caller's `streaming=True` preference alone SHALL NOT downgrade `INDEXED` when the catalog
+remains reachable.
+
+The realized value SHALL track the reader actually in use. Listing a header-resident
+catalog from a **non-seekable** source becomes possible only when the reader can parse it
+forward; some formats are currently backed by third-party readers that require a seekable
+source, so a non-seekable open raises (see `archive-opening`) and produces no listing cost
+until a native streaming reader replaces them. A single-member stream is `INDEXED`
+regardless of seekability (the one member is known up front, though its size/CRC may not
+be until the stream is read).
 
 #### Scenario: Reachable catalog is INDEXED
 - **WHEN** a ZIP, 7z, RAR, folder, or ISO archive is opened from a seekable source
 - **THEN** `member_listing_cost` is `MemberListingCost.INDEXED`
 
-#### Scenario: Catalog format on a non-seekable source is sequential-only
-- **WHEN** a catalog format is opened from a non-seekable source (its end-of-file
-  catalog cannot be reached)
-- **THEN** `member_listing_cost` is `MemberListingCost.SEQUENTIAL_ONLY`
+#### Scenario: Single-member stream is INDEXED even when non-seekable
+- **WHEN** a single-file stream (e.g. a standalone `.gz`) is opened from a non-seekable
+  source
+- **THEN** `member_listing_cost` is `MemberListingCost.INDEXED` (its one member is known
+  up front, even though its size/CRC may not be until the stream is read)
+
+#### Scenario: Header-resident catalog can be INDEXED without seeking
+- **WHEN** a format whose member catalog is read while streaming forward is opened by a
+  reader that can parse that catalog without seeking backward
+- **THEN** `member_listing_cost` is `MemberListingCost.INDEXED` even if the source is
+  non-seekable (a capability native streaming readers unlock; a third-party reader that
+  requires a seekable source instead raises at open and produces no listing cost)
 
 #### Scenario: Seekable tar requires a scan
 - **WHEN** a seekable tar is opened with `streaming=False`
@@ -141,9 +163,25 @@ block or a rewind-from-start wrapper is `EXPENSIVE`; a forward-only stream is
 
 A reader whose out-of-order member access *is* a seek on such a stream — notably
 `TarReader` — SHALL derive its `member_access_cost`, and the `seek_cost` of the member
-streams it serves, by **reading the decompressed stream's `seek_cost`**, rather than
-re-deriving the cost from configuration flags. This keeps a single source of truth in
-the stream layer where backend selection happens.
+streams it serves, from **the underlying stream's seek cost**, rather than re-deriving the
+cost from configuration flags. This keeps a single source of truth in the stream layer
+where backend selection happens.
+
+Because in this phase not every decompressor stream is an Archivey type that exposes
+`seek_cost` (some are returned raw by third-party libraries; the public `ArchiveyStream`
+base that would guarantee the property is the separate `public-stream-interface` change),
+the seek cost SHALL be obtained through a **helper** rather than by assuming the attribute
+is present. The helper SHALL return the stream's own `seek_cost` when it exposes one, and
+otherwise fall back to a conservative estimate from the stream's type and `seekable()`
+(e.g. a seekable stream of unknown mechanism → `EXPENSIVE`; a non-seekable one →
+`UNAVAILABLE`). The estimate is a stopgap that will collapse into a direct read once all
+streams expose `seek_cost`.
+
+#### Scenario: Seek cost falls back for a non-Archivey stream
+- **WHEN** a reader obtains the seek cost of an underlying stream that does not expose a
+  `seek_cost` property
+- **THEN** the helper returns a conservative estimate from the stream's type and
+  `seekable()` (never raising), rather than assuming the property exists
 
 #### Scenario: A decompressor stream reports its own seek cost
 - **WHEN** a multi-block xz decompressor stream is opened over a seekable source
@@ -198,8 +236,9 @@ the member's content. `seek_cost` refines `seekable()` — letting callers disti
 true random-access stream from one that is seekable only by re-decompressing — and the
 two SHALL be consistent: `seekable()` returns `False` exactly when `seek_cost` is
 `UNAVAILABLE`, and `True` otherwise. Where the member's bytes come from a decompressor
-stream (e.g. a TAR member), the member stream's `seek_cost` SHALL be taken from that
-stream's own `seek_cost` rather than re-derived.
+stream (e.g. a TAR member), the member stream's `seek_cost` SHALL be obtained from that
+underlying stream — via the same helper described above (reading its `seek_cost` when
+present, else a conservative estimate) — rather than re-derived from configuration.
 
 The four tiers carry the same meaning as the archive-level `AccessCost` (above),
 applied to within-member seeks:

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -162,27 +162,6 @@ the stream layer where backend selection happens.
   `tar.gz`, `EXPENSIVE` for a rewind-from-start `tar.gz`, and `UNAVAILABLE` for a
   non-seekable source
 
-### Requirement: Returned streams share a common Archivey stream interface
-
-Every stream Archivey returns from `open()` and `iter_members_with_streams()` SHALL be
-an instance of a common base type (`ArchiveyStream`) that exposes the `seek_cost`
-introspection (above) and a `name: str | None` (the member path or source name,
-mirroring stdlib file objects' `.name`). This SHALL hold whether the bytes originate
-from an Archivey stream class or from a third-party library's stream object. A stream obtained from an underlying library
-SHALL be normalized into this interface (the existing protocol-normalizing wrapper is the
-natural place) so that `seek_cost` and `name` are always present; callers SHALL NOT have
-to special-case library-specific stream types to read them.
-
-#### Scenario: A library-backed member stream still exposes the interface
-- **WHEN** a member stream is obtained for a format whose decoding is delegated to a
-  third-party library
-- **THEN** the returned object exposes both `seek_cost` (an `AccessCost`) and `name`,
-  consistent with its `seekable()`
-
-#### Scenario: Member name is available on the stream
-- **WHEN** a member stream is obtained via `open()`
-- **THEN** its `name` reflects the member's path within the archive
-
 ## MODIFIED Requirements
 
 ### Requirement: get_members_if_available avoids full traversal

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -162,6 +162,27 @@ the stream layer where backend selection happens.
   `tar.gz`, `EXPENSIVE` for a rewind-from-start `tar.gz`, and `UNAVAILABLE` for a
   non-seekable source
 
+### Requirement: Returned streams share a common Archivey stream interface
+
+Every stream Archivey returns from `open()` and `iter_members_with_streams()` SHALL be
+an instance of a common base type (`ArchiveyStream`) that exposes the `seek_cost`
+introspection (above) and a `name: str | None` (the member path or source name,
+mirroring stdlib file objects' `.name`). This SHALL hold whether the bytes originate
+from an Archivey stream class or from a third-party library's stream object. A stream obtained from an underlying library
+SHALL be normalized into this interface (the existing protocol-normalizing wrapper is the
+natural place) so that `seek_cost` and `name` are always present; callers SHALL NOT have
+to special-case library-specific stream types to read them.
+
+#### Scenario: A library-backed member stream still exposes the interface
+- **WHEN** a member stream is obtained for a format whose decoding is delegated to a
+  third-party library
+- **THEN** the returned object exposes both `seek_cost` (an `AccessCost`) and `name`,
+  consistent with its `seekable()`
+
+#### Scenario: Member name is available on the stream
+- **WHEN** a member stream is obtained via `open()`
+- **THEN** its `name` reflects the member's path within the archive
+
 ## MODIFIED Requirements
 
 ### Requirement: get_members_if_available avoids full traversal

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -214,40 +214,6 @@ SHALL NOT raise solely because `RANDOM` could not be honored.
 - **THEN** it raises `ValueError` (forward-only and out-of-order are contradictory),
   while `streaming=True` with `AUTO` or `SEQUENTIAL` is permitted
 
-### Requirement: Optional warnings flag inefficient access
-
-archivey SHALL provide an **opt-in** mechanism — a `warn_on_inefficient_access`
-configuration flag that defaults to disabled — which, when enabled, emits a Python
-warning of a dedicated `InefficientAccessWarning` category when archive usage is
-inefficient relative to the declared intent or the archive's cost tier. The mechanism
-SHALL be silent when disabled (the default), and emitting or suppressing a warning SHALL
-NOT change which bytes are returned. Warnings SHALL be derived from the coarse
-`AccessCost` tier, not from per-call measurement.
-
-When enabled, archivey SHALL emit a warning at open time when `access_intent=RANDOM` was
-requested but the realized `member_access_cost` is `EXPENSIVE` or `UNAVAILABLE` (the
-preferred backend was unavailable, the source is non-seekable, or the format cannot
-random-access cheaply), describing why the intent could not be honored. When enabled,
-archivey SHOULD additionally emit a warning when repeated out-of-order member access, or
-repeated re-decompressing backward seeks within a member stream, occur on an
-`EXPENSIVE`-tier target (an O(N²) access pattern).
-
-#### Scenario: Disabled by default
-- **WHEN** an archive is used inefficiently and `warn_on_inefficient_access` is not
-  enabled
-- **THEN** no `InefficientAccessWarning` is emitted
-
-#### Scenario: Unmet RANDOM intent warns at open
-- **WHEN** `warn_on_inefficient_access` is enabled and a `tar.gz` is opened with
-  `access_intent=RANDOM` while rapidgzip is not installed
-- **THEN** an `InefficientAccessWarning` is emitted at open identifying that `RANDOM`
-  could not be honored, and the archive still opens and reads normally
-
-#### Scenario: Inefficient access loop warns
-- **WHEN** `warn_on_inefficient_access` is enabled and a solid 7z archive (cost
-  `EXPENSIVE`) is accessed out of order repeatedly
-- **THEN** an `InefficientAccessWarning` identifying the O(N²) pattern is emitted
-
 ## MODIFIED Requirements
 
 ### Requirement: get_members_if_available avoids full traversal

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -61,22 +61,39 @@ written as one large block) carries a correspondingly loose bound.
 A `MemberListingCost` enum SHALL classify how the complete member list can be obtained,
 so callers can reason about cost up front instead of discovering it at runtime:
 
-- `INDEXED` — obtainable from a catalog / central directory with at most one bounded
-  seek, without scanning member data (ZIP, 7z, RAR, folder, ISO).
-- `SCAN_REQUIRED` — obtainable only by a full pass over the archive body, seeking or
-  reading past each member's data (a seekable TAR opened with `streaming=False`).
-- `SEQUENTIAL_ONLY` — no upfront list; members are discovered only as iteration
-  proceeds (a TAR opened with `streaming=True`, or any non-seekable source).
+- `INDEXED` — the format carries a catalog / central directory (its
+  `has_central_directory` class fact is true) **and that catalog is reachable on this
+  instance** (the source is seekable), so the list is obtainable with at most one
+  bounded seek without scanning member data (ZIP, 7z, RAR, folder, ISO on a seekable
+  source).
+- `SCAN_REQUIRED` — the format has no catalog but the source is seekable, so the list
+  is obtainable only by a full pass over the archive body, seeking or reading past each
+  member's data (a seekable TAR opened with `streaming=False`).
+- `SEQUENTIAL_ONLY` — the source is non-seekable, or iteration is forward-only, so
+  there is no upfront list; members are discovered only as iteration proceeds (a TAR
+  opened with `streaming=True`, or any archive opened from a non-seekable source).
 
-#### Scenario: Catalog format is INDEXED
-- **WHEN** a ZIP, 7z, RAR, folder, or ISO archive is opened
+`member_listing_cost` SHALL be computed **per instance** from the format's
+`has_central_directory` class fact **and** the runtime seekability of the source. It
+SHALL NOT be derived from `has_central_directory` alone: a catalog format opened from a
+non-seekable source cannot reach its catalog and is `SEQUENTIAL_ONLY`. The caller's
+`streaming=True` preference alone SHALL NOT downgrade `INDEXED` when the catalog
+remains reachable (the source is seekable).
+
+#### Scenario: Reachable catalog is INDEXED
+- **WHEN** a ZIP, 7z, RAR, folder, or ISO archive is opened from a seekable source
 - **THEN** `member_listing_cost` is `MemberListingCost.INDEXED`
+
+#### Scenario: Catalog format on a non-seekable source is sequential-only
+- **WHEN** a catalog format is opened from a non-seekable source (its end-of-file
+  catalog cannot be reached)
+- **THEN** `member_listing_cost` is `MemberListingCost.SEQUENTIAL_ONLY`
 
 #### Scenario: Seekable tar requires a scan
 - **WHEN** a seekable tar is opened with `streaming=False`
 - **THEN** `member_listing_cost` is `MemberListingCost.SCAN_REQUIRED`
 
-#### Scenario: Streaming or non-seekable source is sequential-only
+#### Scenario: Streaming tar or non-seekable source is sequential-only
 - **WHEN** a tar is opened with `streaming=True`, or any archive is opened from a
   non-seekable source
 - **THEN** `member_listing_cost` is `MemberListingCost.SEQUENTIAL_ONLY`
@@ -110,13 +127,92 @@ NOT perform archive I/O or raise.
 - **WHEN** `member_access_cost` or `member_listing_cost` is read
 - **THEN** the value is returned without performing archive I/O or raising
 
-#### Scenario: TAR member_access_cost derives from the decompressed stream's seek cost
+### Requirement: Decompressor streams expose seek_cost and readers consume it
+
+Each decompressor/seekable-stream class SHALL expose a `seek_cost` property (an
+`AccessCost` value) describing the cost of seeking within that stream, consistent with
+its `seekable()` (`seekable()` is `False` exactly when `seek_cost` is `UNAVAILABLE`).
+This covers the stdlib rewind-from-start wrapper, rapidgzip, indexed_bzip2, the xz and
+lzip decompressor streams, and a plain seekable file. The `seek_cost` SHALL reflect the
+stream's own mechanism (a plain file or stored data is
+`DIRECT`; rapidgzip / indexed_bzip2 / a multi-block xz reader is `LIMITED`; a single xz
+block or a rewind-from-start wrapper is `EXPENSIVE`; a forward-only stream is
+`UNAVAILABLE`).
+
+A reader whose out-of-order member access *is* a seek on such a stream — notably
+`TarReader` — SHALL derive its `member_access_cost`, and the `seek_cost` of the member
+streams it serves, by **reading the decompressed stream's `seek_cost`**, rather than
+re-deriving the cost from configuration flags. This keeps a single source of truth in
+the stream layer where backend selection happens.
+
+#### Scenario: A decompressor stream reports its own seek cost
+- **WHEN** a multi-block xz decompressor stream is opened over a seekable source
+- **THEN** its `seek_cost` is `AccessCost.LIMITED`, while a rewind-from-start stdlib
+  gzip wrapper opened over the same kind of source reports `AccessCost.EXPENSIVE`
+
+#### Scenario: TAR reads the decompressed stream's seek cost
+- **WHEN** a multi-block `tar.xz` is opened with `streaming=False`
+- **THEN** `member_access_cost` equals the xz stream's `seek_cost` (`AccessCost.LIMITED`),
+  not `AccessCost.EXPENSIVE`
+
+#### Scenario: TAR access cost tracks the decompressor across backends
 - **WHEN** a TAR reader reports `member_access_cost`
-- **THEN** the value equals the `seek_cost` of the decompressed stream it opens
-  (reaching a member out of order is a seek on that stream): `DIRECT` for an
-  uncompressed seekable tar, `LIMITED` for an indexed-decompressor `tar.gz`,
-  `EXPENSIVE` for a rewind-from-start `tar.gz`, and `UNAVAILABLE` for a non-seekable
-  source
+- **THEN** the value equals the `seek_cost` of the decompressed stream it opens:
+  `DIRECT` for an uncompressed seekable tar, `LIMITED` for an indexed-decompressor
+  `tar.gz`, `EXPENSIVE` for a rewind-from-start `tar.gz`, and `UNAVAILABLE` for a
+  non-seekable source
+
+### Requirement: AccessIntent declares the intended access pattern
+
+An `AccessIntent` enum SHALL let a caller declare at open time how they intend to access
+the archive, so archivey can choose backends accordingly:
+
+- `AUTO` (default) — no declared pattern; archivey preserves its default backend
+  selection and honors the explicit `use_*` configuration without selecting optional
+  backends on the caller's behalf.
+- `SEQUENTIAL` — the caller will iterate members in order; archivey MAY prefer the
+  cheapest streaming backend and SHALL NOT build seek indexes eagerly.
+- `RANDOM` — the caller will reach members out of order and/or seek within member
+  streams, possibly repeatedly; archivey SHALL prefer seekable/indexed backends (e.g.
+  rapidgzip, indexed_bzip2, a multi-block xz reader) when their packages are installed.
+
+`open_archive` SHALL accept an `access_intent` parameter defaulting to `AUTO`, and SHALL
+resolve it into the same backend selection driven by the explicit `use_*` configuration
+flags (a high-level shorthand over one selection mechanism, not a parallel one).
+
+#### Scenario: AUTO preserves default backend selection
+- **WHEN** an archive is opened with `access_intent=AUTO` (or the parameter omitted)
+- **THEN** backend selection is identical to opening with the explicit configuration
+  alone, and no optional backend is selected implicitly
+
+#### Scenario: RANDOM prefers an indexed backend when available
+- **WHEN** a `tar.gz` is opened with `access_intent=RANDOM` and rapidgzip is installed
+- **THEN** archivey uses the indexed (rapidgzip) backend and `member_access_cost` is
+  `AccessCost.LIMITED`
+
+### Requirement: Access intent is best-effort and reported through cost
+
+`access_intent` SHALL be a hint, not a guarantee. An explicit `use_*` configuration flag
+SHALL remain mandatory — an absent required package raises as today. `RANDOM` SHALL be
+best-effort: when a preferred optional backend's package is not installed, or the format
+cannot provide cheap random access (a solid 7z, a single-block xz), archivey SHALL fall
+back to an available backend and the cost properties (`member_access_cost`, member-stream
+`seek_cost`) SHALL report the **realized** cost rather than the requested one. archivey
+SHALL NOT raise solely because `RANDOM` could not be honored.
+
+#### Scenario: RANDOM falls back when the preferred package is missing
+- **WHEN** a `tar.gz` is opened with `access_intent=RANDOM` but rapidgzip is not installed
+- **THEN** the archive opens using the stdlib backend and `member_access_cost` is
+  `AccessCost.EXPENSIVE` (no exception is raised)
+
+#### Scenario: RANDOM on a format that cannot random-access cheaply
+- **WHEN** a solid 7z archive is opened with `access_intent=RANDOM`
+- **THEN** the archive opens and `member_access_cost` is `AccessCost.EXPENSIVE`
+
+#### Scenario: streaming=True conflicts with RANDOM
+- **WHEN** `open_archive` is called with `streaming=True` and `access_intent=RANDOM`
+- **THEN** it raises `ValueError` (forward-only and out-of-order are contradictory),
+  while `streaming=True` with `AUTO` or `SEQUENTIAL` is permitted
 
 ## MODIFIED Requirements
 
@@ -153,7 +249,9 @@ view of another property. In *addition*, member streams SHALL expose a separate
 the member's content. `seek_cost` refines `seekable()` — letting callers distinguish a
 true random-access stream from one that is seekable only by re-decompressing — and the
 two SHALL be consistent: `seekable()` returns `False` exactly when `seek_cost` is
-`UNAVAILABLE`, and `True` otherwise.
+`UNAVAILABLE`, and `True` otherwise. Where the member's bytes come from a decompressor
+stream (e.g. a TAR member), the member stream's `seek_cost` SHALL be taken from that
+stream's own `seek_cost` rather than re-derived.
 
 The four tiers carry the same meaning as the archive-level `AccessCost` (above),
 applied to within-member seeks:

--- a/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
+++ b/openspec/changes/base-reader-architecture-extensions/specs/archive-reading/spec.md
@@ -214,6 +214,40 @@ SHALL NOT raise solely because `RANDOM` could not be honored.
 - **THEN** it raises `ValueError` (forward-only and out-of-order are contradictory),
   while `streaming=True` with `AUTO` or `SEQUENTIAL` is permitted
 
+### Requirement: Optional warnings flag inefficient access
+
+archivey SHALL provide an **opt-in** mechanism — a `warn_on_inefficient_access`
+configuration flag that defaults to disabled — which, when enabled, emits a Python
+warning of a dedicated `InefficientAccessWarning` category when archive usage is
+inefficient relative to the declared intent or the archive's cost tier. The mechanism
+SHALL be silent when disabled (the default), and emitting or suppressing a warning SHALL
+NOT change which bytes are returned. Warnings SHALL be derived from the coarse
+`AccessCost` tier, not from per-call measurement.
+
+When enabled, archivey SHALL emit a warning at open time when `access_intent=RANDOM` was
+requested but the realized `member_access_cost` is `EXPENSIVE` or `UNAVAILABLE` (the
+preferred backend was unavailable, the source is non-seekable, or the format cannot
+random-access cheaply), describing why the intent could not be honored. When enabled,
+archivey SHOULD additionally emit a warning when repeated out-of-order member access, or
+repeated re-decompressing backward seeks within a member stream, occur on an
+`EXPENSIVE`-tier target (an O(N²) access pattern).
+
+#### Scenario: Disabled by default
+- **WHEN** an archive is used inefficiently and `warn_on_inefficient_access` is not
+  enabled
+- **THEN** no `InefficientAccessWarning` is emitted
+
+#### Scenario: Unmet RANDOM intent warns at open
+- **WHEN** `warn_on_inefficient_access` is enabled and a `tar.gz` is opened with
+  `access_intent=RANDOM` while rapidgzip is not installed
+- **THEN** an `InefficientAccessWarning` is emitted at open identifying that `RANDOM`
+  could not be honored, and the archive still opens and reads normally
+
+#### Scenario: Inefficient access loop warns
+- **WHEN** `warn_on_inefficient_access` is enabled and a solid 7z archive (cost
+  `EXPENSIVE`) is accessed out of order repeatedly
+- **THEN** an `InefficientAccessWarning` identifying the O(N²) pattern is emitted
+
 ## MODIFIED Requirements
 
 ### Requirement: get_members_if_available avoids full traversal

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -68,8 +68,18 @@
 - [ ] 4.4 Raise `ValueError` for `streaming=True` together with `access_intent=RANDOM`;
       allow `streaming=True` with `AUTO`/`SEQUENTIAL`
 
-## 5. Validation
+## 5. Inefficient-access warnings (§8.G)
 
-- [ ] 5.1 `openspec validate base-reader-architecture-extensions --type change --strict`
-- [ ] 5.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
-      default keeps current backend selection)
+- [ ] 5.1 Add a `warn_on_inefficient_access: bool = False` config flag and an
+      `InefficientAccessWarning` warning category
+- [ ] 5.2 When enabled, emit the warning at open when `access_intent=RANDOM` but the
+      realized `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` (name the cause)
+- [ ] 5.3 (secondary, may split) When enabled, track per-archive access patterns and
+      warn on repeated out-of-order access / re-decompressing backward seeks on an
+      `EXPENSIVE` target; keep this off the hot path and silent when the flag is off
+
+## 6. Validation
+
+- [ ] 6.1 `openspec validate base-reader-architecture-extensions --type change --strict`
+- [ ] 6.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
+      default + `warn_on_inefficient_access=False` keep current behavior)

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -13,9 +13,12 @@
       cannot random-access — i.e. a compressed TAR whose decompressor is
       non-seekable at construction time
 - [ ] 1.2 Replace the `members_list_supported` `__init__` argument with a
-      `has_central_directory: ClassVar[bool]` on each reader class (`True` for
-      ZIP/7z/RAR/ISO/folder/single-file, `False` for TAR); remove the standalone
-      boolean (it is now `member_listing_cost == INDEXED`)
+      catalog-location `ClassVar` on each reader class capturing *where* the member
+      catalog lives — header-resident (readable streaming forward), tail-resident (ZIP
+      EOCD), single-known-member (single-file), or none (TAR) — richer than a plain
+      "has a catalog" bool; remove the standalone boolean (it is now
+      `member_listing_cost == INDEXED`). Confirm each format's actual catalog location
+      (e.g. RAR/7z/ISO) when wiring this up
 
 ## 2. Compression method types (§8.D)
 
@@ -42,23 +45,31 @@
       `SEQUENTIAL_ONLY`) and a shared `AccessCost` enum (`DIRECT` / `LIMITED` /
       `EXPENSIVE` / `UNAVAILABLE`) to `types.py`
 - [ ] 3.2 Add a `member_listing_cost: MemberListingCost` property computed **per
-      instance** from `has_central_directory` **and** source seekability (do **not**
-      derive `INDEXED` from the ClassVar alone); `streaming=True` on a seekable catalog
-      source stays `INDEXED`
+      instance** from the catalog-location ClassVar **and** source seekability (do
+      **not** derive `INDEXED` from a "has a catalog" flag alone): `INDEXED` when the
+      catalog/single member is reachable without a backward seek (header catalog,
+      single-member, or tail catalog on a seekable source), `SCAN_REQUIRED` for a
+      seekable no-catalog format, `SEQUENTIAL_ONLY` otherwise; `streaming=True` on a
+      seekable catalog source stays `INDEXED`, and a single-file `.gz` is `INDEXED` even
+      on a pipe
 - [ ] 3.3 Add a `seek_cost: AccessCost` property to each decompressor/seekable-stream
       class (stdlib rewind wrapper, rapidgzip, indexed_bzip2, `XzDecompressorStream`,
       lzip, plain file), consistent with its `seekable()`
+- [ ] 3.3a Add a tolerant `seek_cost_of(stream) -> AccessCost` helper that returns
+      `stream.seek_cost` when present and otherwise a conservative estimate from the
+      stream's type / `seekable()` (seekable-unknown → `EXPENSIVE`, non-seekable →
+      `UNAVAILABLE`), so readers do not assume every stream is an Archivey type yet
 - [ ] 3.4 Add a `member_access_cost: AccessCost` property to
       `ArchiveReader`/`BaseArchiveReader`; have each reader report it by mechanism
-      (no I/O, no raise). For `TarReader`, **read** `member_access_cost` from the
-      `seek_cost` of the decompressed stream it opens (do not re-derive from
+      (no I/O, no raise). For `TarReader`, derive `member_access_cost` from the
+      decompressed stream it opens via `seek_cost_of(...)` (do not re-derive from
       `config.use_*`); this refines the inner-stream `seekable()` check at
       `tar_reader.py:112`
 - [ ] 3.5 Add a `seek_cost: AccessCost` property to the member-stream wrapper
       (`ArchiveStream`) *alongside* the protocol-required `seekable()` (keep
       `seekable()` as-is — the IO contract); keep the two consistent (`seekable()` is
-      `False` iff `seek_cost == UNAVAILABLE`), and take it from the underlying
-      decompressor stream's `seek_cost` where applicable
+      `False` iff `seek_cost == UNAVAILABLE`), and take it from the underlying stream via
+      `seek_cost_of(...)` where applicable
 - [ ] 3.6 Remove `has_random_access()`; migrate callers/docs to
       `member_access_cost != AccessCost.UNAVAILABLE`
 - [ ] 3.7 Tighten `get_members_if_available()` so it returns the list only for

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -68,18 +68,8 @@
 - [ ] 4.4 Raise `ValueError` for `streaming=True` together with `access_intent=RANDOM`;
       allow `streaming=True` with `AUTO`/`SEQUENTIAL`
 
-## 5. Inefficient-access warnings (§8.G)
+## 5. Validation
 
-- [ ] 5.1 Add a `warn_on_inefficient_access: bool = False` config flag and an
-      `InefficientAccessWarning` warning category
-- [ ] 5.2 When enabled, emit the warning at open when `access_intent=RANDOM` but the
-      realized `member_access_cost` is `EXPENSIVE`/`UNAVAILABLE` (name the cause)
-- [ ] 5.3 (secondary, may split) When enabled, track per-archive access patterns and
-      warn on repeated out-of-order access / re-decompressing backward seeks on an
-      `EXPENSIVE` target; keep this off the hot path and silent when the flag is off
-
-## 6. Validation
-
-- [ ] 6.1 `openspec validate base-reader-architecture-extensions --type change --strict`
-- [ ] 6.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
-      default + `warn_on_inefficient_access=False` keep current behavior)
+- [ ] 5.1 `openspec validate base-reader-architecture-extensions --type change --strict`
+- [ ] 5.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
+      default keeps current backend selection)

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -19,15 +19,27 @@
 
 ## 2. Compression method types (§8.D)
 
-- [ ] 2.1 Add `CompressionMethod` `StrEnum` (STORED, DEFLATE, LZMA, LZMA2, ZSTD,
-      BZIP2, PPMD, BCJ2, …, UNKNOWN) in `types.py`; add a free-form
+- [ ] 2.1 Add `CompressionMethod` `StrEnum` in `types.py`, **exhaustive over every
+      `StreamFormat`**: STORED, DEFLATE (gzip/zlib), BZIP2, LZMA2 (xz), LZMA (lzip),
+      ZSTD, LZ4, BROTLI, LZW (Unix compress), plus container-internal codecs (PPMD,
+      BCJ2, DEFLATE64, DELTA, …) and UNKNOWN; add a free-form
       `compression_method_detail: Optional[str]` field to `ArchiveMember`
+- [ ] 2.1a Add a regression test asserting every `StreamFormat` member resolves to a
+      defined (non-`UNKNOWN`) `CompressionMethod`, so a new `StreamFormat` without its
+      codec fails CI
 - [ ] 2.2 Map readers' primary `compression_method` onto the enum (`UNKNOWN` for
       reported-but-unmapped, `None` when unreported); preserve the verbatim/full
       codec description (e.g. 7z filter chains) in `compression_method_detail`
 
 ## 3. Cost introspection (§8.E)
 
+- [ ] 3.0 Introduce a shared `ArchiveyStream` base (subclass of `io.RawIOBase,
+      BinaryIO`) declaring `seek_cost: AccessCost` (consistent with `seekable()`) and
+      `name: str | None`; have `ArchiveStream` / `DecompressorStream` (and the
+      decompressor subclasses) inherit it. Make `BinaryIOWrapper` / `ensure_binaryio`
+      (`internal/io_helpers.py`) produce an `ArchiveyStream` so foreign library streams
+      carry the same surface, and ensure `open()` / `iter_members_with_streams()` only
+      ever return `ArchiveyStream` instances (wrap rather than annotate raw streams)
 - [ ] 3.1 Add a `MemberListingCost` enum (`INDEXED` / `SCAN_REQUIRED` /
       `SEQUENTIAL_ONLY`) and a shared `AccessCost` enum (`DIRECT` / `LIMITED` /
       `EXPENSIVE` / `UNAVAILABLE`) to `types.py`

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -12,13 +12,15 @@
       `__init__`, **not** a ClassVar); set `False` only when the format genuinely
       cannot random-access — i.e. a compressed TAR whose decompressor is
       non-seekable at construction time
-- [ ] 1.2 Replace the `members_list_supported` `__init__` argument with a
-      catalog-location `ClassVar` on each reader class capturing *where* the member
-      catalog lives — header-resident (readable streaming forward), tail-resident (ZIP
-      EOCD), single-known-member (single-file), or none (TAR) — richer than a plain
-      "has a catalog" bool; remove the standalone boolean (it is now
-      `member_listing_cost == INDEXED`). Confirm each format's actual catalog location
-      (e.g. RAR/7z/ISO) when wiring this up
+- [ ] 1.2 Replace the `members_list_supported` `__init__` argument with a catalog-location
+      fact capturing *where* the opened archive's member catalog lives — header-resident
+      (readable streaming forward), tail-resident (ZIP EOCD), single-known-member
+      (single-file), or none (TAR) — richer than a plain "has a catalog" bool. Allow it to
+      be a `ClassVar` where the format's layout is uniform (ZIP, TAR) **but per-instance
+      where it varies**: RAR has an upfront catalog only when its optional end-of-archive
+      "quick open" index is present, else its per-member headers are scan-only. Remove the
+      standalone boolean (it is now `member_listing_cost == INDEXED`). Confirm each
+      format's actual catalog location/variation (RAR/7z/ISO) when wiring this up
 
 ## 2. Compression method types (§8.D)
 
@@ -45,12 +47,13 @@
       `SEQUENTIAL_ONLY`) and a shared `AccessCost` enum (`DIRECT` / `LIMITED` /
       `EXPENSIVE` / `UNAVAILABLE`) to `types.py`
 - [ ] 3.2 Add a `member_listing_cost: MemberListingCost` property computed **per
-      instance** from the catalog-location ClassVar **and** source seekability (do
-      **not** derive `INDEXED` from a "has a catalog" flag alone): `INDEXED` when the
-      catalog/single member is reachable without a backward seek (header catalog,
-      single-member, or tail catalog on a seekable source), `SCAN_REQUIRED` for a
-      seekable no-catalog format, `SEQUENTIAL_ONLY` otherwise; `streaming=True` on a
-      seekable catalog source stays `INDEXED`, and a single-file `.gz` is `INDEXED` even
+      instance** from the realized catalog location (ClassVar baseline or, where it varies
+      per file like RAR's optional quick-open index, determined at open) **and** source
+      seekability (do **not** derive `INDEXED` from a "has a catalog" flag alone):
+      `INDEXED` when the catalog/single member is reachable without a backward seek (header
+      catalog, single-member, or tail catalog on a seekable source), `SCAN_REQUIRED` for a
+      seekable no-upfront-catalog archive, `SEQUENTIAL_ONLY` otherwise; `streaming=True` on
+      a seekable catalog source stays `INDEXED`, and a single-file `.gz` is `INDEXED` even
       on a pipe
 - [ ] 3.3 Add a `seek_cost: AccessCost` property to each decompressor/seekable-stream
       class (stdlib rewind wrapper, rapidgzip, indexed_bzip2, `XzDecompressorStream`,

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -33,13 +33,11 @@
 
 ## 3. Cost introspection (§8.E)
 
-- [ ] 3.0 Introduce a shared `ArchiveyStream` base (subclass of `io.RawIOBase,
-      BinaryIO`) declaring `seek_cost: AccessCost` (consistent with `seekable()`) and
-      `name: str | None`; have `ArchiveStream` / `DecompressorStream` (and the
-      decompressor subclasses) inherit it. Make `BinaryIOWrapper` / `ensure_binaryio`
-      (`internal/io_helpers.py`) produce an `ArchiveyStream` so foreign library streams
-      carry the same surface, and ensure `open()` / `iter_members_with_streams()` only
-      ever return `ArchiveyStream` instances (wrap rather than annotate raw streams)
+> The shared **public** `ArchiveyStream` base — guaranteeing `seek_cost` on *every*
+> returned stream, including third-party library streams — is split into the separate
+> `public-stream-interface` change. Here, `seek_cost` is added to archivey's own stream
+> classes only.
+
 - [ ] 3.1 Add a `MemberListingCost` enum (`INDEXED` / `SCAN_REQUIRED` /
       `SEQUENTIAL_ONLY`) and a shared `AccessCost` enum (`DIRECT` / `LIMITED` /
       `EXPENSIVE` / `UNAVAILABLE`) to `types.py`

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -1,8 +1,10 @@
 # Implementation Tasks: Base reader architecture extensions
 
-> Scope: §8.B–§8.F. §8.A (migrate the 7z/RAR solid readers onto the existing
+> Scope: §8.B–§8.E. §8.A (migrate the 7z/RAR solid readers onto the existing
 > `_iter_members_and_streams_internal` hook) is folded into the native-reader
-> changes (`rar-native-metadata-reader` / `sevenzip-native-reader`).
+> changes (`rar-native-metadata-reader` / `sevenzip-native-reader`). §8.F (access
+> intent) is split out into the separate `access-intent` change, which builds on the
+> cost introspection added here.
 
 ## 1. Capability/preference split (§8.B, §8.C)
 
@@ -53,23 +55,8 @@
       `INDEXED` (or already-registered) members and never triggers a `SCAN_REQUIRED`
       pass
 
-## 4. Access intent (§8.F)
+## 4. Validation
 
-- [ ] 4.1 Add an `AccessIntent` `StrEnum` (`AUTO` / `SEQUENTIAL` / `RANDOM`) to
-      `types.py`
-- [ ] 4.2 Add an `access_intent: AccessIntent` parameter to `open_archive`
-      (default `AUTO`, accepting the string literal too) and resolve it into the
-      effective backend selection (the existing `use_*` flags), without adding a
-      parallel selection path
-- [ ] 4.3 Make `RANDOM` best-effort: prefer rapidgzip / indexed_bzip2 / multi-block xz
-      **when installed**, otherwise fall back and let the cost properties report the
-      realized (`EXPENSIVE`) outcome; keep explicit `use_*` flags mandatory (still
-      raise `PackageNotInstalledError` when their package is absent)
-- [ ] 4.4 Raise `ValueError` for `streaming=True` together with `access_intent=RANDOM`;
-      allow `streaming=True` with `AUTO`/`SEQUENTIAL`
-
-## 5. Validation
-
-- [ ] 5.1 `openspec validate base-reader-architecture-extensions --type change --strict`
-- [ ] 5.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
-      default keeps current backend selection)
+- [ ] 4.1 `openspec validate base-reader-architecture-extensions --type change --strict`
+- [ ] 4.2 `hatch run lint` and `hatch run test` (no behavioral regressions; cost
+      properties are additive and `streaming` still drives access mode here)

--- a/openspec/changes/base-reader-architecture-extensions/tasks.md
+++ b/openspec/changes/base-reader-architecture-extensions/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Tasks: Base reader architecture extensions
 
-> Scope: §8.B–§8.E. §8.A (migrate the 7z/RAR solid readers onto the existing
+> Scope: §8.B–§8.F. §8.A (migrate the 7z/RAR solid readers onto the existing
 > `_iter_members_and_streams_internal` hook) is folded into the native-reader
 > changes (`rar-native-metadata-reader` / `sevenzip-native-reader`).
 
@@ -10,10 +10,12 @@
       `__init__`, **not** a ClassVar); set `False` only when the format genuinely
       cannot random-access — i.e. a compressed TAR whose decompressor is
       non-seekable at construction time
-- [ ] 1.2 Make `members_list_supported` a ClassVar on each reader instead of an
-      `__init__` argument
+- [ ] 1.2 Replace the `members_list_supported` `__init__` argument with a
+      `has_central_directory: ClassVar[bool]` on each reader class (`True` for
+      ZIP/7z/RAR/ISO/folder/single-file, `False` for TAR); remove the standalone
+      boolean (it is now `member_listing_cost == INDEXED`)
 
-## 2. Public introspection & types (§8.D, §8.E)
+## 2. Compression method types (§8.D)
 
 - [ ] 2.1 Add `CompressionMethod` `StrEnum` (STORED, DEFLATE, LZMA, LZMA2, ZSTD,
       BZIP2, PPMD, BCJ2, …, UNKNOWN) in `types.py`; add a free-form
@@ -21,25 +23,53 @@
 - [ ] 2.2 Map readers' primary `compression_method` onto the enum (`UNKNOWN` for
       reported-but-unmapped, `None` when unreported); preserve the verbatim/full
       codec description (e.g. 7z filter chains) in `compression_method_detail`
-- [ ] 2.3 Add a `MemberListingCost` enum (`INDEXED` / `SCAN_REQUIRED` /
+
+## 3. Cost introspection (§8.E)
+
+- [ ] 3.1 Add a `MemberListingCost` enum (`INDEXED` / `SCAN_REQUIRED` /
       `SEQUENTIAL_ONLY`) and a shared `AccessCost` enum (`DIRECT` / `LIMITED` /
       `EXPENSIVE` / `UNAVAILABLE`) to `types.py`
-- [ ] 2.4 Add `member_listing_cost: MemberListingCost` and `member_access_cost: AccessCost`
-      properties to `ArchiveReader`/`BaseArchiveReader`; have each reader report both
-      by mechanism (no I/O, no raise). For `TarReader`, derive `member_access_cost` from the
-      `seek_cost` of the decompressed stream it opens (refining the inner-stream
-      `seekable()` check at `tar_reader.py:112`)
-- [ ] 2.5 Remove `has_random_access()`; migrate callers/docs to
+- [ ] 3.2 Add a `member_listing_cost: MemberListingCost` property computed **per
+      instance** from `has_central_directory` **and** source seekability (do **not**
+      derive `INDEXED` from the ClassVar alone); `streaming=True` on a seekable catalog
+      source stays `INDEXED`
+- [ ] 3.3 Add a `seek_cost: AccessCost` property to each decompressor/seekable-stream
+      class (stdlib rewind wrapper, rapidgzip, indexed_bzip2, `XzDecompressorStream`,
+      lzip, plain file), consistent with its `seekable()`
+- [ ] 3.4 Add a `member_access_cost: AccessCost` property to
+      `ArchiveReader`/`BaseArchiveReader`; have each reader report it by mechanism
+      (no I/O, no raise). For `TarReader`, **read** `member_access_cost` from the
+      `seek_cost` of the decompressed stream it opens (do not re-derive from
+      `config.use_*`); this refines the inner-stream `seekable()` check at
+      `tar_reader.py:112`
+- [ ] 3.5 Add a `seek_cost: AccessCost` property to the member-stream wrapper
+      (`ArchiveStream`) *alongside* the protocol-required `seekable()` (keep
+      `seekable()` as-is — the IO contract); keep the two consistent (`seekable()` is
+      `False` iff `seek_cost == UNAVAILABLE`), and take it from the underlying
+      decompressor stream's `seek_cost` where applicable
+- [ ] 3.6 Remove `has_random_access()`; migrate callers/docs to
       `member_access_cost != AccessCost.UNAVAILABLE`
-- [ ] 2.6 Add a `seek_cost: AccessCost` property to the member-stream wrapper
-      *alongside* the protocol-required `seekable()` (keep `seekable()` as-is — the IO
-      contract); keep the two consistent (`seekable()` is `False` iff `seek_cost ==
-      UNAVAILABLE`)
-- [ ] 2.7 Tighten `get_members_if_available()` so it returns the list only for
+- [ ] 3.7 Tighten `get_members_if_available()` so it returns the list only for
       `INDEXED` (or already-registered) members and never triggers a `SCAN_REQUIRED`
       pass
 
-## 3. Validation
+## 4. Access intent (§8.F)
 
-- [ ] 3.1 `openspec validate base-reader-architecture-extensions --type change --strict`
-- [ ] 3.2 `hatch run lint` and `hatch run test` (no behavioral regressions)
+- [ ] 4.1 Add an `AccessIntent` `StrEnum` (`AUTO` / `SEQUENTIAL` / `RANDOM`) to
+      `types.py`
+- [ ] 4.2 Add an `access_intent: AccessIntent` parameter to `open_archive`
+      (default `AUTO`, accepting the string literal too) and resolve it into the
+      effective backend selection (the existing `use_*` flags), without adding a
+      parallel selection path
+- [ ] 4.3 Make `RANDOM` best-effort: prefer rapidgzip / indexed_bzip2 / multi-block xz
+      **when installed**, otherwise fall back and let the cost properties report the
+      realized (`EXPENSIVE`) outcome; keep explicit `use_*` flags mandatory (still
+      raise `PackageNotInstalledError` when their package is absent)
+- [ ] 4.4 Raise `ValueError` for `streaming=True` together with `access_intent=RANDOM`;
+      allow `streaming=True` with `AUTO`/`SEQUENTIAL`
+
+## 5. Validation
+
+- [ ] 5.1 `openspec validate base-reader-architecture-extensions --type change --strict`
+- [ ] 5.2 `hatch run lint` and `hatch run test` (no behavioral regressions; `AUTO`
+      default keeps current backend selection)

--- a/openspec/changes/public-stream-interface/proposal.md
+++ b/openspec/changes/public-stream-interface/proposal.md
@@ -67,6 +67,14 @@ Depends on `base-reader-architecture-extensions` (the `AccessCost` / `seek_cost`
 Should be scheduled **after** a dedicated exploration of archivey's stream usage; the spec
 here is intentionally minimal until that analysis is done.
 
+Recommended order: implemented **last** of the pending changes
+(`test-suite-parametrization` → `base-reader-architecture-extensions` → `access-intent`
+→ native readers → `unify-junction-handling` → **this change**). It is sequenced last on
+purpose — blocking the cost foundation on this exploration would stall everything, and
+the cost of waiting is small and known: this change hoists the per-class `seek_cost` that
+`base-reader-architecture-extensions` adds onto the shared `ArchiveyStream` base, at which
+point that change's tolerant `seek_cost_of` helper collapses into a direct property read.
+
 ## Impact
 
 - **Files (anticipated)**: `internal/io_helpers.py` (the `ArchiveyStream` base + the

--- a/openspec/changes/public-stream-interface/proposal.md
+++ b/openspec/changes/public-stream-interface/proposal.md
@@ -1,0 +1,76 @@
+# Public stream interface — `ArchiveyStream` (exploration)
+
+## Status
+
+**Exploration — the surface is not finalized.** This change records a direction and its
+open questions; the spec delta is deliberately minimal. It is split out of
+`base-reader-architecture-extensions` (which adds `seek_cost` to archivey's *own* stream
+classes) so that the broader question — *how archivey constructs, wraps, and hands back
+streams in general* — can be analyzed on its own before we commit to a public API.
+
+## Why
+
+`base-reader-architecture-extensions` adds `seek_cost` (and the `AccessCost` scale) to
+archivey's member-stream and decompressor-stream classes. But the introspection is only
+as good as its reach:
+
+- archivey has several stream classes that each independently subclass
+  `io.RawIOBase, BinaryIO` (`ArchiveStream`, `DecompressorStream`, `BinaryIOWrapper`,
+  `StatsIO`, `ConcatenationStream`, `RecordableStream`, `ErrorIOStream`), with **no shared
+  archivey base**; and
+- a stream handed back from a third-party library (py7zr / rarfile / zipfile) may not be
+  an archivey type at all, so nothing guarantees `seek_cost` / metadata is present on
+  **every** stream archivey returns.
+
+If `seek_cost` and friends are worth exposing, a caller should be able to read them on any
+returned stream without special-casing the concrete type — which means a **public** base
+type that every returned stream is an instance of. That public type is also the natural
+seed for a wider review of archivey's stream handling.
+
+## What we already know (decided)
+
+- **`ArchiveyStream` is public API.** The whole point of attaching cost + metadata is for
+  callers to use them; an internal-only base would defeat that. It is *also* a normal
+  binary stream (`io.RawIOBase` / `BinaryIO`), usable anywhere a file object is.
+- It carries at least `seek_cost: AccessCost` (consistent with `seekable()`) and a
+  `name: str | None` (mirroring stdlib file objects' `.name`).
+- Streams from third-party libraries are normalized into it (the existing
+  `ensure_binaryio()` / `BinaryIOWrapper` path is the natural seam); the working
+  recommendation is to **wrap** rather than `setattr` onto the raw object.
+
+## Open questions (to explore)
+
+- **Full metadata set** — beyond `seek_cost` + `name`: a back-reference to the
+  `ArchiveMember`? the member's `CompressionMethod`? the source `StreamFormat`? a size?
+- **Base class vs mixin vs `Protocol`** — should every internal stream class inherit one
+  concrete base, or should the public surface be a `Protocol` plus a mixin, given the
+  classes already carry divergent `io.RawIOBase` plumbing?
+- **Wrapping cost** — is the extra wrapper layer ever a measurable hotspot (archives with
+  very many small members)? If so, when is annotate-in-place justified?
+- **Scope of "streams in general"** — recording, concatenation, stats, rewindable
+  wrappers, and error streams may want a more unified model. This is the analysis to do
+  before locking the API.
+- **Write paths** — does the public base cover only readable streams, or also writable
+  ones?
+
+## Capabilities
+
+### New Capabilities
+
+- `archivey-stream`: a public `ArchiveyStream` stream type that every returned stream is
+  an instance of, exposing `seek_cost` and `name` (with the surface to be expanded after
+  the exploration above).
+
+## Dependencies / Sequencing
+
+Depends on `base-reader-architecture-extensions` (the `AccessCost` / `seek_cost` surface).
+Should be scheduled **after** a dedicated exploration of archivey's stream usage; the spec
+here is intentionally minimal until that analysis is done.
+
+## Impact
+
+- **Files (anticipated)**: `internal/io_helpers.py` (the `ArchiveyStream` base + the
+  normalizing wrapper), the existing stream classes (inherit it), `core.py` (return-type
+  guarantee), public exports in `__init__.py`.
+- **Live specs touched**: new `archivey-stream` capability.
+- **Design reference**: `docs/format-architecture-comparison.md` §8.E.

--- a/openspec/changes/public-stream-interface/specs/archivey-stream/spec.md
+++ b/openspec/changes/public-stream-interface/specs/archivey-stream/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Returned streams are public ArchiveyStream instances
+
+Archivey SHALL provide a public stream type (`ArchiveyStream`) that is a normal binary
+stream (`io.RawIOBase` / `BinaryIO`) and additionally exposes `seek_cost` (an
+`AccessCost`, consistent with `seekable()`) and a `name: str | None`. Every stream
+Archivey returns from `open()` and `iter_members_with_streams()` SHALL be an
+`ArchiveyStream`, including streams whose bytes originate from a third-party library; such
+streams SHALL be normalized into the type rather than returned raw, so callers SHALL NOT
+have to special-case library-specific stream types to read `seek_cost` or `name`.
+
+This capability is at **exploration stage**: the metadata surface beyond `seek_cost` and
+`name`, the choice between a base class / mixin / protocol, and read-vs-write scope are
+open and will be refined before implementation. The requirement below fixes only the
+parts already decided.
+
+#### Scenario: A returned member stream is an ArchiveyStream
+- **WHEN** a member stream is obtained via `open()`
+- **THEN** it is an `ArchiveyStream` exposing `seek_cost` and `name`, and is usable as a
+  normal binary stream
+
+#### Scenario: A library-backed stream is normalized
+- **WHEN** a member's bytes are produced by a third-party library that returns its own
+  stream object
+- **THEN** the stream Archivey returns is still an `ArchiveyStream` exposing `seek_cost`
+  and `name`

--- a/openspec/changes/public-stream-interface/tasks.md
+++ b/openspec/changes/public-stream-interface/tasks.md
@@ -1,0 +1,28 @@
+# Implementation Tasks: Public stream interface (`ArchiveyStream`)
+
+> **Exploration stage.** Do the analysis tasks first; the implementation surface is not
+> finalized. Depends on `base-reader-architecture-extensions` (the `seek_cost` surface).
+
+## 1. Exploration (do first)
+
+- [ ] 1.1 Inventory every stream class archivey constructs and every path that returns a
+      stream to a caller (including raw third-party streams), and where wrapping happens
+- [ ] 1.2 Decide the public shape: concrete base class vs mixin vs `Protocol` (+ runtime
+      type), and the full metadata set beyond `seek_cost` + `name`
+- [ ] 1.3 Decide wrap-vs-annotate, with a quick benchmark on a many-small-members archive
+      if wrapper overhead is a concern
+- [ ] 1.4 Decide read-only vs read+write scope, and whether `ArchiveyStream` is exported
+
+## 2. Implementation (after the surface is settled)
+
+- [ ] 2.1 Add the public `ArchiveyStream` type exposing `seek_cost` (consistent with
+      `seekable()`) and `name`
+- [ ] 2.2 Have archivey's stream classes provide it; normalize third-party streams into
+      it at the `ensure_binaryio()` / `BinaryIOWrapper` seam
+- [ ] 2.3 Guarantee `open()` / `iter_members_with_streams()` return only `ArchiveyStream`
+      instances; export it publicly
+
+## 3. Validation
+
+- [ ] 3.1 `openspec validate public-stream-interface --type change --strict`
+- [ ] 3.2 `hatch run lint` and `hatch run test`


### PR DESCRIPTION
## Summary

Three OpenSpec change proposals derived from `docs/format-architecture-comparison.md` §8, split along clean seams: the cost **receipt**, the access **request**, and the **public stream type** that carries the receipt. No source code changes — proposals/specs only. All three validate `--strict`.

### 1. `base-reader-architecture-extensions` (§8.B–§8.E) — the cost *receipt*
- **§8.B/§8.C** (internal): per-instance `_format_supports_random_access` flag; replace the `members_list_supported` `__init__` arg with a `has_central_directory` ClassVar.
- **§8.D**: typed `CompressionMethod` enum + lossless `compression_method_detail`. The enum is **exhaustive over every `StreamFormat`** (STORED, DEFLATE for gzip/zlib, BZIP2, LZMA2, LZMA, ZSTD, LZ4, BROTLI, LZW) plus container-internal codecs (PPMD, BCJ2, DEFLATE64, DELTA), with a regression test asserting every `StreamFormat` maps to a non-`UNKNOWN` codec.
- **§8.E**: `MemberListingCost` / shared `AccessCost` enums; `member_listing_cost` / `member_access_cost` introspection; `seek_cost` hoisted onto the decompressor-stream abstraction (TAR derives its cost from it, fixing the multi-block `tar.xz` mis-report); `get_members_if_available` tightened to never scan; `has_random_access()` removed. Cost-computation **pseudocode** is written out in the design.
- Live specs: `archive-reading`, `archive-metadata`.

### 2. `access-intent` (§8.F) — the access *request* (depends on #1)
- **One-axis `AccessIntent`** (`AUTO` / `SEQUENTIAL` / `RANDOM`); `RANDOM` = out-of-order + within-member seeking. A within-member "content seek" facet is deferred (additive).
- **Replaces `streaming` / `streaming_only` outright**: `streaming=True` → `SEQUENTIAL`, `streaming=False` → `AUTO` (default).
- **`AUTO` vs `RANDOM`** = "don't pay vs pay to make random access cheap"; both raise on a non-seekable source.
- **Tri-state backend flags** (`True` / `False` / `"auto"`, default `"auto"`); `"auto"` activates a seekable/indexed backend only under `RANDOM`, so the default open path is behavior-preserving.
- Live specs: `archive-opening`, `configuration`, `archive-reading`.

### 3. `public-stream-interface` — public `ArchiveyStream` (**exploration stage**, depends on #1)
- A public `ArchiveyStream` base: a normal binary stream that *also* exposes `seek_cost` + `name`, that **every** returned stream (including third-party library streams, normalized at the existing wrap point) is an instance of.
- Deliberately **not finalized**: open questions on the full metadata set, base-class vs mixin vs `Protocol`, wrap-vs-annotate cost, and a broader review of how archivey constructs/wraps streams. Tasks lead with an exploration phase.
- Live specs: new `archivey-stream` capability.

## Recommended implementation order
`test-suite-parametrization` (harness) → **base-reader-architecture-extensions** (foundation; both others depend on it) → **access-intent** (ready, breaking API — land before more code accretes on `streaming`) → native readers (`rar-native-metadata-reader`, `sevenzip-native-reader`; `§8.D` is a prereq for 7z) → `unify-junction-handling`. **`public-stream-interface` is implemented last** (after its exploration), accepting a small later refactor that hoists the per-class `seek_cost` onto the shared base.

## Note for reviewers
The `access-intent` `archive-reading` delta adds one bridging requirement and leaves the mechanical rewording of existing `open_archive(streaming=…)` scenarios as an implementation task (task 2.3), rather than restating each in the proposal.

## Validation
- `openspec validate base-reader-architecture-extensions --type change --strict` ✅
- `openspec validate access-intent --type change --strict` ✅
- `openspec validate public-stream-interface --type change --strict` ✅

https://claude.ai/code/session_01Th3cWtDHE6jaSQ4KhkLfTb