### PR TITLE
Add seekable XZ decompression with block-level seeking

### DIFF
--- a/src/archivey/formats/compressed_streams.py
+++ b/src/archivey/formats/compressed_streams.py
@@ -92,6 +92,7 @@ from archivey.exceptions import (
 from archivey.formats.decompressor_stream import (
     BrotliDecompressorStream,
     LzipDecompressorStream,
+    XzDecompressorStream,
     ZlibDecompressorStream,
 )
 from archivey.internal.io_helpers import ensure_binaryio
@@ -259,6 +260,18 @@ def open_python_xz_stream(path: str | BinaryIO) -> BinaryIO:
         ) from None  # pragma: no cover -- lz4 is installed for main tests
 
     return ensure_binaryio(xz.open(path))
+
+
+def _translate_xz_stream_exception(e: Exception) -> Optional[ArchiveError]:
+    if isinstance(e, lzma.LZMAError):
+        return ArchiveCorruptedError(f"Error reading XZ archive: {repr(e)}")
+    if isinstance(e, EOFError):
+        return ArchiveEOFError(f"XZ file is truncated: {repr(e)}")
+    return None
+
+
+def open_xz_stream(path: str | BinaryIO) -> BinaryIO:
+    return XzDecompressorStream(path)
 
 
 class ZstandardReopenOnBackwardsSeekIO(io.RawIOBase, BinaryIO):
@@ -487,7 +500,7 @@ def get_stream_open_fn(
     if format == StreamFormat.XZ:
         if config.use_python_xz:
             return open_python_xz_stream, _translate_python_xz_exception
-        return open_lzma_stream, _translate_lzma_exception
+        return open_xz_stream, _translate_xz_stream_exception
 
     if format == StreamFormat.LZ4:
         return open_lz4_stream, _translate_lz4_exception

--- a/src/archivey/formats/decompressor_stream.py
+++ b/src/archivey/formats/decompressor_stream.py
@@ -20,6 +20,7 @@ from typing_extensions import Buffer
 
 from archivey.exceptions import ArchiveCorruptedError, ArchiveEOFError
 from archivey.formats.lzip_stream import _LzipState, _read_index_backwards
+from archivey.formats.xz_stream import _XzState, _read_xz_index_backwards
 from archivey.internal.io_helpers import ensure_bufferedio
 
 if TYPE_CHECKING:
@@ -443,3 +444,112 @@ class BrotliDecompressorStream(DecompressorStream):
 
     def _is_decompressor_finished(self) -> bool:
         return self._decompressor.is_finished()
+
+
+class XzDecompressorStream(DecompressorStream[_XzState]):
+    """Seekable XZ decompressor backed by Python's stdlib lzma.
+
+    Builds a seek-point table from XZ block headers:
+      - Progressively via _update_index() as blocks are decoded forward.
+      - On-demand via a one-shot backwards stream+index scan (_build_index()).
+
+    Each seek point stores the absolute compressed-file offset of the block
+    header start plus the filter chain, so seeking jumps directly to the block
+    and decompresses with lzma.FORMAT_RAW.
+
+    Supports multi-block XZ files (xz --block-size=...) and multi-stream
+    concatenated XZ files.  Works on non-seekable input streams (seek points
+    won't be available, but sequential reading is unaffected).
+    """
+
+    def __init__(self, path: str | BinaryIO) -> None:
+        self._decomp_cursor: int = 0
+        super().__init__(path)
+
+    # ------------------------------------------------------------------
+    # DecompressorStream abstract interface
+    # ------------------------------------------------------------------
+
+    def _create_decompressor(self, point: SeekPoint) -> _XzState:
+        self._decomp_cursor = point.decompressed_offset
+        if point.state is not None:
+            return _XzState(
+                initial_compressed_offset=point.compressed_offset,
+                seek_state=point.state,
+            )
+        return _XzState(initial_compressed_offset=point.compressed_offset)
+
+    def _decompress_chunk(self, chunk: bytes) -> bytes:
+        data, new_blocks = self._decompressor.feed(chunk)
+        self._update_index(new_blocks)
+        return data
+
+    def _flush_decompressor(self) -> bytes:
+        data, new_blocks = self._decompressor.flush()
+        self._update_index(new_blocks)
+        return data
+
+    def _is_decompressor_finished(self) -> bool:
+        return self._decompressor.is_finished()
+
+    # ------------------------------------------------------------------
+    # Seek-point machinery
+    # ------------------------------------------------------------------
+
+    def _update_index(self, new_blocks: list[dict]) -> None:
+        """Extend the seek-point table with newly completed blocks."""
+        for b in new_blocks:
+            self.add_seek_points(
+                [
+                    SeekPoint(
+                        decompressed_offset=self._decomp_cursor,
+                        compressed_offset=b["header_abs_start"],
+                        state={
+                            "block_header_size": b["block_header_size"],
+                            "compressed_data_size": b["compressed_data_size"],
+                            "check_size": b["check_size"],
+                            "filters": b["filters"],
+                        },
+                    )
+                ]
+            )
+            self._decomp_cursor += b["decomp_size"]
+
+    def _build_index(self, last_known: SeekPoint) -> tuple[list[SeekPoint], int | None]:
+        """Scan XZ stream footers and indexes backwards to build the complete index.
+
+        Covers only the portion of the file not already indexed by forward reading
+        (i.e., compressed offsets > last_known.compressed_offset).
+
+        On failure (e.g. trailing data or corrupt footer), logs a warning and
+        returns empty results so the base class falls back to sequential
+        decompression.
+        """
+        file_size = self._inner.seek(0, io.SEEK_END)
+        try:
+            blocks = _read_xz_index_backwards(
+                cast("BinaryIO", self._inner),
+                file_size,
+                stop_at=last_known.compressed_offset,
+                start_decompressed_offset=last_known.decompressed_offset,
+            )
+            points = [
+                SeekPoint(
+                    b.decompressed_start,
+                    b.compressed_start,
+                    state=b.to_seek_state(),
+                )
+                for b in blocks
+            ]
+            total_size = (
+                blocks[-1].decompressed_end if blocks else None
+            )
+            return points, total_size
+        except (ArchiveCorruptedError, ArchiveEOFError) as e:
+            logger.warning(
+                "XZ backwards index scan failed (the file may have trailing data "
+                "or a corrupt footer); falling back to sequential decompression. "
+                "Reason: %s",
+                e,
+            )
+            return [], None

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -12,6 +12,7 @@ from archivey.exceptions import (
 )
 from archivey.formats.compressed_streams import get_stream_open_fn
 from archivey.formats.format_detection import EXTENSION_TO_FORMAT
+from archivey.formats.lzip_stream import _read_index_backwards as _lzip_read_index_backwards
 from archivey.internal.base_reader import BaseArchiveReader
 from archivey.internal.io_helpers import (  # Updated import
     is_seekable,
@@ -209,6 +210,22 @@ def read_xz_metadata(path: str | BinaryIO, member: ArchiveMember):
         )
 
 
+def read_lzip_metadata(path: str | BinaryIO, member: ArchiveMember) -> None:
+    """Read lzip member trailers backwards to determine the total uncompressed size."""
+    logger.info("Reading lzip metadata for %s", path)
+    with open_if_file(path) as f:
+        try:
+            file_size = f.seek(0, io.SEEK_END)
+        except io.UnsupportedOperation:
+            return
+        try:
+            members = _lzip_read_index_backwards(f, file_size)
+            if members:
+                member.file_size = members[-1].decompressed_start + members[-1].decompressed_size
+        except (ArchiveCorruptedError, Exception) as e:
+            logger.debug("lzip metadata read failed: %s", e)
+
+
 class SingleFileReader(BaseArchiveReader):
     """Reader for raw compressed files (gz, bz2, xz, zstd, lz4)."""
 
@@ -288,6 +305,8 @@ class SingleFileReader(BaseArchiveReader):
                 read_gzip_metadata(archive_path, self.member, self.use_stored_metadata)
             elif self.format == ArchiveFormat.XZ:
                 read_xz_metadata(archive_path, self.member)
+            elif self.format == ArchiveFormat.LZIP:
+                read_lzip_metadata(archive_path, self.member)
 
         # Open the file to see if it's supported by the library and valid.
         # To avoid opening the file twice, we'll store the reference and return it

--- a/src/archivey/formats/xz_stream.py
+++ b/src/archivey/formats/xz_stream.py
@@ -1,0 +1,703 @@
+"""
+Pure-stdlib XZ decompression with block-level seeking using Python's lzma module.
+
+XZ file format spec: https://tukaani.org/xz/xz-file-format-1.0.4.txt
+
+XZ file structure (one or more concatenated streams):
+
+  Each stream:
+    stream_header (12 bytes):
+      magic         6 bytes   \\xfd7zXZ\\x00
+      stream_flags  2 bytes   (check type in low 4 bits)
+      CRC32         4 bytes
+
+    [block ...]
+
+    index (variable, multiple of 4 bytes):
+      indicator     1 byte    0x00
+      record_count  varint
+      records       N x (unpadded_size: varint, uncompressed_size: varint)
+      padding       0-3 bytes of zeros to reach 4-byte alignment
+      CRC32         4 bytes
+
+    stream_footer (12 bytes):
+      CRC32              4 bytes
+      backward_size      4 bytes LE   index_size = (backward_size + 1) * 4
+      magic              2 bytes   "YZ"
+
+  Each block:
+    block_header (multiple of 4 bytes):
+      header_size    1 byte   actual_size = (header_size + 1) * 4
+      flags          1 byte   filter_count (bits 1-0) + has_comp (bit 6) + has_uncomp (bit 7)
+      [comp_size     varint]  if has_comp
+      [uncomp_size   varint]  if has_uncomp
+      [filter specs  ...]     filter_count entries of (filter_id: varint, props_size: varint, props)
+      padding        zeros to 4-byte alignment
+      CRC32          4 bytes
+    compressed data
+    check (0/4/8/32 bytes depending on stream check type)
+    block padding  0-3 zero bytes to round total block size to multiple of 4
+
+  "unpadded_size" stored in the index = block_header_size + compressed_data_size + check_size.
+  Actual padded block size = round_up(unpadded_size, 4).
+
+Implementation notes:
+  Block-level decompression uses lzma.FORMAT_RAW with the filter chain from the block
+  header, decoded via lzma._decode_filter_properties (private but stable CPython API).
+  This is the same pattern as constructing the synthetic LZMA_ALONE header for lzip.
+
+  check_size is determined by stream_flags & 0x0f:
+    0x00 -> 0 bytes (no check)
+    0x01 -> 4 bytes (CRC32)
+    0x04 -> 8 bytes (CRC64)
+    0x0A -> 32 bytes (SHA-256)
+"""
+
+import lzma
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Any, BinaryIO
+
+from archivey.exceptions import ArchiveCorruptedError, ArchiveEOFError
+
+_STREAM_HEADER_MAGIC = b"\xfd7zXZ\x00"
+_STREAM_FOOTER_MAGIC = b"YZ"
+
+_CHECK_SIZES: dict[int, int] = {0x00: 0, 0x01: 4, 0x04: 8, 0x0A: 32}
+_DEFAULT_CHECK_SIZE = 4  # CRC32 is most common
+
+
+@dataclass
+class _XzBlockInfo:
+    """Compressed/decompressed extents for one XZ block."""
+
+    compressed_start: int  # absolute byte offset of block header in compressed stream
+    decompressed_start: int  # cumulative decompressed bytes before this block
+    block_header_size: int  # size of block header in bytes
+    compressed_data_size: int  # size of raw compressed data (after header, before check)
+    check_size: int  # size of check value (0, 4, 8, or 32 bytes)
+    decompressed_size: int  # uncompressed size of this block
+    filters: list[dict[str, Any]]  # lzma filter chain for FORMAT_RAW decompression
+
+    @property
+    def decompressed_end(self) -> int:
+        return self.decompressed_start + self.decompressed_size
+
+    def to_seek_state(self) -> dict[str, Any]:
+        return {
+            "block_header_size": self.block_header_size,
+            "compressed_data_size": self.compressed_data_size,
+            "check_size": self.check_size,
+            "filters": self.filters,
+        }
+
+
+def _read_varint(data: bytes | bytearray, offset: int) -> tuple[int, int]:
+    """Read an XZ variable-length integer from data at offset.
+
+    Returns (value, new_offset).
+    """
+    value = 0
+    shift = 0
+    while True:
+        if offset >= len(data):
+            raise ArchiveEOFError("Truncated varint in XZ data")
+        b = data[offset]
+        offset += 1
+        value |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            break
+        shift += 7
+        if shift > 63:
+            raise ArchiveCorruptedError("XZ varint too large (> 63-bit)")
+    return value, offset
+
+
+def _parse_block_header_bytes(header: bytes) -> tuple[list[dict[str, Any]], int | None]:
+    """Parse an XZ block header (already fully buffered).
+
+    Returns (filters, compressed_size_or_None).
+    Raises ArchiveCorruptedError on invalid header.
+    """
+    if len(header) < 4:
+        raise ArchiveCorruptedError("XZ block header too short")
+
+    block_header_size = (header[0] + 1) * 4
+    if len(header) != block_header_size:
+        raise ArchiveCorruptedError(
+            f"XZ block header buffer size {len(header)} != expected {block_header_size}"
+        )
+
+    stored_crc32 = struct.unpack_from("<I", header, block_header_size - 4)[0]
+    computed_crc32 = zlib.crc32(header[: block_header_size - 4]) & 0xFFFFFFFF
+    if stored_crc32 != computed_crc32:
+        raise ArchiveCorruptedError(
+            f"XZ block header CRC32 mismatch: stored {stored_crc32:#010x}, "
+            f"computed {computed_crc32:#010x}"
+        )
+
+    flags = header[1]
+    filter_count = (flags & 0x03) + 1
+    has_compressed_size = bool(flags & 0x40)
+    has_uncompressed_size = bool(flags & 0x80)
+
+    offset = 2
+    compressed_size: int | None = None
+    if has_compressed_size:
+        compressed_size, offset = _read_varint(header, offset)
+    if has_uncompressed_size:
+        _, offset = _read_varint(header, offset)
+
+    filters: list[dict[str, Any]] = []
+    for _ in range(filter_count):
+        filter_id, offset = _read_varint(header, offset)
+        props_size, offset = _read_varint(header, offset)
+        if offset + props_size > block_header_size - 4:
+            raise ArchiveCorruptedError("XZ filter properties extend past block header")
+        props = bytes(header[offset : offset + props_size])
+        offset += props_size
+        try:
+            # lzma._decode_filter_properties is private but stable in CPython.
+            filter_dict = lzma._decode_filter_properties(filter_id, props)  # type: ignore[attr-defined]
+        except (ValueError, lzma.LZMAError) as e:
+            raise ArchiveCorruptedError(
+                f"Unsupported or invalid XZ filter 0x{filter_id:x}: {e}"
+            ) from e
+        filters.append(filter_dict)
+
+    return filters, compressed_size
+
+
+def _parse_xz_block_header_from_stream(
+    stream: BinaryIO, block_start: int
+) -> tuple[int, list[dict[str, Any]], int | None]:
+    """Read and parse an XZ block header from the stream at block_start.
+
+    Returns (block_header_size, filters, compressed_size_or_None).
+    """
+    stream.seek(block_start)
+    first_byte = stream.read(1)
+    if not first_byte:
+        raise ArchiveCorruptedError("Truncated XZ block header size byte")
+    block_header_size = (first_byte[0] + 1) * 4
+
+    stream.seek(block_start)
+    header = stream.read(block_header_size)
+    if len(header) < block_header_size:
+        raise ArchiveCorruptedError("Truncated XZ block header")
+
+    filters, compressed_size = _parse_block_header_bytes(bytes(header))
+    return block_header_size, filters, compressed_size
+
+
+def _read_xz_stream_index(
+    stream: BinaryIO, index_offset: int, index_size: int
+) -> list[tuple[int, int]]:
+    """Read and parse an XZ stream index.
+
+    Returns list of (unpadded_size, uncompressed_size) per block.
+    """
+    stream.seek(index_offset)
+    index_data = stream.read(index_size)
+    if len(index_data) < index_size:
+        raise ArchiveCorruptedError("Truncated XZ stream index")
+
+    if index_data[0] != 0x00:
+        raise ArchiveCorruptedError(
+            f"XZ index indicator byte is not 0x00: {index_data[0]:#x}"
+        )
+
+    offset = 1
+    record_count, offset = _read_varint(index_data, offset)
+
+    records: list[tuple[int, int]] = []
+    for _ in range(record_count):
+        unpadded_size, offset = _read_varint(index_data, offset)
+        uncompressed_size, offset = _read_varint(index_data, offset)
+        records.append((unpadded_size, uncompressed_size))
+
+    return records
+
+
+def _read_xz_index_backwards(
+    stream: BinaryIO,
+    file_size: int,
+    stop_at: int = 0,
+    start_decompressed_offset: int = 0,
+) -> list[_XzBlockInfo]:
+    """Build the block index by scanning XZ streams backwards.
+
+    Reads only the stream footers, stream indexes, and block headers — no
+    decompression is performed.  Supports multi-stream XZ files and stream
+    padding (4-byte-aligned zero bytes between streams).
+
+    stop_at: stop scanning when the current stream would start at or before
+      this compressed offset.
+    start_decompressed_offset: cumulative decompressed bytes before the first
+      scanned block.
+
+    Returns all blocks in forward order with correct decompressed_start values.
+    Raises ArchiveCorruptedError or ArchiveEOFError on corrupt/truncated data.
+    """
+    streams_reversed: list[list[_XzBlockInfo]] = []
+    compressed_end = file_size
+
+    while compressed_end > stop_at:
+        if compressed_end < 12:
+            raise ArchiveCorruptedError("XZ file too small for a stream footer")
+
+        # Skip trailing stream padding (4-byte-aligned zero blocks between streams)
+        while compressed_end >= 4:
+            stream.seek(compressed_end - 4)
+            last4 = stream.read(4)
+            if last4 == b"\x00\x00\x00\x00":
+                compressed_end -= 4
+                if compressed_end <= stop_at:
+                    break
+            else:
+                break
+
+        if compressed_end - stop_at < 12:
+            break
+
+        # Read stream footer
+        stream.seek(compressed_end - 12)
+        footer = stream.read(12)
+        if len(footer) < 12:
+            raise ArchiveCorruptedError("Truncated XZ stream footer")
+
+        if footer[-2:] != _STREAM_FOOTER_MAGIC:
+            raise ArchiveCorruptedError(
+                f"XZ stream footer magic not found before offset {compressed_end}: "
+                f"got {footer[-2:]!r}"
+            )
+
+        backward_size_field = struct.unpack("<I", footer[4:8])[0]
+        index_size = (backward_size_field + 1) * 4
+        stream_flags = struct.unpack(">H", footer[8:10])[0]
+        check_size = _CHECK_SIZES.get(stream_flags & 0x0F, _DEFAULT_CHECK_SIZE)
+
+        if compressed_end < 12 + index_size:
+            raise ArchiveCorruptedError("XZ stream index extends before start of file")
+
+        index_offset = compressed_end - 12 - index_size
+        records = _read_xz_stream_index(stream, index_offset, index_size)
+
+        # Compute total padded size of all blocks in this stream
+        stream_data_size = sum((unp + 3) & ~3 for unp, _ in records)
+        stream_start = index_offset - stream_data_size - 12  # 12-byte stream header
+
+        if stream_start < 0:
+            raise ArchiveCorruptedError(
+                f"XZ stream data size {stream_data_size} puts stream start at "
+                f"negative offset {stream_start}"
+            )
+
+        # Verify stream header magic
+        stream.seek(stream_start)
+        magic = stream.read(6)
+        if magic != _STREAM_HEADER_MAGIC:
+            raise ArchiveCorruptedError(
+                f"XZ stream header magic not found at {stream_start}: got {magic!r}"
+            )
+
+        # Parse each block header to obtain the filter chain
+        block_offset = stream_start + 12
+        stream_blocks: list[_XzBlockInfo] = []
+
+        for unpadded_size, uncomp_size in records:
+            block_header_size, filters, _ = _parse_xz_block_header_from_stream(
+                stream, block_offset
+            )
+            compressed_data_size = unpadded_size - block_header_size - check_size
+            if compressed_data_size < 0:
+                raise ArchiveCorruptedError(
+                    f"XZ block at {block_offset}: negative compressed data size "
+                    f"(unpadded={unpadded_size}, header={block_header_size}, check={check_size})"
+                )
+            stream_blocks.append(
+                _XzBlockInfo(
+                    compressed_start=block_offset,
+                    decompressed_start=0,  # filled in the forward pass below
+                    block_header_size=block_header_size,
+                    compressed_data_size=compressed_data_size,
+                    check_size=check_size,
+                    decompressed_size=uncomp_size,
+                    filters=filters,
+                )
+            )
+            block_offset += (unpadded_size + 3) & ~3
+
+        streams_reversed.append(stream_blocks)
+        compressed_end = stream_start
+
+    # Assign decompressed_start values in forward order
+    result: list[_XzBlockInfo] = []
+    decompressed_cursor = start_decompressed_offset
+    for stream_blocks in reversed(streams_reversed):
+        for block in stream_blocks:
+            block.decompressed_start = decompressed_cursor
+            decompressed_cursor += block.decompressed_size
+        result.extend(stream_blocks)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Streaming state machine
+# ---------------------------------------------------------------------------
+
+
+class _XzState:
+    """Streaming state machine for multi-block, multi-stream XZ decompression.
+
+    Two construction modes:
+
+    1. Default (_XzState()): starts at the beginning of an XZ stream
+       (NEED_STREAM_HEADER state).  Handles full stream framing including
+       stream header, block headers, index, and stream footer.  Supports
+       multiple concatenated streams.
+
+    2. Seek mode (_XzState(seek_state=..., initial_compressed_offset=...)):
+       starts mid-stream at a known block.  The block header bytes are
+       skipped (its size is in seek_state), and the block's compressed data
+       is decompressed with the stored filter chain.  After the block, the
+       state machine continues normally (reads subsequent block headers or
+       skips the index/footer).
+
+    feed(chunk) returns (decompressed_bytes, new_blocks) where new_blocks is
+    a list of dicts with keys:
+      decomp_size, header_abs_start, block_header_size,
+      compressed_data_size, check_size, filters
+    for each block whose data was fully produced in this call.
+
+    flush() succeeds cleanly when between streams (NEED_STREAM_HEADER with
+    >= 1 block seen) and raises ArchiveEOFError if the stream is truncated.
+    """
+
+    _NEED_STREAM_HEADER = 0
+    _NEED_BLOCK_HEADER = 1
+    _IN_BLOCK = 2
+    _SKIP_CHECK_AND_PADDING = 3
+    _SKIP_INDEX = 4
+    _NEED_STREAM_FOOTER = 5
+    _SKIP_BLOCK_HEADER = 6  # initial state when starting from a seek point
+
+    def __init__(
+        self,
+        initial_compressed_offset: int = 0,
+        seek_state: dict[str, Any] | None = None,
+    ) -> None:
+        self._buf = bytearray()
+        self._finished = False
+        self._blocks_seen = 0
+        self._streams_seen = 0
+        self._consumed = 0
+        self._initial_compressed_offset = initial_compressed_offset
+
+        # Active block decompressor
+        self._dec: lzma.LZMADecompressor | None = None
+        self._stream_check_size = _DEFAULT_CHECK_SIZE
+
+        # Per-block tracking
+        self._current_block_abs_start = 0
+        self._current_block_header_size = 0
+        self._current_block_compressed_data_size = 0
+        self._current_block_decomp_size = 0
+        self._current_block_filters: list[dict[str, Any]] = []
+        self._compressed_data_remaining: int | None = None
+
+        # Generic byte-skip counter (check + block padding, or block header)
+        self._skip_remaining = 0
+
+        # Index-skip sub-state
+        self._index_bytes_consumed = 0
+        self._index_count: int | None = None
+        self._index_varints_remaining = 0
+
+        if seek_state is not None:
+            self._state = self._SKIP_BLOCK_HEADER
+            self._skip_remaining = seek_state["block_header_size"]
+            self._current_block_abs_start = initial_compressed_offset
+            self._current_block_header_size = seek_state["block_header_size"]
+            self._current_block_filters = seek_state["filters"]
+            self._compressed_data_remaining = seek_state["compressed_data_size"]
+            self._stream_check_size = seek_state["check_size"]
+        else:
+            self._state = self._NEED_STREAM_HEADER
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def feed(self, data: bytes) -> tuple[bytes, list[dict[str, Any]]]:
+        self._buf.extend(data)
+        return self._process()
+
+    def flush(self) -> tuple[bytes, list[dict[str, Any]]]:
+        if self._state == self._NEED_STREAM_HEADER:
+            if self._blocks_seen == 0 and self._streams_seen == 0:
+                raise ArchiveCorruptedError("Not a valid XZ file: no blocks found")
+            self._finished = True
+            return b"", []
+        raise ArchiveEOFError("XZ file is truncated")
+
+    def is_finished(self) -> bool:
+        return self._finished
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _consume(self, n: int) -> None:
+        del self._buf[:n]
+        self._consumed += n
+
+    def _abs_offset(self) -> int:
+        """Absolute position in the compressed file (of the next unread byte)."""
+        return self._initial_compressed_offset + self._consumed
+
+    def _enter_skip_check_and_padding(self) -> None:
+        """Compute and record how many bytes to skip (check + block padding)."""
+        unpadded = (
+            self._current_block_header_size
+            + self._current_block_compressed_data_size
+            + self._stream_check_size
+        )
+        padded = (unpadded + 3) & ~3
+        self._skip_remaining = self._stream_check_size + (padded - unpadded)
+        self._state = self._SKIP_CHECK_AND_PADDING
+
+    # ------------------------------------------------------------------
+    # Main processing loop
+    # ------------------------------------------------------------------
+
+    def _process(self) -> tuple[bytes, list[dict[str, Any]]]:
+        output = bytearray()
+        new_blocks: list[dict[str, Any]] = []
+
+        while True:
+            # ---- SKIP_BLOCK_HEADER (seek mode: skip the known block header) ----
+            if self._state == self._SKIP_BLOCK_HEADER:
+                to_skip = min(self._skip_remaining, len(self._buf))
+                self._consume(to_skip)
+                self._skip_remaining -= to_skip
+                if self._skip_remaining == 0:
+                    self._dec = lzma.LZMADecompressor(
+                        format=lzma.FORMAT_RAW, filters=self._current_block_filters
+                    )
+                    self._current_block_decomp_size = 0
+                    self._current_block_compressed_data_size = 0
+                    self._state = self._IN_BLOCK
+                else:
+                    break
+
+            # ---- NEED_STREAM_HEADER ----
+            elif self._state == self._NEED_STREAM_HEADER:
+                # Skip stream padding (zero bytes between concatenated streams)
+                while self._buf and self._buf[0] == 0x00:
+                    self._consume(1)
+
+                if len(self._buf) < 12:
+                    break
+
+                header = bytes(self._buf[:12])
+                self._consume(12)
+
+                if header[:6] != _STREAM_HEADER_MAGIC:
+                    if self._blocks_seen > 0:
+                        # Unrecognised data after a valid stream → treat as trailing
+                        self._finished = True
+                        break
+                    raise ArchiveCorruptedError(
+                        f"Not a valid XZ stream header: magic {header[:6]!r}"
+                    )
+                stream_flags = struct.unpack(">H", header[6:8])[0]
+                self._stream_check_size = _CHECK_SIZES.get(
+                    stream_flags & 0x0F, _DEFAULT_CHECK_SIZE
+                )
+                self._state = self._NEED_BLOCK_HEADER
+
+            # ---- NEED_BLOCK_HEADER ----
+            elif self._state == self._NEED_BLOCK_HEADER:
+                if not self._buf:
+                    break
+                first_byte = self._buf[0]
+
+                if first_byte == 0x00:
+                    # Index indicator byte
+                    self._consume(1)
+                    self._index_bytes_consumed = 1
+                    self._index_count = None
+                    self._index_varints_remaining = 0
+                    self._state = self._SKIP_INDEX
+                    continue
+
+                block_header_size = (first_byte + 1) * 4
+                if len(self._buf) < block_header_size:
+                    break
+
+                # Record abs start before consuming
+                block_abs_start = self._abs_offset()
+                header_bytes = bytes(self._buf[:block_header_size])
+                self._consume(block_header_size)
+
+                try:
+                    filters, compressed_size = _parse_block_header_bytes(header_bytes)
+                except Exception as e:
+                    raise ArchiveCorruptedError(
+                        f"Invalid XZ block header at {block_abs_start}: {e}"
+                    ) from e
+
+                self._current_block_abs_start = block_abs_start
+                self._current_block_header_size = block_header_size
+                self._current_block_filters = filters
+                self._current_block_decomp_size = 0
+                self._current_block_compressed_data_size = 0
+                self._compressed_data_remaining = compressed_size
+
+                self._dec = lzma.LZMADecompressor(
+                    format=lzma.FORMAT_RAW, filters=filters
+                )
+                self._state = self._IN_BLOCK
+
+            # ---- IN_BLOCK ----
+            elif self._state == self._IN_BLOCK:
+                if not self._buf:
+                    break
+
+                if self._compressed_data_remaining == 0:
+                    self._enter_skip_check_and_padding()
+                    continue
+
+                if self._compressed_data_remaining is not None:
+                    chunk = bytes(self._buf[: self._compressed_data_remaining])
+                else:
+                    chunk = bytes(self._buf)
+                self._consume(len(chunk))
+
+                assert self._dec is not None
+                try:
+                    plain = self._dec.decompress(chunk)
+                except lzma.LZMAError as e:
+                    raise ArchiveCorruptedError(
+                        f"XZ block decompression error at {self._current_block_abs_start}: {e}"
+                    ) from e
+
+                if plain:
+                    output.extend(plain)
+                    self._current_block_decomp_size += len(plain)
+
+                if self._compressed_data_remaining is not None:
+                    self._current_block_compressed_data_size += len(chunk)
+                    self._compressed_data_remaining -= len(chunk)
+                    if self._compressed_data_remaining == 0:
+                        self._enter_skip_check_and_padding()
+                elif self._dec.eof:
+                    # LZMA2 EOS detected; unused_data is the check + possible next data
+                    unused = self._dec.unused_data
+                    self._current_block_compressed_data_size += len(chunk) - len(unused)
+                    # Put unused bytes back
+                    self._buf[0:0] = unused
+                    self._consumed -= len(unused)
+                    self._enter_skip_check_and_padding()
+
+            # ---- SKIP_CHECK_AND_PADDING ----
+            elif self._state == self._SKIP_CHECK_AND_PADDING:
+                to_skip = min(self._skip_remaining, len(self._buf))
+                self._consume(to_skip)
+                self._skip_remaining -= to_skip
+                if self._skip_remaining == 0:
+                    new_blocks.append(
+                        {
+                            "decomp_size": self._current_block_decomp_size,
+                            "header_abs_start": self._current_block_abs_start,
+                            "block_header_size": self._current_block_header_size,
+                            "compressed_data_size": self._current_block_compressed_data_size,
+                            "check_size": self._stream_check_size,
+                            "filters": self._current_block_filters,
+                        }
+                    )
+                    self._blocks_seen += 1
+                    self._dec = None
+                    self._state = self._NEED_BLOCK_HEADER
+
+            # ---- SKIP_INDEX ----
+            elif self._state == self._SKIP_INDEX:
+                if self._do_skip_index():
+                    self._state = self._NEED_STREAM_FOOTER
+                else:
+                    break
+
+            # ---- NEED_STREAM_FOOTER ----
+            elif self._state == self._NEED_STREAM_FOOTER:
+                if len(self._buf) < 12:
+                    break
+                footer = bytes(self._buf[:12])
+                self._consume(12)
+                if footer[-2:] != _STREAM_FOOTER_MAGIC:
+                    raise ArchiveCorruptedError(
+                        f"Invalid XZ stream footer magic: {footer[-2:]!r}"
+                    )
+                self._streams_seen += 1
+                self._state = self._NEED_STREAM_HEADER
+
+            else:  # pragma: no cover
+                raise RuntimeError(f"Unknown _XzState state: {self._state}")
+
+        return bytes(output), new_blocks
+
+    def _do_skip_index(self) -> bool:
+        """Consume index bytes from _buf.  Returns True when fully skipped."""
+        if self._index_count is None:
+            # Read the record-count varint
+            off = 0
+            val = 0
+            shift = 0
+            found = False
+            while off < len(self._buf):
+                b = self._buf[off]
+                off += 1
+                val |= (b & 0x7F) << shift
+                if not (b & 0x80):
+                    found = True
+                    break
+                shift += 7
+            if not found:
+                return False
+            self._consume(off)
+            self._index_bytes_consumed += off
+            self._index_count = val
+            self._index_varints_remaining = val * 2  # 2 varints per record
+
+        # Skip the record varints one at a time
+        while self._index_varints_remaining > 0:
+            if not self._buf:
+                return False
+            off = 0
+            found = False
+            while off < len(self._buf):
+                b = self._buf[off]
+                off += 1
+                if not (b & 0x80):
+                    found = True
+                    break
+            if not found:
+                return False
+            self._consume(off)
+            self._index_bytes_consumed += off
+            self._index_varints_remaining -= 1
+
+        # Padding to align index size to a multiple of 4 bytes
+        padding = (-self._index_bytes_consumed) % 4
+        if len(self._buf) < padding:
+            return False
+        self._consume(padding)
+
+        # CRC32 (4 bytes)
+        if len(self._buf) < 4:
+            return False
+        self._consume(4)
+
+        return True

--- a/tests/archivey/sample_archives.py
+++ b/tests/archivey/sample_archives.py
@@ -518,7 +518,7 @@ LZIP_LIBRARY = ArchiveCreationInfo(
     file_suffix="lib.lz",
     format=ArchiveFormat.LZIP,
     generation_method=GenerationMethod.SINGLE_FILE_LIBRARY,
-    features=ArchiveFormatFeatures(file_size=False, mtime_with_tz=True),
+    features=ArchiveFormatFeatures(file_size=True, mtime_with_tz=True),
 )
 ZLIB_LIBRARY = ArchiveCreationInfo(
     file_suffix="lib.zz",

--- a/tests/archivey/test_open_nonseekable.py
+++ b/tests/archivey/test_open_nonseekable.py
@@ -31,9 +31,11 @@ SKIPPABLE_FORMATS: set[ArchiveFormat] = {
 EXPECTED_NON_SEEKABLE_FAILURES: set[tuple[ArchiveFormat, bool]] = {
     (ArchiveFormat.GZIP, True),
     (ArchiveFormat.BZIP2, True),
+    # XZ with use_python_xz=True still fails on non-seekable streams (python-xz requires seeking)
     (ArchiveFormat.XZ, True),
     (ArchiveFormat.TAR_GZ, True),
     (ArchiveFormat.TAR_BZ2, True),
+    # TAR_XZ with use_python_xz=True still fails on non-seekable streams
     (ArchiveFormat.TAR_XZ, True),
     (ArchiveFormat.TAR_Z, False),
     (ArchiveFormat.TAR_Z, True),

--- a/tests/archivey/test_xz_stream.py
+++ b/tests/archivey/test_xz_stream.py
@@ -1,0 +1,507 @@
+"""Tests for XzDecompressorStream: multi-block files and efficient seeking."""
+
+import io
+import lzma
+import subprocess
+import sys
+from typing import BinaryIO, cast
+
+import pytest
+
+from archivey.exceptions import ArchiveCorruptedError, ArchiveEOFError
+from archivey.formats.compressed_streams import _translate_xz_stream_exception
+from archivey.formats.decompressor_stream import XzDecompressorStream, SeekPoint
+from archivey.formats.xz_stream import _read_xz_index_backwards
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_XZ_CLI_AVAILABLE = bool(subprocess.run(
+    ["xz", "--version"],
+    capture_output=True,
+    timeout=5,
+).returncode == 0)
+
+requires_xz_cli = pytest.mark.skipif(
+    not _XZ_CLI_AVAILABLE,
+    reason="xz CLI not available",
+)
+
+
+def make_xz(data: bytes) -> bytes:
+    """Single-stream, single-block XZ using stdlib lzma (no CLI)."""
+    return lzma.compress(data, format=lzma.FORMAT_XZ)
+
+
+def make_xz_multiblock(data: bytes, block_size: int) -> bytes:
+    """Multi-block XZ file with the given block size (bytes), using xz CLI."""
+    result = subprocess.run(
+        ["xz", "-c", f"--block-size={block_size}", "-"],
+        input=data,
+        capture_output=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"xz failed: {result.stderr.decode()}")
+    return result.stdout
+
+
+def make_xz_multistream(parts: list[bytes]) -> bytes:
+    """Concatenate multiple independent XZ streams."""
+    return b"".join(lzma.compress(p, format=lzma.FORMAT_XZ) for p in parts)
+
+
+class _NonSeekableStream(io.RawIOBase):
+    """Wraps BytesIO but refuses to seek."""
+
+    def __init__(self, data: bytes) -> None:
+        super().__init__()
+        self._inner = io.BytesIO(data)
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b: bytearray | memoryview) -> int:
+        data = self._inner.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+    def seekable(self) -> bool:
+        return False
+
+    def seek(self, *args, **kwargs):
+        raise io.UnsupportedOperation("seek")
+
+
+class _CountingStream(io.RawIOBase):
+    """Wraps BytesIO and counts total bytes read."""
+
+    def __init__(self, data: bytes) -> None:
+        super().__init__()
+        self._inner = io.BytesIO(data)
+        self.bytes_read = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b: bytearray | memoryview) -> int:
+        n = self._inner.readinto(b)
+        if n:
+            self.bytes_read += n
+        return n
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self._inner.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self._inner.tell()
+
+    def seekable(self) -> bool:
+        return True
+
+
+def open_xz(data: bytes) -> XzDecompressorStream:
+    return XzDecompressorStream(io.BytesIO(data))
+
+
+# ---------------------------------------------------------------------------
+# Basic reading
+# ---------------------------------------------------------------------------
+
+
+def test_single_block_read_all():
+    payload = b"hello world"
+    with open_xz(make_xz(payload)) as f:
+        assert f.read() == payload
+
+
+def test_single_block_read_chunked():
+    payload = b"abcdefghij" * 100
+    xz_data = make_xz(payload)
+    with open_xz(xz_data) as f:
+        result = bytearray()
+        while True:
+            chunk = f.read(64)
+            if not chunk:
+                break
+            result.extend(chunk)
+    assert bytes(result) == payload
+
+
+def test_empty_payload_single_block():
+    """An XZ file with zero blocks (empty payload) must decompress to empty bytes."""
+    payload = b""
+    xz_data = make_xz(payload)
+    with open_xz(xz_data) as f:
+        assert f.read() == payload
+
+
+@requires_xz_cli
+def test_multi_block_read_all():
+    payload = b"x" * 12000
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    with open_xz(xz_data) as f:
+        assert f.read() == payload
+
+
+@requires_xz_cli
+def test_multi_block_read_chunked():
+    parts = [b"A" * 3000, b"B" * 3000, b"C" * 3000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=3000)
+    with open_xz(xz_data) as f:
+        result = bytearray()
+        while True:
+            chunk = f.read(256)
+            if not chunk:
+                break
+            result.extend(chunk)
+    assert bytes(result) == payload
+
+
+def test_multi_stream_read():
+    parts = [b"first stream", b"second stream", b"third stream"]
+    xz_data = make_xz_multistream(parts)
+    with open_xz(xz_data) as f:
+        assert f.read() == b"".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Forward seeking
+# ---------------------------------------------------------------------------
+
+
+def test_single_block_seek_forward():
+    payload = b"abcdefghij"
+    with open_xz(make_xz(payload)) as f:
+        f.seek(3)
+        assert f.read(4) == b"defg"
+
+
+@requires_xz_cli
+def test_multi_block_seek_forward_into_later_block():
+    parts = [b"A" * 4000, b"B" * 4000, b"C" * 4000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    with open_xz(xz_data) as f:
+        f.seek(8000)
+        assert f.read(4000) == b"C" * 4000
+
+
+def test_multi_stream_seek_forward_into_later_stream():
+    parts = [b"AAAA", b"BBBB", b"CCCC"]
+    xz_data = make_xz_multistream(parts)
+    with open_xz(xz_data) as f:
+        f.seek(8)
+        assert f.read(4) == b"CCCC"
+
+
+# ---------------------------------------------------------------------------
+# Backward seeking
+# ---------------------------------------------------------------------------
+
+
+def test_single_block_seek_backward():
+    payload = b"abcdefghij"
+    with open_xz(make_xz(payload)) as f:
+        f.read()
+        f.seek(3)
+        assert f.read(4) == b"defg"
+
+
+@requires_xz_cli
+def test_multi_block_seek_backward_to_earlier_block():
+    parts = [b"A" * 4000, b"B" * 4000, b"C" * 4000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    with open_xz(xz_data) as f:
+        f.read()  # read all (builds index)
+        f.seek(4000)
+        assert f.read(4000) == b"B" * 4000
+
+
+@requires_xz_cli
+def test_backward_seek_uses_index_not_position_zero():
+    """After reading all blocks, seeking backward to block 1 jumps directly there."""
+    parts = [b"a" * 5000, b"b" * 5000, b"c" * 5000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=5000)
+    with open_xz(xz_data) as f:
+        f.read()
+        assert len(f._seek_points) >= 3  # type: ignore[attr-defined]
+
+        target = len(parts[0])
+        f.seek(target)
+        assert f._decomp_cursor == target  # type: ignore[attr-defined]
+        assert f.read(len(parts[1])) == parts[1]
+
+
+def test_multi_stream_seek_backward():
+    parts = [b"AAAA", b"BBBB", b"CCCC"]
+    xz_data = make_xz_multistream(parts)
+    with open_xz(xz_data) as f:
+        f.read()
+        f.seek(0)
+        assert f.read(4) == b"AAAA"
+        f.seek(4)
+        assert f.read(4) == b"BBBB"
+
+
+# ---------------------------------------------------------------------------
+# SEEK_END
+# ---------------------------------------------------------------------------
+
+
+def test_seek_end_returns_correct_size_single_block():
+    payload = b"hello world"
+    with open_xz(make_xz(payload)) as f:
+        size = f.seek(0, io.SEEK_END)
+        assert size == len(payload)
+
+
+def test_seek_end_returns_correct_size_multi_stream():
+    parts = [b"hello", b"world", b"!"]
+    xz_data = make_xz_multistream(parts)
+    with open_xz(xz_data) as f:
+        size = f.seek(0, io.SEEK_END)
+        assert size == sum(len(p) for p in parts)
+
+
+@requires_xz_cli
+def test_seek_end_returns_correct_size_multi_block():
+    payload = b"X" * 12000
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    with open_xz(xz_data) as f:
+        size = f.seek(0, io.SEEK_END)
+        assert size == len(payload)
+
+
+def test_seek_end_does_not_decompress_single_block():
+    """SEEK_END on a single-stream file uses the backwards scan, not decompression."""
+    payload = b"data" * 500
+    with open_xz(make_xz(payload)) as f:
+        f.seek(0, io.SEEK_END)
+        assert f._decomp_cursor == 0  # type: ignore[attr-defined]
+        assert f._index_built  # type: ignore[attr-defined]
+
+
+@requires_xz_cli
+def test_seek_end_does_not_decompress_multi_block():
+    """SEEK_END should use the backwards scan for all blocks."""
+    payload = b"Z" * 15000
+    xz_data = make_xz_multiblock(payload, block_size=5000)
+    with open_xz(xz_data) as f:
+        f.seek(0, io.SEEK_END)
+        assert f._decomp_cursor == 0  # type: ignore[attr-defined]
+        assert f._index_built  # type: ignore[attr-defined]
+
+
+def test_seek_end_then_read_last_bytes():
+    parts = [b"first", b"second", b"last!"]
+    xz_data = make_xz_multistream(parts)
+    with open_xz(xz_data) as f:
+        f.seek(-5, io.SEEK_END)
+        assert f.read() == b"last!"
+
+
+def test_seek_past_eof_then_read_returns_empty():
+    payload = b"hello world"
+    with open_xz(make_xz(payload)) as f:
+        size = f.seek(0, io.SEEK_END)
+        f.seek(1, io.SEEK_END)
+        assert f.read() == b""
+        assert f.seek(0, io.SEEK_END) == size
+
+
+@requires_xz_cli
+def test_seek_end_negative_offset_into_earlier_block():
+    parts = [b"A" * 4000, b"B" * 4000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    with open_xz(xz_data) as f:
+        # Seek 1 byte into the second block from the end
+        f.seek(-4001, io.SEEK_END)
+        result = f.read(5)
+        assert result == b"A" + b"B" * 4
+
+
+# ---------------------------------------------------------------------------
+# Index building
+# ---------------------------------------------------------------------------
+
+
+@requires_xz_cli
+def test_seek_points_built_progressively():
+    """Reading forward adds seek points for completed blocks."""
+    parts = [b"part0" * 1000, b"part1" * 1000, b"part2" * 1000]
+    payload = b"".join(parts)
+    xz_data = make_xz_multiblock(payload, block_size=len(parts[0]))
+    with open_xz(xz_data) as f:
+        # Origin point only initially
+        assert len(f._seek_points) == 1  # type: ignore[attr-defined]
+
+        # After reading part0 fully, its block seek point is added
+        f.read(len(parts[0]))
+        # The first block's seek point is at offset 0, same as origin — deduplication
+        # means the count may still be 1 after reading part0 only if the origin point
+        # already covers block 0's start.  After reading through part1, we get 2.
+        f.read(len(parts[1]))
+        assert len(f._seek_points) >= 2  # type: ignore[attr-defined]
+
+        f.read()
+        assert len(f._seek_points) >= 3  # type: ignore[attr-defined]
+
+
+def test_backward_scan_multi_stream():
+    """_read_xz_index_backwards correctly handles concatenated XZ streams."""
+    parts = [b"hello", b"world"]
+    xz_data = make_xz_multistream(parts)
+    stream = io.BytesIO(xz_data)
+    blocks = _read_xz_index_backwards(stream, len(xz_data))
+    assert len(blocks) == 2
+    assert blocks[0].decompressed_start == 0
+    assert blocks[0].decompressed_size == len(parts[0])
+    assert blocks[1].decompressed_start == len(parts[0])
+    assert blocks[1].decompressed_size == len(parts[1])
+
+
+@requires_xz_cli
+def test_backward_scan_multi_block():
+    """_read_xz_index_backwards returns correct block info for multi-block XZ."""
+    payload = b"X" * 12000
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    stream = io.BytesIO(xz_data)
+    blocks = _read_xz_index_backwards(stream, len(xz_data))
+    assert len(blocks) == 3
+    total = sum(b.decompressed_size for b in blocks)
+    assert total == len(payload)
+    # Blocks should be in forward order
+    for i, block in enumerate(blocks):
+        assert block.decompressed_start == i * 4000
+    # Consecutive blocks are contiguous in compressed space
+    for i in range(len(blocks) - 1):
+        end = blocks[i].compressed_start + blocks[i].block_header_size + blocks[i].compressed_data_size + blocks[i].check_size
+        # Padded end (rounded to 4 bytes) should equal next block's start
+        padded_end = (end + 3) & ~3
+        assert padded_end == blocks[i + 1].compressed_start
+
+
+def test_backward_scan_single_block():
+    payload = b"test data"
+    xz_data = make_xz(payload)
+    stream = io.BytesIO(xz_data)
+    blocks = _read_xz_index_backwards(stream, len(xz_data))
+    assert len(blocks) == 1
+    assert blocks[0].decompressed_size == len(payload)
+    assert blocks[0].decompressed_start == 0
+
+
+# ---------------------------------------------------------------------------
+# Non-seekable stream
+# ---------------------------------------------------------------------------
+
+
+def test_non_seekable_stream_sequential_read():
+    """Sequential reading must work on a non-seekable input stream."""
+    payload = b"hello from non-seekable stream"
+    xz_data = make_xz(payload)
+    ns_stream = io.BufferedReader(_NonSeekableStream(xz_data))
+    with XzDecompressorStream(ns_stream) as f:
+        assert not f.seekable()
+        assert f.read() == payload
+
+
+@requires_xz_cli
+def test_non_seekable_multi_block_sequential():
+    """Multi-block sequential read must work on non-seekable streams."""
+    payload = b"M" * 12000
+    xz_data = make_xz_multiblock(payload, block_size=4000)
+    ns_stream = io.BufferedReader(_NonSeekableStream(xz_data))
+    with XzDecompressorStream(ns_stream) as f:
+        assert not f.seekable()
+        assert f.read() == payload
+
+
+def test_non_seekable_multi_stream_sequential():
+    """Multi-stream sequential read must work on non-seekable streams."""
+    parts = [b"stream1", b"stream2", b"stream3"]
+    xz_data = make_xz_multistream(parts)
+    ns_stream = io.BufferedReader(_NonSeekableStream(xz_data))
+    with XzDecompressorStream(ns_stream) as f:
+        assert not f.seekable()
+        assert f.read() == b"".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Corruption detection
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_magic_raises_corrupted_error():
+    """Data not starting with XZ magic must raise ArchiveCorruptedError."""
+    gzip_magic = b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03"
+    with open_xz(gzip_magic + b"\x00" * 100) as f:
+        with pytest.raises(ArchiveCorruptedError):
+            f.read()
+
+
+def test_empty_file_raises_corrupted_error():
+    with open_xz(b"") as f:
+        with pytest.raises(ArchiveCorruptedError):
+            f.read()
+
+
+def test_truncated_file_raises_eof_error():
+    payload = b"truncated data"
+    xz_data = make_xz(payload)
+    truncated = xz_data[: len(xz_data) - 10]
+    with open_xz(truncated) as f:
+        with pytest.raises((ArchiveCorruptedError, ArchiveEOFError)):
+            f.read()
+
+
+def test_corrupted_block_data_raises_error():
+    """Flipping the first byte of compressed data triggers an LZMA decompression error."""
+    payload = b"valid content"
+    xz_data = bytearray(make_xz(payload))
+    # Byte 24 = first byte of compressed data (after 12-byte stream header + 12-byte block header).
+    # Flipping it reliably produces lzma.LZMAError.
+    xz_data[24] ^= 0xFF
+    with open_xz(bytes(xz_data)) as f:
+        with pytest.raises((ArchiveCorruptedError, ArchiveEOFError)):
+            f.read()
+
+
+def test_backward_scan_corrupted_footer_raises_error():
+    """_read_xz_index_backwards raises ArchiveCorruptedError on bad footer magic."""
+    payload = b"some data"
+    xz_data = bytearray(make_xz(payload))
+    # Corrupt the "YZ" footer magic (last 2 bytes)
+    xz_data[-2] = 0xFF
+    xz_data[-1] = 0xFF
+    stream = io.BytesIO(bytes(xz_data))
+    with pytest.raises(ArchiveCorruptedError):
+        _read_xz_index_backwards(stream, len(xz_data))
+
+
+# ---------------------------------------------------------------------------
+# Exception translation
+# ---------------------------------------------------------------------------
+
+
+def test_translate_xz_exception_wraps_lzma_error():
+    result = _translate_xz_stream_exception(lzma.LZMAError("bad data"))
+    assert isinstance(result, ArchiveCorruptedError)
+
+
+def test_translate_xz_exception_wraps_eof_error():
+    from archivey.exceptions import ArchiveEOFError as _ArchiveEOFError
+    result = _translate_xz_stream_exception(EOFError("truncated"))
+    assert isinstance(result, _ArchiveEOFError)
+
+
+def test_translate_xz_exception_returns_none_for_unknown():
+    result = _translate_xz_stream_exception(ValueError("something else"))
+    assert result is None


### PR DESCRIPTION
## Summary

Implement efficient, seekable XZ decompression using Python's stdlib `lzma` module with block-level seeking support. This enables fast random access to multi-block XZ files without decompressing the entire stream.

## Key Changes

- **New `xz_stream.py` module**: Pure-stdlib XZ decompression with:
  - `_XzState`: Streaming state machine for multi-block, multi-stream XZ parsing
  - `_read_xz_index_backwards()`: One-shot backwards scan of XZ stream footers and indexes to build a complete block index without decompression
  - Block header parsing with filter chain extraction for `lzma.FORMAT_RAW` decompression
  - Support for concatenated XZ streams and stream padding
  - Comprehensive error handling for truncated/corrupted files

- **New `XzDecompressorStream` class**: Seekable decompressor that:
  - Progressively builds seek-point table as blocks are decoded forward
  - Falls back to on-demand backwards index scan for random access
  - Stores block metadata (header size, compressed data size, check size, filter chain) at each seek point
  - Jumps directly to any block and decompresses with the correct filter chain
  - Works on both seekable and non-seekable input streams

- **Integration with existing infrastructure**:
  - Added `_translate_xz_stream_exception()` in `compressed_streams.py` for exception translation
  - Updated `decompressor_stream.py` to import and use XZ components
  - Updated `single_file_reader.py` with lzip metadata reading support
  - Updated test expectations in `test_open_nonseekable.py` and `sample_archives.py`

- **Comprehensive test suite** (`test_xz_stream.py`):
  - Single-block and multi-block reading (sequential and chunked)
  - Forward and backward seeking
  - `SEEK_END` support with correct size calculation
  - Multi-stream concatenation
  - Index building and progressive seek-point accumulation
  - Non-seekable stream support
  - Corruption detection and error handling

## Implementation Details

- Uses `lzma._decode_filter_properties()` (private but stable CPython API) to reconstruct filter chains from block headers, enabling `lzma.FORMAT_RAW` decompression
- Backwards index scan reads only stream footers, indexes, and block headers—no decompression—making it O(1) in decompressed size
- Supports all XZ check types (none, CRC32, CRC64, SHA-256) via the `_CHECK_SIZES` mapping
- Handles variable-length integer encoding used throughout XZ format
- Properly tracks decompressed offsets across multiple streams and blocks

https://claude.ai/code/session_01Jf5PyfkhdCNogCSSty1LLB